### PR TITLE
Add MCP Server start and output confirmation

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -1,3 +1,7 @@
+# Output MCP Server Start confirmation in stderr for Claude Desktop or CLI
+import sys
+print("Personnal ServiceNow MCP Server started...", file=sys.stderr)
+
 from mcp.server.fastmcp import FastMCP
 from Table_Tools.consolidated_tools import (
     # Incident tools
@@ -37,3 +41,6 @@ tools = [
 
 for tool in tools:
     mcp.tool()(tool)
+
+# Triggering MCP Server Run - To prevent immediate MCP server closing in Claude Desktop
+mcp.run()  # Run using default transport (stdio) or supply transport="http" for web API


### PR DESCRIPTION
Fix: Ensure MCP server stays alive by invoking mcp.run()

This PR addresses an issue where the MCP server process would exit immediately after execution, causing Claude Desktop to disconnect unexpectedly.

Changes:

Added mcp.run() at the end of tools.py to start the server loop and keep the process alive.

This ensures the MCP server properly responds to incoming protocol messages and maintains a stable connection.

Tested locally with Claude Desktop integration — the server now initializes, registers tools, and remains active as expected.