### PR TITLE
feat(kb): add write tools for knowledge article lifecycle management

### DIFF
--- a/Table_Tools/consolidated_tools.py
+++ b/Table_Tools/consolidated_tools.py
@@ -295,7 +295,7 @@ async def get_knowledge_by_category(category: str, kb_base: Optional[str] = None
 
 async def get_active_knowledge_articles(input_text: str) -> Dict[str, Any]:  # noqa: ARG001
     """Get active knowledge articles matching text."""
-    filters = {"state": "published"}
+    filters = {"workflow_state": "published"}
     return await query_table_with_generic_filters("kb_knowledge", filters)
 
 

--- a/Table_Tools/kb_article_tools.py
+++ b/Table_Tools/kb_article_tools.py
@@ -1,0 +1,104 @@
+from service_now_api_oauth import make_nws_request, NWS_API_BASE
+from typing import Any, Dict
+import httpx
+from constants import (
+    ERROR_KB_NO_UPDATE_DATA,
+    ERROR_KB_ARTICLE_NOT_FOUND_OP,
+    ERROR_KB_ARTICLE_REQUEST_FAILED,
+    ERROR_KB_ARTICLE_AUTH_FAILED,
+    ERROR_KB_ARTICLE_ACCESS_DENIED,
+    ERROR_KB_ARTICLE_INVALID_REQUEST,
+    ERROR_KB_ARTICLE_NOT_FOUND,
+    ERROR_KB_ARTICLE_SERVER_ERROR,
+)
+
+
+def _handle_kb_error(error: httpx.HTTPStatusError, operation: str) -> str:
+    status_code = error.response.status_code
+    error_messages = {
+        401: ERROR_KB_ARTICLE_AUTH_FAILED.format(operation=operation),
+        403: ERROR_KB_ARTICLE_ACCESS_DENIED.format(operation=operation),
+        400: ERROR_KB_ARTICLE_INVALID_REQUEST.format(operation=operation),
+        404: ERROR_KB_ARTICLE_NOT_FOUND.format(operation=operation),
+    }
+    return error_messages.get(status_code, ERROR_KB_ARTICLE_SERVER_ERROR.format(operation=operation))
+
+
+def _unwrap_kb_write_response(result: Any, operation: str) -> Dict[str, Any] | str:
+    if result and isinstance(result, dict) and result.get('result'):
+        return result['result']
+    return result if result else f"Knowledge article {operation} successful but no data returned."
+
+
+async def _write_kb_article(
+    method: str,
+    url: str,
+    payload: Dict[str, Any],
+    operation: str,
+) -> Dict[str, Any] | str:
+    try:
+        result = await make_nws_request(url, method=method, json_data=payload)
+    except httpx.HTTPStatusError as e:
+        return _handle_kb_error(e, operation)
+    except Exception:
+        return ERROR_KB_ARTICLE_REQUEST_FAILED.format(operation=operation)
+    return _unwrap_kb_write_response(result, operation)
+
+
+async def _get_kb_article_sys_id(article_number: str) -> str | None:
+    url = f"{NWS_API_BASE}/api/now/table/kb_knowledge?sysparm_fields=sys_id&sysparm_query=number={article_number}"
+    data = await make_nws_request(url)
+    if not data or not data.get('result') or not data['result']:
+        return None
+    return data['result'][0]['sys_id']
+
+
+async def update_knowledge_article(article_number: str, update_data: Dict[str, Any]) -> Dict[str, Any] | str:
+    """Update fields on a knowledge article by article number (e.g. KB0001234).
+
+    Args:
+        article_number: The KB article number.
+        update_data: Fields to update (e.g. short_description, text, kb_category).
+
+    Returns:
+        Updated article record dict, or error string on failure.
+    """
+    if not update_data:
+        return ERROR_KB_NO_UPDATE_DATA
+    sys_id = await _get_kb_article_sys_id(article_number)
+    if not sys_id:
+        return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
+    url = f"{NWS_API_BASE}/api/now/table/kb_knowledge/{sys_id}"
+    return await _write_kb_article("PATCH", url, update_data, "update")
+
+
+async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str:
+    """Publish a knowledge article (workflow_state → published).
+
+    Args:
+        article_number: The KB article number (e.g. KB0001234).
+
+    Returns:
+        Updated article record dict, or error string on failure.
+    """
+    sys_id = await _get_kb_article_sys_id(article_number)
+    if not sys_id:
+        return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
+    url = f"{NWS_API_BASE}/api/now/table/kb_knowledge/{sys_id}"
+    return await _write_kb_article("PATCH", url, {"workflow_state": "published"}, "publish")
+
+
+async def retire_knowledge_article(article_number: str) -> Dict[str, Any] | str:
+    """Retire a knowledge article (workflow_state → retired).
+
+    Args:
+        article_number: The KB article number (e.g. KB0001234).
+
+    Returns:
+        Updated article record dict, or error string on failure.
+    """
+    sys_id = await _get_kb_article_sys_id(article_number)
+    if not sys_id:
+        return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
+    url = f"{NWS_API_BASE}/api/now/table/kb_knowledge/{sys_id}"
+    return await _write_kb_article("PATCH", url, {"workflow_state": "retired"}, "retire")

--- a/constants.py
+++ b/constants.py
@@ -50,6 +50,16 @@ ERROR_PRIVATE_TASK_INVALID_REQUEST = "Error during private task {operation}: Inv
 ERROR_PRIVATE_TASK_NOT_FOUND = "Error during private task {operation}: Task not found"
 ERROR_PRIVATE_TASK_SERVER_ERROR = "Error during private task {operation}: Server error"
 
+# KB Article-specific error messages
+ERROR_KB_NO_UPDATE_DATA = "Error: No update data provided."
+ERROR_KB_ARTICLE_NOT_FOUND_OP = "Knowledge article {number} not found."
+ERROR_KB_ARTICLE_REQUEST_FAILED = "Error during knowledge article {operation}: Request failed"
+ERROR_KB_ARTICLE_AUTH_FAILED = "Error during knowledge article {operation}: Authentication failed"
+ERROR_KB_ARTICLE_ACCESS_DENIED = "Error during knowledge article {operation}: Access denied"
+ERROR_KB_ARTICLE_INVALID_REQUEST = "Error during knowledge article {operation}: Invalid request data"
+ERROR_KB_ARTICLE_NOT_FOUND = "Error during knowledge article {operation}: Article not found"
+ERROR_KB_ARTICLE_SERVER_ERROR = "Error during knowledge article {operation}: Server error"
+
 # Table-specific error messages
 TABLE_ERROR_MESSAGES = {
     "incident": "Incident not found.",
@@ -67,7 +77,7 @@ ESSENTIAL_FIELDS = {
     "incident": ["number", "short_description", "priority", "state", "category", "sys_created_on"],
     "change_request": ["number", "short_description", "priority", "state", "sys_created_on"],
     "universal_request": ["number", "short_description", "priority", "state", "sys_created_on"],
-    "kb_knowledge": ["number", "short_description", "kb_category", "state", "sys_created_on"],
+    "kb_knowledge": ["number", "short_description", "kb_category", "workflow_state", "sys_created_on"],
     "vtb_task": ["number", "short_description", "priority", "state", "sys_created_on"],
     "task_sla": ["task", "sla", "stage", "business_percentage", "active", "sys_created_on"],
     "sc_req_item": ["number", "short_description", "priority", "state", "sys_created_on", "cat_item"],
@@ -78,7 +88,7 @@ DETAIL_FIELDS = {
     "incident": ["number", "short_description", "description", "priority", "state", "category", "sys_created_on", "assigned_to", "assignment_group", "work_notes", "comments", "u_reference_1", "company", "cmdb_ci", "correlation_id", "major_incident_state"],
     "change_request": ["number", "short_description", "description", "priority", "state", "sys_created_on", "assigned_to", "assignment_group", "work_notes", "comments", "u_reference_1", "company", "cmdb_ci"],
     "universal_request": ["number", "short_description", "priority", "state", "sys_created_on", "assigned_to", "assignment_group", "comments", "u_reference_1", "company", "cmdb_ci"],
-    "kb_knowledge": ["number", "short_description", "text","kb_category", "state", "sys_created_on", "assigned_to"],
+    "kb_knowledge": ["number", "short_description", "text", "kb_category", "workflow_state", "sys_created_on", "assigned_to"],
     "vtb_task": ["number", "short_description", "priority", "state", "sys_created_on", "assigned_to", "assignment_group", "work_notes", "comments"],
     "task_sla": ["task", "sla", "stage", "business_percentage", "active", "sys_created_on", "breach_time", "business_time_left", "duration", "has_breached", "business_duration", "business_elapsed_time", "planned_end_time"],
     "sc_req_item": ["number", "short_description", "description", "priority", "state", "sys_created_on", "assigned_to", "assignment_group", "comments", "cat_item", "request", "stage"],
@@ -227,7 +237,7 @@ TABLE_CONFIGS = {
         "supports_comments": False,
         "number_prefix": "KB",
         "priority_field": None,
-        "state_field": "state"
+        "state_field": "workflow_state"
     },
     "vtb_task": {
         "display_name": "Private Task",

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -252,7 +252,7 @@ class TestKnowledgeTools:
         with patch('Table_Tools.consolidated_tools.query_table_with_generic_filters') as mock_query:
             mock_query.return_value = {"result": [{"number": "KB001"}]}
             result = await get_active_knowledge_articles("test")
-            mock_query.assert_called_once_with("kb_knowledge", {"state": "published"})
+            mock_query.assert_called_once_with("kb_knowledge", {"workflow_state": "published"})
 
 
 class TestSLATools:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -60,11 +60,11 @@ class TestToolRegistry:
 
     def test_expected_tool_count(self):
         import tools
-        # v4.0 Sprint 2: SLA tools consolidated 10 -> 5 (32 total).
-        # (5 server/auth + 5 generic + 1 priority + 3 knowledge +
-        #  2 vtb CRUD + 5 SLA + 6 CMDB + 5 intelligent).
-        assert len(tools.tools) == 32, (
-            f"Expected 32 registered tools, got {len(tools.tools)}. "
+        # v4.1: KB article write tools added (+3: update/publish/retire = 35 total).
+        # (5 server/auth + 5 generic + 1 priority + 3 knowledge read +
+        #  2 vtb CRUD + 3 KB write + 5 SLA + 6 CMDB + 5 intelligent).
+        assert len(tools.tools) == 35, (
+            f"Expected 35 registered tools, got {len(tools.tools)}. "
             "If tool count changed intentionally, update this test and CLAUDE.md."
         )
 

--- a/tests/test_kb_article_tools.py
+++ b/tests/test_kb_article_tools.py
@@ -1,0 +1,258 @@
+"""
+Tests for kb_article_tools.py — KB article write path (update / publish / retire).
+Target: 90%+ line coverage, 75%+ branch coverage.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+import httpx
+
+from Table_Tools.kb_article_tools import (
+    _handle_kb_error,
+    _unwrap_kb_write_response,
+    _write_kb_article,
+    _get_kb_article_sys_id,
+    update_knowledge_article,
+    publish_knowledge_article,
+    retire_knowledge_article,
+)
+
+
+def _make_http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    response = MagicMock()
+    response.status_code = status_code
+    return httpx.HTTPStatusError(str(status_code), request=MagicMock(), response=response)
+
+
+class TestHandleKbError:
+
+    def test_401_returns_auth_failed(self):
+        result = _handle_kb_error(_make_http_status_error(401), "publish")
+        assert "Authentication failed" in result
+
+    def test_403_returns_access_denied(self):
+        result = _handle_kb_error(_make_http_status_error(403), "retire")
+        assert "Access denied" in result
+
+    def test_400_returns_invalid_request(self):
+        result = _handle_kb_error(_make_http_status_error(400), "update")
+        assert "Invalid request" in result
+
+    def test_404_returns_not_found(self):
+        result = _handle_kb_error(_make_http_status_error(404), "update")
+        assert "not found" in result.lower()
+
+    def test_500_returns_server_error(self):
+        result = _handle_kb_error(_make_http_status_error(500), "publish")
+        assert "server error" in result.lower()
+
+
+class TestUnwrapKbWriteResponse:
+
+    def test_unwrap_with_inner_result(self):
+        result = _unwrap_kb_write_response({"result": {"number": "KB0001234"}}, "update")
+        assert result == {"number": "KB0001234"}
+
+    def test_unwrap_empty_dict_returns_fallback(self):
+        result = _unwrap_kb_write_response({}, "publish")
+        assert "successful but no data returned" in result
+
+    def test_unwrap_none_returns_fallback(self):
+        result = _unwrap_kb_write_response(None, "retire")
+        assert "successful but no data returned" in result
+
+    def test_unwrap_dict_without_result_key_returns_as_is(self):
+        result = _unwrap_kb_write_response({"some": "value"}, "update")
+        assert result == {"some": "value"}
+
+
+class TestWriteKbArticle:
+
+    @pytest.mark.asyncio
+    async def test_success_returns_inner_result(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = {"result": {"number": "KB0001234", "workflow_state": "published"}}
+
+            result = await _write_kb_article(
+                "PATCH",
+                "https://test.service-now.com/api/now/table/kb_knowledge/abc123",
+                {"workflow_state": "published"},
+                "publish",
+            )
+
+            assert result == {"number": "KB0001234", "workflow_state": "published"}
+            mock_request.assert_called_once_with(
+                "https://test.service-now.com/api/now/table/kb_knowledge/abc123",
+                method="PATCH",
+                json_data={"workflow_state": "published"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_none_result_returns_fallback(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = None
+
+            result = await _write_kb_article("PATCH", "http://x", {}, "update")
+            assert "successful but no data returned" in result
+
+    @pytest.mark.asyncio
+    async def test_http_status_error_mapped(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.side_effect = _make_http_status_error(401)
+
+            result = await _write_kb_article("PATCH", "http://x", {}, "publish")
+            assert "Authentication failed" in result
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_request_failed(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.side_effect = Exception("Network error")
+
+            result = await _write_kb_article("PATCH", "http://x", {}, "retire")
+            assert "Request failed" in result
+
+
+class TestGetKbArticleSysId:
+
+    @pytest.mark.asyncio
+    async def test_success_returns_sys_id(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = {"result": [{"sys_id": "abc123def456"}]}
+
+            sys_id = await _get_kb_article_sys_id("KB0001234")
+
+            assert sys_id == "abc123def456"
+            mock_request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_result_returns_none(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = {"result": []}
+
+            assert await _get_kb_article_sys_id("KB9999999") is None
+
+    @pytest.mark.asyncio
+    async def test_none_response_returns_none(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = None
+
+            assert await _get_kb_article_sys_id("KB0001234") is None
+
+    @pytest.mark.asyncio
+    async def test_none_result_key_returns_none(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = {"result": None}
+
+            assert await _get_kb_article_sys_id("KB0001234") is None
+
+
+class TestUpdateKnowledgeArticle:
+
+    @pytest.mark.asyncio
+    async def test_empty_update_data_returns_error(self):
+        result = await update_knowledge_article("KB0001234", {})
+        assert "No update data provided" in result
+
+    @pytest.mark.asyncio
+    async def test_article_not_found_returns_error(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id:
+            mock_sys_id.return_value = None
+
+            result = await update_knowledge_article("KB9999999", {"short_description": "x"})
+            assert "KB9999999" in result
+            assert "not found" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_success_returns_updated_record(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id, \
+             patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_sys_id.return_value = "abc123"
+            mock_request.return_value = {"result": {"number": "KB0001234", "short_description": "Updated"}}
+
+            result = await update_knowledge_article("KB0001234", {"short_description": "Updated"})
+
+            assert result["number"] == "KB0001234"
+            kwargs = mock_request.call_args.kwargs
+            assert kwargs["method"] == "PATCH"
+            assert kwargs["json_data"] == {"short_description": "Updated"}
+
+
+class TestPublishKnowledgeArticle:
+
+    @pytest.mark.asyncio
+    async def test_article_not_found_returns_error(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id:
+            mock_sys_id.return_value = None
+
+            result = await publish_knowledge_article("KB9999999")
+            assert "KB9999999" in result
+
+    @pytest.mark.asyncio
+    async def test_success_patches_workflow_state_published(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id, \
+             patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_sys_id.return_value = "abc123"
+            mock_request.return_value = {"result": {"number": "KB0001234", "workflow_state": "published"}}
+
+            result = await publish_knowledge_article("KB0001234")
+
+            assert result["workflow_state"] == "published"
+            kwargs = mock_request.call_args.kwargs
+            assert kwargs["method"] == "PATCH"
+            assert kwargs["json_data"] == {"workflow_state": "published"}
+
+
+class TestRetireKnowledgeArticle:
+
+    @pytest.mark.asyncio
+    async def test_article_not_found_returns_error(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id:
+            mock_sys_id.return_value = None
+
+            result = await retire_knowledge_article("KB9999999")
+            assert "KB9999999" in result
+
+    @pytest.mark.asyncio
+    async def test_success_patches_workflow_state_retired(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id, \
+             patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_sys_id.return_value = "abc123"
+            mock_request.return_value = {"result": {"number": "KB0001234", "workflow_state": "retired"}}
+
+            result = await retire_knowledge_article("KB0001234")
+
+            assert result["workflow_state"] == "retired"
+            kwargs = mock_request.call_args.kwargs
+            assert kwargs["method"] == "PATCH"
+            assert kwargs["json_data"] == {"workflow_state": "retired"}
+
+
+class TestRoutesThroughUnifiedPipeline:
+    """Verify write ops use make_nws_request write path (not GET path)."""
+
+    @pytest.mark.asyncio
+    async def test_publish_routes_through_make_nws_request(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id, \
+             patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_sys_id.return_value = "abc123"
+            mock_request.return_value = {"result": {"number": "KB0001234"}}
+
+            await publish_knowledge_article("KB0001234")
+
+            mock_request.assert_called_once()
+            call_kwargs = mock_request.call_args.kwargs
+            assert call_kwargs["method"] == "PATCH"
+            assert "sysparm_display_value" not in mock_request.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_retire_routes_through_make_nws_request(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id, \
+             patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_sys_id.return_value = "abc123"
+            mock_request.return_value = {"result": {"number": "KB0001234"}}
+
+            await retire_knowledge_article("KB0001234")
+
+            mock_request.assert_called_once()
+            call_kwargs = mock_request.call_args.kwargs
+            assert call_kwargs["method"] == "PATCH"

--- a/tools.py
+++ b/tools.py
@@ -17,6 +17,7 @@ from Table_Tools.consolidated_tools import (
 )
 from Table_Tools.table_tools import nowtestauth, nowtest_auth_input
 from Table_Tools.vtb_task_tools import create_private_task, update_private_task
+from Table_Tools.kb_article_tools import update_knowledge_article, publish_knowledge_article, retire_knowledge_article
 from Table_Tools.cmdb_tools import (
     find_cis_by_type, search_cis_by_attributes, get_ci_details, similar_cis_for_ci, get_all_ci_types, quick_ci_search
 )
@@ -28,7 +29,7 @@ from Table_Tools.intelligent_query_tools import (
 
 mcp = FastMCP("personalmcpservicenow")
 
-# Register tools — consolidated from 55 -> 37 (v3.0) -> 32 (v4.0)
+# Register tools — consolidated from 55 -> 37 (v3.0) -> 32 (v4.0) -> 35 (v4.1 KB write)
 tools = [
     # Server & Authentication tools
     nowtest, now_test_oauth, now_auth_info, nowtestauth, nowtest_auth_input,
@@ -44,6 +45,9 @@ tools = [
 
     # Private Task CRUD
     create_private_task, update_private_task,
+
+    # KB Article write tools (update content, publish, retire)
+    update_knowledge_article, publish_knowledge_article, retire_knowledge_article,
 
     # SLA tools (v4.0: 10 -> 5 consolidated; presets exposed via query_slas_by_status)
     similar_slas_for_text, get_sla_details,


### PR DESCRIPTION
## Summary

- Adds 3 new MCP tools: `update_knowledge_article`, `publish_knowledge_article`, `retire_knowledge_article` (32 → 35 tools total)
- Write path mirrors `vtb_task_tools` pattern — PATCH bypasses `add_default_params`/`extract_display_values` per token-optimization invariant
- Fixes pre-existing bug: `kb_knowledge` was referencing `"state"` field throughout (`ESSENTIAL_FIELDS`, `DETAIL_FIELDS`, `TABLE_CONFIGS`, `get_active_knowledge_articles`) instead of correct `"workflow_state"` — confirmed via XML export of live article

## Test plan

- [x] 26 new tests in `tests/test_kb_article_tools.py` — all passing
- [x] Full suite 601/601 passing, 0 regressions
- [x] `workflow_state` field confirmed correct from ServiceNow XML export (`KB0011388`)
- [ ] Manual smoke: call `publish_knowledge_article("KB0011388")` against test article, verify state changes in ServiceNow UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)