### PR TITLE
fix(kb): use workflow endpoint for publish/retire instead of field write

### DIFF
--- a/Table_Tools/kb_article_tools.py
+++ b/Table_Tools/kb_article_tools.py
@@ -53,6 +53,13 @@ async def _get_kb_article_sys_id(article_number: str) -> str | None:
     return data['result'][0]['sys_id']
 
 
+async def _call_kb_workflow(sys_id: str, action: str) -> Dict[str, Any] | str:
+    # Workflow endpoint triggers the actual state-machine transition.
+    # Direct PATCH to workflow_state is silently ignored by ServiceNow (read-only field).
+    url = f"{NWS_API_BASE}/api/now/table/kb_knowledge/{sys_id}/workflow/{action}"
+    return await _write_kb_article("POST", url, {}, action)
+
+
 async def update_knowledge_article(article_number: str, update_data: Dict[str, Any]) -> Dict[str, Any] | str:
     """Update fields on a knowledge article by article number (e.g. KB0001234).
 
@@ -73,7 +80,7 @@ async def update_knowledge_article(article_number: str, update_data: Dict[str, A
 
 
 async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str:
-    """Publish a knowledge article (workflow_state → published).
+    """Publish a knowledge article via the ServiceNow workflow endpoint.
 
     Args:
         article_number: The KB article number (e.g. KB0001234).
@@ -84,12 +91,11 @@ async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str
     sys_id = await _get_kb_article_sys_id(article_number)
     if not sys_id:
         return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
-    url = f"{NWS_API_BASE}/api/now/table/kb_knowledge/{sys_id}"
-    return await _write_kb_article("PATCH", url, {"workflow_state": "published"}, "publish")
+    return await _call_kb_workflow(sys_id, "publish")
 
 
 async def retire_knowledge_article(article_number: str) -> Dict[str, Any] | str:
-    """Retire a knowledge article (workflow_state → retired).
+    """Retire a knowledge article via the ServiceNow workflow endpoint.
 
     Args:
         article_number: The KB article number (e.g. KB0001234).
@@ -100,5 +106,4 @@ async def retire_knowledge_article(article_number: str) -> Dict[str, Any] | str:
     sys_id = await _get_kb_article_sys_id(article_number)
     if not sys_id:
         return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
-    url = f"{NWS_API_BASE}/api/now/table/kb_knowledge/{sys_id}"
-    return await _write_kb_article("PATCH", url, {"workflow_state": "retired"}, "retire")
+    return await _call_kb_workflow(sys_id, "retire")

--- a/tests/test_kb_article_tools.py
+++ b/tests/test_kb_article_tools.py
@@ -188,7 +188,7 @@ class TestPublishKnowledgeArticle:
             assert "KB9999999" in result
 
     @pytest.mark.asyncio
-    async def test_success_patches_workflow_state_published(self):
+    async def test_success_posts_to_workflow_publish_endpoint(self):
         with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id, \
              patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
             mock_sys_id.return_value = "abc123"
@@ -197,9 +197,10 @@ class TestPublishKnowledgeArticle:
             result = await publish_knowledge_article("KB0001234")
 
             assert result["workflow_state"] == "published"
-            kwargs = mock_request.call_args.kwargs
-            assert kwargs["method"] == "PATCH"
-            assert kwargs["json_data"] == {"workflow_state": "published"}
+            call_url = mock_request.call_args.args[0]
+            call_kwargs = mock_request.call_args.kwargs
+            assert "abc123/workflow/publish" in call_url
+            assert call_kwargs["method"] == "POST"
 
 
 class TestRetireKnowledgeArticle:
@@ -213,7 +214,7 @@ class TestRetireKnowledgeArticle:
             assert "KB9999999" in result
 
     @pytest.mark.asyncio
-    async def test_success_patches_workflow_state_retired(self):
+    async def test_success_posts_to_workflow_retire_endpoint(self):
         with patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_sys_id, \
              patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
             mock_sys_id.return_value = "abc123"
@@ -222,9 +223,10 @@ class TestRetireKnowledgeArticle:
             result = await retire_knowledge_article("KB0001234")
 
             assert result["workflow_state"] == "retired"
-            kwargs = mock_request.call_args.kwargs
-            assert kwargs["method"] == "PATCH"
-            assert kwargs["json_data"] == {"workflow_state": "retired"}
+            call_url = mock_request.call_args.args[0]
+            call_kwargs = mock_request.call_args.kwargs
+            assert "abc123/workflow/retire" in call_url
+            assert call_kwargs["method"] == "POST"
 
 
 class TestRoutesThroughUnifiedPipeline:
@@ -241,7 +243,7 @@ class TestRoutesThroughUnifiedPipeline:
 
             mock_request.assert_called_once()
             call_kwargs = mock_request.call_args.kwargs
-            assert call_kwargs["method"] == "PATCH"
+            assert call_kwargs["method"] == "POST"
             assert "sysparm_display_value" not in mock_request.call_args.args[0]
 
     @pytest.mark.asyncio
@@ -255,4 +257,4 @@ class TestRoutesThroughUnifiedPipeline:
 
             mock_request.assert_called_once()
             call_kwargs = mock_request.call_args.kwargs
-            assert call_kwargs["method"] == "PATCH"
+            assert call_kwargs["method"] == "POST"


### PR DESCRIPTION
## Summary

- `publish_knowledge_article` and `retire_knowledge_article` were PATCHing `workflow_state` directly — silently ignored by ServiceNow on Utah+ (read-only field)
- Fixed by replacing with `POST /api/now/table/kb_knowledge/{sys_id}/workflow/publish` and `.../workflow/retire`
- Adds `_call_kb_workflow(sys_id, action)` helper — single entry point for all lifecycle transitions

## Root cause

ServiceNow Table API silently accepts the PATCH but discards the `workflow_state` write. The `/workflow/{action}` endpoint triggers the actual state-machine transition and is the only reliable method on Utah+.

## Test plan

- [x] 26 tests passing, 0 regressions (601/601)
- [x] Tests now assert POST to correct workflow URL (`abc123/workflow/publish`, `abc123/workflow/retire`)
- [ ] Manual smoke: `publish_knowledge_article("KB0011388")` — expected `workflow_state: "published"` in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)