### PR TITLE
Feat/v4.1 kb expansion

### DIFF
--- a/Table_Tools/consolidated_tools.py
+++ b/Table_Tools/consolidated_tools.py
@@ -299,6 +299,126 @@ async def get_active_knowledge_articles(input_text: str) -> Dict[str, Any]:  # n
     return await query_table_with_generic_filters("kb_knowledge", filters)
 
 
+# Canonical workflow_state precedence for KB de-duplication.
+# Lower index = higher priority (= the row chosen as "current" when one number has multiple versions).
+# Rationale: published reflects live content; draft/review are in-flight; outdated is a versioning
+# artefact left behind by ServiceNow when a newer version publishes; retired = explicitly killed.
+_KB_STATE_PRIORITY = ["published", "draft", "review", "outdated", "retired"]
+_KB_STATE_RANK = {state: idx for idx, state in enumerate(_KB_STATE_PRIORITY)}
+_KB_DEDUP_FIELDS = [
+    "number", "sys_id", "short_description", "workflow_state",
+    "kb_category", "sys_updated_on",
+]
+
+
+def _pick_canonical_kb_row(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """De-duplicate kb_knowledge rows by `number`, keeping the highest-priority workflow_state row.
+
+    Returns a dict keyed by number with {canonical_row, version_count, canonical_rank}.
+    """
+    by_number: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        num = row.get("number")
+        if not num:
+            continue
+        state = (row.get("workflow_state") or "").strip().lower()
+        rank = _KB_STATE_RANK.get(state, len(_KB_STATE_PRIORITY))
+        entry = by_number.get(num)
+        if entry is None:
+            by_number[num] = {"row": row, "rank": rank, "version_count": 1}
+        else:
+            entry["version_count"] += 1
+            if rank < entry["rank"]:
+                entry["row"] = row
+                entry["rank"] = rank
+    return by_number
+
+
+def _format_deduped_kb_row(number: str, info: Dict[str, Any]) -> Dict[str, Any]:
+    """Render a de-duplicated KB row in the public response shape."""
+    row = info["row"]
+    return {
+        "number": number,
+        "sys_id": row.get("sys_id"),
+        "short_description": row.get("short_description"),
+        "current_state": (row.get("workflow_state") or "").strip().lower(),
+        "version_count": info["version_count"],
+        "kb_category": row.get("kb_category"),
+        "sys_updated_on": row.get("sys_updated_on"),
+    }
+
+
+async def get_kb_articles_by_state(
+    workflow_state: Optional[str] = None,
+    category: Optional[str] = None,
+    kb_base: Optional[str] = None,
+    max_results: int = 100,
+) -> Dict[str, Any]:
+    """List kb_knowledge articles de-duplicated by article number.
+
+    ServiceNow KB versioning surfaces the same article number across several
+    workflow states (publish creates a new sys_id and leaves the prior row as
+    `outdated`). The generic `filter_records` tool exposes this raw — useful
+    for some callers, painful for bulk state assessment. This tool collapses
+    the raw rows: one entry per number, with `current_state` set to the
+    highest-priority row found and `version_count` reflecting how many raw
+    rows exist for that number.
+
+    Priority order (highest first): published > draft > review > outdated > retired.
+
+    Args:
+        workflow_state: Optional canonical-state filter applied AFTER de-duplication.
+            E.g. `workflow_state="published"` returns only numbers whose live
+            version is currently published.
+        category: Optional kb_category filter (applied server-side).
+        kb_base: Optional kb_knowledge_base filter (applied server-side).
+        max_results: Max raw rows fetched from ServiceNow (default 100, max 1000).
+            De-duplicated output can be smaller; `truncated` reflects the raw fetch.
+
+    Returns:
+        {"result": [{"number", "sys_id", "short_description", "current_state",
+                     "version_count", "kb_category", "sys_updated_on"}, ...],
+         "returned_count": N, "truncated": bool}
+    """
+    filters: Dict[str, str] = {}
+    if category:
+        filters["kb_category"] = category
+    if kb_base:
+        filters["kb_knowledge_base"] = kb_base
+
+    params = TableFilterParams(
+        filters=filters or None,
+        fields=_KB_DEDUP_FIELDS,
+        max_results=max_results,
+    )
+    raw = await query_table_with_filters("kb_knowledge", params)
+    rows = raw.get("result", []) or []
+
+    by_number = _pick_canonical_kb_row(rows)
+
+    target_state = workflow_state.strip().lower() if workflow_state else None
+    deduped = []
+    for num, info in by_number.items():
+        formatted = _format_deduped_kb_row(num, info)
+        if target_state and formatted["current_state"] != target_state:
+            continue
+        deduped.append(formatted)
+
+    if not deduped:
+        return {
+            "result": [],
+            "message": "No matching KB articles.",
+            "returned_count": 0,
+            "truncated": raw.get("truncated", False),
+        }
+
+    return {
+        "result": deduped,
+        "returned_count": len(deduped),
+        "truncated": raw.get("truncated", False),
+    }
+
+
 # ---------------------------------------------------------------------------
 # SLA tools — v4.0 consolidation (10 -> 5)
 # ---------------------------------------------------------------------------

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -649,25 +649,30 @@ async def _make_paginated_request(
 
 async def query_table_with_filters(table_name: str, params: TableFilterParams) -> dict[str, Any]:
     """Generic function to query table with custom filters and fields.
-    
+
     Supports multiple date filtering formats:
     - Standard dates: "2024-01-01" or "2024-01-01 12:00:00"
     - ServiceNow JavaScript: ">=javascript:gs.daysAgoStart(14)"
     - Relative operators: field_gte, field_lte, field_gt, field_lt
-    
+
     Examples:
     - sys_created_on_gte: "2024-01-01"
     - sys_created_on: ">=javascript:gs.daysAgoStart(14)"
+
+    Response always includes returned_count + truncated + max_results so the
+    caller can detect silent caps. truncated=True is a heuristic — it fires when
+    returned_count == max_results (may be a false positive on exact-boundary
+    result sets, but never a false negative).
     """
     fields = params.fields or ESSENTIAL_FIELDS.get(table_name, ["number", "short_description"])
-    
+
     # Validate filters before making request
     if params.filters:
         validation_result = validate_query_filters(params.filters)
         if validation_result.has_issues():
             # Log warnings but continue with query
             print(f"Query validation warnings: {validation_result.warnings}")
-    
+
     query_string = _build_query_string(params.filters)
     # Apply category filtering for incidents
     query_string = _apply_incident_category_filter(table_name, query_string)
@@ -679,21 +684,32 @@ async def query_table_with_filters(table_name: str, params: TableFilterParams) -
 
     if encoded_query:
         base_url += f"&sysparm_query={encoded_query}"
-    
-    # Use pagination for potentially large result sets
-    all_results = await _make_paginated_request(base_url)
-    
+
+    max_results = params.max_results
+    all_results = await _make_paginated_request(base_url, max_results=max_results)
+    returned_count = len(all_results)
+    truncated = returned_count >= max_results
+
     if all_results:
         # Validate result completeness
-        result_validation = validate_result_count(table_name, params.filters or {}, len(all_results))
+        result_validation = validate_result_count(table_name, params.filters or {}, returned_count)
         if result_validation.has_issues():
             print(f"Result validation warnings: {result_validation.warnings}")
-        
-        # Return in ServiceNow API format
-        return {"result": all_results}
 
-    # Return consistent dict format for no results
-    return {"result": [], "message": NO_RECORDS_FOUND}
+        return {
+            "result": all_results,
+            "returned_count": returned_count,
+            "truncated": truncated,
+            "max_results": max_results,
+        }
+
+    return {
+        "result": [],
+        "message": NO_RECORDS_FOUND,
+        "returned_count": 0,
+        "truncated": False,
+        "max_results": max_results,
+    }
 
 
 def _determine_filter_sources(

--- a/Table_Tools/generic_tool_wrappers.py
+++ b/Table_Tools/generic_tool_wrappers.py
@@ -115,6 +115,7 @@ async def filter_records(
     table: str,
     filters: Dict[str, str],
     fields: Optional[List[str]] = None,
+    max_results: int = 100,
 ) -> Dict[str, Any]:
     """Query a ServiceNow table with field-value filters.
 
@@ -129,12 +130,15 @@ async def filter_records(
         table: ServiceNow table name
         filters: Dict of field-value filter pairs
         fields: Optional list of fields to return (defaults to ESSENTIAL_FIELDS)
+        max_results: Hard cap on rows returned (default 100, max 1000). The
+            response carries truncated=True when this cap is hit so callers
+            can detect partial result sets.
 
     Returns:
-        {"result": [...]}
+        {"result": [...], "returned_count": N, "truncated": bool, "max_results": N}
     """
     error = _validate_table(table)
     if error:
         return error
-    params = TableFilterParams(filters=filters, fields=fields)
+    params = TableFilterParams(filters=filters, fields=fields, max_results=max_results)
     return await query_table_with_filters(table, params)

--- a/Table_Tools/kb_article_tools.py
+++ b/Table_Tools/kb_article_tools.py
@@ -1,5 +1,6 @@
+import asyncio
 from service_now_api_oauth import make_nws_request, NWS_API_BASE
-from typing import Any, Dict
+from typing import Any, Dict, List
 import httpx
 from constants import (
     ERROR_KB_NO_UPDATE_DATA,
@@ -11,6 +12,7 @@ from constants import (
     ERROR_KB_ARTICLE_NOT_FOUND,
     ERROR_KB_ARTICLE_SERVER_ERROR,
     KB_WRITE_RESPONSE_FIELDS,
+    KB_DUPLICATE_IGNORED_STATES,
 )
 
 
@@ -75,11 +77,13 @@ async def _get_kb_article_meta(article_number: str) -> Dict[str, Any] | None:
 
 
 async def _check_kb_duplicates(short_description: str, exclude_number: str) -> list:
-    """Return KB articles matching short_description exactly across ALL workflow states.
+    """Return KB articles matching short_description exactly across live workflow states.
 
     Queries with CONTAINS then exact-matches in Python so the check catches
-    drafts, published, and retired articles — not just active ones.
-    Excludes the article being published (exclude_number) from results.
+    drafts, review, and published articles. Retired + outdated articles are
+    skipped — retired = explicitly killed, outdated = prior version after a newer
+    publish (ServiceNow versioning artefact). Excludes the article being published
+    (exclude_number) from results.
     """
     url = (
         f"{NWS_API_BASE}/api/now/table/kb_knowledge"
@@ -94,6 +98,7 @@ async def _check_kb_duplicates(short_description: str, exclude_number: str) -> l
         r for r in data['result']
         if r.get('short_description', '').strip().lower() == needle
         and r.get('number') != exclude_number
+        and r.get('workflow_state', '').strip().lower() not in KB_DUPLICATE_IGNORED_STATES
     ]
 
 
@@ -152,6 +157,109 @@ async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str
         }
 
     return await _call_kb_workflow(meta['sys_id'], "publish")
+
+
+async def _check_single_kb_duplicate(article_number: str) -> Dict[str, Any]:
+    """Lookup meta then check duplicates for one article. Used by check_kb_duplicates fan-out."""
+    meta = await _get_kb_article_meta(article_number)
+    if not meta:
+        return {
+            "number": article_number,
+            "has_duplicate": False,
+            "duplicates": [],
+            "error": ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number),
+        }
+    duplicates = await _check_kb_duplicates(meta["short_description"], article_number)
+    return {
+        "number": article_number,
+        "has_duplicate": bool(duplicates),
+        "duplicates": [
+            {"number": d.get("number"), "workflow_state": d.get("workflow_state")}
+            for d in duplicates
+        ],
+    }
+
+
+async def check_kb_duplicates(
+    article_numbers: List[str],
+    concurrency: int = 5,
+) -> Dict[str, Any]:
+    """Check for duplicate KB articles without publishing.
+
+    For each number: looks up short_description, then finds matching live KB
+    articles (draft / review / published). Retired + outdated states are
+    skipped. Lets the caller resolve all conflicts upfront before running a
+    publish loop.
+
+    Args:
+        article_numbers: List of KB article numbers (e.g. ["KB0001234", ...]).
+            Capped at 50 per call to keep response size bounded.
+        concurrency: Max concurrent ServiceNow round-trips. Default 5.
+
+    Returns:
+        {"result": [{"number", "has_duplicate", "duplicates": [{"number", "workflow_state"}], "error"?}, ...]}
+    """
+    if not article_numbers:
+        return {"result": []}
+    if len(article_numbers) > 50:
+        return {"error": "check_kb_duplicates accepts at most 50 article numbers per call."}
+
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    async def _bounded(num: str) -> Dict[str, Any]:
+        async with semaphore:
+            return await _check_single_kb_duplicate(num)
+
+    results = await asyncio.gather(*(_bounded(n) for n in article_numbers))
+    return {"result": results}
+
+
+def _normalize_publish_result(article_number: str, result: Dict[str, Any] | str) -> Dict[str, Any]:
+    """Normalize publish_knowledge_article output into a flat batch-result row."""
+    if isinstance(result, str):
+        return {"number": article_number, "status": "error", "message": result}
+    if isinstance(result, dict) and result.get("success") is False:
+        return {
+            "number": article_number,
+            "status": "blocked",
+            "message": result.get("message"),
+            "blockers": result.get("duplicates", []),
+        }
+    workflow_state = result.get("workflow_state") if isinstance(result, dict) else None
+    return {"number": article_number, "status": "published", "workflow_state": workflow_state}
+
+
+async def publish_knowledge_articles(
+    article_numbers: List[str],
+    concurrency: int = 5,
+) -> Dict[str, Any]:
+    """Publish multiple KB articles in one tool call.
+
+    Runs full publish flow per article (meta lookup → duplicate check →
+    ServiceNow workflow POST). Returns a flat status row per article so
+    failures and duplicate blocks do not abort the rest of the batch.
+
+    Args:
+        article_numbers: KB numbers to publish. Capped at 20 per call.
+        concurrency: Max concurrent ServiceNow round-trips. Default 5.
+
+    Returns:
+        {"result": [{"number", "status": "published"|"blocked"|"error", ...}, ...]}
+    """
+    if not article_numbers:
+        return {"result": []}
+    if len(article_numbers) > 20:
+        return {"error": "publish_knowledge_articles accepts at most 20 article numbers per call."}
+
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    async def _bounded(num: str) -> Dict[str, Any]:
+        async with semaphore:
+            outcome = await publish_knowledge_article(num)
+            return _normalize_publish_result(num, outcome)
+
+    results = await asyncio.gather(*(_bounded(n) for n in article_numbers))
+    return {"result": results}
 
 
 async def retire_knowledge_article(article_number: str) -> Dict[str, Any] | str:

--- a/constants.py
+++ b/constants.py
@@ -119,6 +119,11 @@ DETAILED_VTB_TASK_FIELDS = COMMON_VTB_TASK_FIELDS + [
 
 KB_WRITE_RESPONSE_FIELDS = {"number", "sys_id", "short_description", "workflow_state"}
 
+# Workflow states that should NOT block a publish on duplicate check.
+# Retired = explicitly killed; outdated = prior version after a newer publish (ServiceNow versioning artefact).
+# Draft / review / published remain blockers because they represent live or pending content.
+KB_DUPLICATE_IGNORED_STATES = {"retired", "outdated"}
+
 # ServiceNow Query Patterns and Validation
 SERVICENOW_OR_SYNTAX_EXAMPLE = "1^ORpriority=2"
 SERVICENOW_DATE_RANGE_EXAMPLE = ">=2024-01-01 00:00:00^<=2024-01-31 23:59:59"

--- a/filter/models.py
+++ b/filter/models.py
@@ -13,6 +13,12 @@ class TableFilterParams(BaseModel):
         None, description="Field-value pairs for filtering"
     )
     fields: Optional[List[str]] = Field(None, description="Fields to return")
+    max_results: int = Field(
+        100,
+        description="Hard cap on rows returned. Response includes truncated=true when this cap is hit.",
+        ge=1,
+        le=1000,
+    )
 
 
 class SmartQueryParams(BaseModel):

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -21,6 +21,9 @@ from Table_Tools.consolidated_tools import (
     similar_knowledge_for_text,
     get_knowledge_by_category,
     get_active_knowledge_articles,
+    get_kb_articles_by_state,
+    _pick_canonical_kb_row,
+    _KB_STATE_RANK,
     # SLA tools (v4.0: 10 -> 5 consolidated)
     similar_slas_for_text,
     get_sla_details,
@@ -253,6 +256,117 @@ class TestKnowledgeTools:
             mock_query.return_value = {"result": [{"number": "KB001"}]}
             result = await get_active_knowledge_articles("test")
             mock_query.assert_called_once_with("kb_knowledge", {"workflow_state": "published"})
+
+
+class TestPickCanonicalKbRow:
+    """De-dup helper picks highest-priority workflow_state per number."""
+
+    def test_published_beats_draft(self):
+        rows = [
+            {"number": "KB001", "workflow_state": "draft", "sys_id": "s1"},
+            {"number": "KB001", "workflow_state": "published", "sys_id": "s2"},
+        ]
+        result = _pick_canonical_kb_row(rows)
+        assert result["KB001"]["row"]["sys_id"] == "s2"
+        assert result["KB001"]["version_count"] == 2
+
+    def test_draft_beats_outdated(self):
+        rows = [
+            {"number": "KB001", "workflow_state": "outdated", "sys_id": "s1"},
+            {"number": "KB001", "workflow_state": "draft", "sys_id": "s2"},
+        ]
+        result = _pick_canonical_kb_row(rows)
+        assert result["KB001"]["row"]["sys_id"] == "s2"
+
+    def test_unknown_state_ranks_lowest(self):
+        rows = [
+            {"number": "KB001", "workflow_state": "frobnicated", "sys_id": "s1"},
+            {"number": "KB001", "workflow_state": "retired", "sys_id": "s2"},
+        ]
+        result = _pick_canonical_kb_row(rows)
+        assert result["KB001"]["row"]["sys_id"] == "s2"
+
+    def test_version_count_tracks_all_rows(self):
+        rows = [
+            {"number": "KB001", "workflow_state": "published"},
+            {"number": "KB001", "workflow_state": "outdated"},
+            {"number": "KB001", "workflow_state": "outdated"},
+        ]
+        result = _pick_canonical_kb_row(rows)
+        assert result["KB001"]["version_count"] == 3
+
+    def test_state_rank_order(self):
+        assert _KB_STATE_RANK["published"] < _KB_STATE_RANK["draft"]
+        assert _KB_STATE_RANK["draft"] < _KB_STATE_RANK["review"]
+        assert _KB_STATE_RANK["review"] < _KB_STATE_RANK["outdated"]
+        assert _KB_STATE_RANK["outdated"] < _KB_STATE_RANK["retired"]
+
+
+class TestGetKbArticlesByState:
+
+    @pytest.mark.asyncio
+    async def test_dedups_multiple_versions_to_canonical(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": [
+                    {"number": "KB001", "sys_id": "s1", "short_description": "x", "workflow_state": "outdated"},
+                    {"number": "KB001", "sys_id": "s2", "short_description": "x", "workflow_state": "published"},
+                    {"number": "KB002", "sys_id": "s3", "short_description": "y", "workflow_state": "draft"},
+                ],
+                "truncated": False,
+            }
+            result = await get_kb_articles_by_state()
+
+        numbers = {r["number"]: r for r in result["result"]}
+        assert len(numbers) == 2
+        assert numbers["KB001"]["current_state"] == "published"
+        assert numbers["KB001"]["version_count"] == 2
+        assert numbers["KB001"]["sys_id"] == "s2"
+        assert numbers["KB002"]["current_state"] == "draft"
+        assert numbers["KB002"]["version_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_workflow_state_filter_post_dedup(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": [
+                    {"number": "KB001", "sys_id": "s1", "workflow_state": "published"},
+                    {"number": "KB002", "sys_id": "s2", "workflow_state": "draft"},
+                ],
+                "truncated": False,
+            }
+            result = await get_kb_articles_by_state(workflow_state="published")
+
+        numbers = [r["number"] for r in result["result"]]
+        assert numbers == ["KB001"]
+
+    @pytest.mark.asyncio
+    async def test_category_passed_to_server_side_filter(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {"result": [], "truncated": False}
+            await get_kb_articles_by_state(category="IT", kb_base="IT_KB")
+
+            params = mock_query.call_args[0][1]
+            assert params.filters == {"kb_category": "IT", "kb_knowledge_base": "IT_KB"}
+
+    @pytest.mark.asyncio
+    async def test_propagates_truncated_flag(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": [{"number": "KB001", "sys_id": "s1", "workflow_state": "published"}],
+                "truncated": True,
+            }
+            result = await get_kb_articles_by_state()
+            assert result["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_empty_result_returns_message(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {"result": [], "truncated": False}
+            result = await get_kb_articles_by_state()
+            assert result["result"] == []
+            assert "message" in result
+            assert result["returned_count"] == 0
 
 
 class TestSLATools:

--- a/tests/test_generic_table_tools.py
+++ b/tests/test_generic_table_tools.py
@@ -591,6 +591,45 @@ class TestAsyncTableOperations:
 
             assert result["result"] == []
             assert "message" in result
+            assert result["returned_count"] == 0
+            assert result["truncated"] is False
+            assert result["max_results"] == 100
+
+    @pytest.mark.asyncio
+    async def test_query_table_with_filters_truncated_when_cap_hit(self):
+        """When _make_paginated_request returns exactly max_results, truncated=True."""
+        with patch("Table_Tools.generic_table_tools._make_paginated_request") as mock_request, \
+             patch("Table_Tools.generic_table_tools.validate_query_filters") as mock_validate, \
+             patch("Table_Tools.generic_table_tools.validate_result_count") as mock_count:
+
+            mock_request.return_value = [{"number": f"INC{i}"} for i in range(5)]
+            mock_validate.return_value = MagicMock(has_issues=lambda: False)
+            mock_count.return_value = MagicMock(has_issues=lambda: False)
+
+            params = TableFilterParams(filters={"priority": "1"}, max_results=5)
+            result = await query_table_with_filters("incident", params)
+
+            assert result["returned_count"] == 5
+            assert result["truncated"] is True
+            assert result["max_results"] == 5
+
+    @pytest.mark.asyncio
+    async def test_query_table_with_filters_not_truncated_when_under_cap(self):
+        """When _make_paginated_request returns fewer than max_results, truncated=False."""
+        with patch("Table_Tools.generic_table_tools._make_paginated_request") as mock_request, \
+             patch("Table_Tools.generic_table_tools.validate_query_filters") as mock_validate, \
+             patch("Table_Tools.generic_table_tools.validate_result_count") as mock_count:
+
+            mock_request.return_value = [{"number": "INC001"}, {"number": "INC002"}]
+            mock_validate.return_value = MagicMock(has_issues=lambda: False)
+            mock_count.return_value = MagicMock(has_issues=lambda: False)
+
+            params = TableFilterParams(filters={"priority": "1"}, max_results=100)
+            result = await query_table_with_filters("incident", params)
+
+            assert result["returned_count"] == 2
+            assert result["truncated"] is False
+            assert result["max_results"] == 100
 
     @pytest.mark.asyncio
     async def test_get_records_by_priority_success(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -60,11 +60,12 @@ class TestToolRegistry:
 
     def test_expected_tool_count(self):
         import tools
-        # v4.1: KB article write tools added (+3: update/publish/retire = 35 total).
-        # (5 server/auth + 5 generic + 1 priority + 3 knowledge read +
-        #  2 vtb CRUD + 3 KB write + 5 SLA + 6 CMDB + 5 intelligent).
-        assert len(tools.tools) == 35, (
-            f"Expected 35 registered tools, got {len(tools.tools)}. "
+        # v4.1: KB write expansion + KB de-dup read. 35 + check_kb_duplicates +
+        # publish_knowledge_articles + get_kb_articles_by_state = 38.
+        # (5 server/auth + 5 generic + 1 priority + 4 knowledge read +
+        #  2 vtb CRUD + 5 KB write + 5 SLA + 6 CMDB + 5 intelligent).
+        assert len(tools.tools) == 38, (
+            f"Expected 38 registered tools, got {len(tools.tools)}. "
             "If tool count changed intentionally, update this test and CLAUDE.md."
         )
 

--- a/tests/test_kb_article_tools.py
+++ b/tests/test_kb_article_tools.py
@@ -3,6 +3,7 @@ Tests for kb_article_tools.py — KB article write path (update / publish / reti
 Target: 90%+ line coverage, 75%+ branch coverage.
 """
 
+import asyncio
 import pytest
 from unittest.mock import patch, MagicMock
 import httpx
@@ -14,9 +15,12 @@ from Table_Tools.kb_article_tools import (
     _get_kb_article_sys_id,
     _get_kb_article_meta,
     _check_kb_duplicates,
+    _normalize_publish_result,
     update_knowledge_article,
     publish_knowledge_article,
+    publish_knowledge_articles,
     retire_knowledge_article,
+    check_kb_duplicates,
 )
 
 
@@ -263,6 +267,51 @@ class TestCheckKbDuplicates:
 
             assert await _check_kb_duplicates("Test", "KB0001234") == []
 
+    @pytest.mark.asyncio
+    async def test_retired_duplicate_skipped(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = {"result": [
+                {"number": "KB0009999", "short_description": "Account self-registration", "workflow_state": "retired"}
+            ]}
+
+            result = await _check_kb_duplicates("Account self-registration", "KB0001234")
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_outdated_duplicate_skipped(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = {"result": [
+                {"number": "KB0009998", "short_description": "Account self-registration", "workflow_state": "outdated"}
+            ]}
+
+            result = await _check_kb_duplicates("Account self-registration", "KB0001234")
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_states_only_live_returned(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = {"result": [
+                {"number": "KB1000001", "short_description": "Account self-registration", "workflow_state": "draft"},
+                {"number": "KB1000002", "short_description": "Account self-registration", "workflow_state": "review"},
+                {"number": "KB1000003", "short_description": "Account self-registration", "workflow_state": "published"},
+                {"number": "KB1000004", "short_description": "Account self-registration", "workflow_state": "retired"},
+                {"number": "KB1000005", "short_description": "Account self-registration", "workflow_state": "outdated"},
+            ]}
+
+            result = await _check_kb_duplicates("Account self-registration", "KB0001234")
+            numbers = {r["number"] for r in result}
+            assert numbers == {"KB1000001", "KB1000002", "KB1000003"}
+
+    @pytest.mark.asyncio
+    async def test_workflow_state_case_insensitive(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
+            mock_request.return_value = {"result": [
+                {"number": "KB0009999", "short_description": "Account self-registration", "workflow_state": "RETIRED"}
+            ]}
+
+            result = await _check_kb_duplicates("Account self-registration", "KB0001234")
+            assert result == []
+
 
 class TestPublishKnowledgeArticle:
 
@@ -329,6 +378,163 @@ class TestRetireKnowledgeArticle:
             call_kwargs = mock_request.call_args.kwargs
             assert "/api/qonv/mateco_knowledge/articles/abc123/retire" in call_url
             assert call_kwargs["method"] == "POST"
+
+
+class TestCheckKbDuplicatesTool:
+
+    @pytest.mark.asyncio
+    async def test_empty_list_returns_empty_result(self):
+        result = await check_kb_duplicates([])
+        assert result == {"result": []}
+
+    @pytest.mark.asyncio
+    async def test_over_50_returns_error(self):
+        result = await check_kb_duplicates([f"KB{i:07d}" for i in range(51)])
+        assert "error" in result
+        assert "50" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_single_article_no_duplicates(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_meta') as mock_meta, \
+             patch('Table_Tools.kb_article_tools._check_kb_duplicates') as mock_dupes:
+            mock_meta.return_value = {"sys_id": "abc", "short_description": "Onboarding"}
+            mock_dupes.return_value = []
+
+            result = await check_kb_duplicates(["KB0001234"])
+
+            assert len(result["result"]) == 1
+            assert result["result"][0] == {
+                "number": "KB0001234",
+                "has_duplicate": False,
+                "duplicates": [],
+            }
+
+    @pytest.mark.asyncio
+    async def test_single_article_with_duplicates(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_meta') as mock_meta, \
+             patch('Table_Tools.kb_article_tools._check_kb_duplicates') as mock_dupes:
+            mock_meta.return_value = {"sys_id": "abc", "short_description": "Onboarding"}
+            mock_dupes.return_value = [
+                {"number": "KB0009999", "workflow_state": "published", "short_description": "Onboarding", "kb_category": "x"},
+            ]
+
+            result = await check_kb_duplicates(["KB0001234"])
+
+            entry = result["result"][0]
+            assert entry["has_duplicate"] is True
+            # Response is slimmed to number + workflow_state only
+            assert entry["duplicates"] == [{"number": "KB0009999", "workflow_state": "published"}]
+
+    @pytest.mark.asyncio
+    async def test_missing_article_reports_error_entry(self):
+        with patch('Table_Tools.kb_article_tools._get_kb_article_meta') as mock_meta:
+            mock_meta.return_value = None
+
+            result = await check_kb_duplicates(["KB9999999"])
+
+            entry = result["result"][0]
+            assert entry["number"] == "KB9999999"
+            assert entry["has_duplicate"] is False
+            assert "error" in entry
+
+    @pytest.mark.asyncio
+    async def test_mixed_batch_returns_per_article_status(self):
+        async def fake_meta(num):
+            if num == "KB_MISSING":
+                return None
+            return {"sys_id": f"sysid_{num}", "short_description": f"desc_{num}"}
+
+        async def fake_dupes(short_desc, exclude_number):
+            if exclude_number == "KB_DUP":
+                return [{"number": "KB_OTHER", "workflow_state": "draft"}]
+            return []
+
+        with patch('Table_Tools.kb_article_tools._get_kb_article_meta', side_effect=fake_meta), \
+             patch('Table_Tools.kb_article_tools._check_kb_duplicates', side_effect=fake_dupes):
+
+            result = await check_kb_duplicates(["KB_CLEAN", "KB_DUP", "KB_MISSING"])
+
+            by_num = {r["number"]: r for r in result["result"]}
+            assert by_num["KB_CLEAN"]["has_duplicate"] is False
+            assert by_num["KB_DUP"]["has_duplicate"] is True
+            assert "error" in by_num["KB_MISSING"]
+
+
+class TestNormalizePublishResult:
+
+    def test_error_string_becomes_error_row(self):
+        row = _normalize_publish_result("KB001", "Authentication failed during publish")
+        assert row == {
+            "number": "KB001",
+            "status": "error",
+            "message": "Authentication failed during publish",
+        }
+
+    def test_duplicate_block_becomes_blocked_row(self):
+        row = _normalize_publish_result(
+            "KB001",
+            {"success": False, "message": "Duplicate KB article(s) found.", "duplicates": [{"number": "KB999"}]},
+        )
+        assert row["status"] == "blocked"
+        assert row["blockers"] == [{"number": "KB999"}]
+
+    def test_success_record_becomes_published_row(self):
+        row = _normalize_publish_result(
+            "KB001",
+            {"number": "KB001", "sys_id": "abc", "workflow_state": "published", "short_description": "x"},
+        )
+        assert row == {"number": "KB001", "status": "published", "workflow_state": "published"}
+
+
+class TestPublishKnowledgeArticles:
+
+    @pytest.mark.asyncio
+    async def test_empty_list_returns_empty_result(self):
+        result = await publish_knowledge_articles([])
+        assert result == {"result": []}
+
+    @pytest.mark.asyncio
+    async def test_over_20_returns_error(self):
+        result = await publish_knowledge_articles([f"KB{i:07d}" for i in range(21)])
+        assert "error" in result
+        assert "20" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_batch_yields_per_article_status(self):
+        async def fake_publish(num):
+            if num == "KB_OK":
+                return {"number": num, "workflow_state": "published", "sys_id": "s", "short_description": "x"}
+            if num == "KB_DUP":
+                return {"success": False, "message": "Duplicate KB article(s) found.", "duplicates": [{"number": "KB_OTHER", "workflow_state": "draft"}]}
+            return "Authentication failed during publish"
+
+        with patch('Table_Tools.kb_article_tools.publish_knowledge_article', side_effect=fake_publish):
+            result = await publish_knowledge_articles(["KB_OK", "KB_DUP", "KB_ERR"])
+
+        by_num = {r["number"]: r for r in result["result"]}
+        assert by_num["KB_OK"]["status"] == "published"
+        assert by_num["KB_DUP"]["status"] == "blocked"
+        assert by_num["KB_DUP"]["blockers"] == [{"number": "KB_OTHER", "workflow_state": "draft"}]
+        assert by_num["KB_ERR"]["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_concurrency_cap_respected(self):
+        """Verify Semaphore prevents more than `concurrency` in-flight publishes."""
+        in_flight = 0
+        max_seen = 0
+
+        async def fake_publish(num):
+            nonlocal in_flight, max_seen
+            in_flight += 1
+            max_seen = max(max_seen, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return {"number": num, "workflow_state": "published"}
+
+        with patch('Table_Tools.kb_article_tools.publish_knowledge_article', side_effect=fake_publish):
+            await publish_knowledge_articles([f"KB{i:03d}" for i in range(10)], concurrency=3)
+
+        assert max_seen <= 3
 
 
 class TestRoutesThroughUnifiedPipeline:

--- a/tools.py
+++ b/tools.py
@@ -11,13 +11,20 @@ from Table_Tools.consolidated_tools import (
     get_priority_incidents,
     # Knowledge-specific tools
     similar_knowledge_for_text, get_knowledge_by_category, get_active_knowledge_articles,
+    get_kb_articles_by_state,
     # SLA tools (v4.0: 10 -> 5 consolidated)
     similar_slas_for_text, get_sla_details,
     query_slas_by_task, query_slas_by_status, query_slas_custom,
 )
 from Table_Tools.table_tools import nowtestauth, nowtest_auth_input
 from Table_Tools.vtb_task_tools import create_private_task, update_private_task
-from Table_Tools.kb_article_tools import update_knowledge_article, publish_knowledge_article, retire_knowledge_article
+from Table_Tools.kb_article_tools import (
+    update_knowledge_article,
+    publish_knowledge_article,
+    publish_knowledge_articles,
+    retire_knowledge_article,
+    check_kb_duplicates,
+)
 from Table_Tools.cmdb_tools import (
     find_cis_by_type, search_cis_by_attributes, get_ci_details, similar_cis_for_ci, get_all_ci_types, quick_ci_search
 )
@@ -42,12 +49,14 @@ tools = [
 
     # Knowledge-specific tools (unique params)
     similar_knowledge_for_text, get_knowledge_by_category, get_active_knowledge_articles,
+    get_kb_articles_by_state,
 
     # Private Task CRUD
     create_private_task, update_private_task,
 
-    # KB Article write tools (update content, publish, retire)
-    update_knowledge_article, publish_knowledge_article, retire_knowledge_article,
+    # KB Article write tools (update content, publish, batch publish, retire, dup-check)
+    update_knowledge_article, publish_knowledge_article, publish_knowledge_articles,
+    retire_knowledge_article, check_kb_duplicates,
 
     # SLA tools (v4.0: 10 -> 5 consolidated; presets exposed via query_slas_by_status)
     similar_slas_for_text, get_sla_details,


### PR DESCRIPTION
## Summary
v4.1 KB workflow expansion + filter_records pagination metadata.

- **P1** — `_check_kb_duplicates` now skips `retired`/`outdated` workflow states (`KB_DUPLICATE_IGNORED_STATES`). Removes false-positive publish blocks.
- **P2** — `filter_records` response carries `returned_count` + `truncated` + `max_results`. Optional `max_results` param (default 100, max 1000). Non-breaking — applies to all generic tool consumers.
- **P3** — `publish_knowledge_articles` batch tool. Cap 20, concurrency 5. Flat per-article status rows.
- **P4** — `check_kb_duplicates` standalone tool. Cap 50, concurrency 5. Pre-publish conflict resolution.
- **P6** — `get_kb_articles_by_state` KB-specific de-dup tool. One row per number with `current_state` + `version_count`. Generic `filter_records` left untouched.