### PR TITLE
test(oauth): stop swallowing AssertionError in client-creation test

### DIFF
--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -76,16 +76,13 @@ class TestOAuthClientCreation(unittest.TestCase):
         """Test successful OAuth client creation."""
         try:
             from oauth import ServiceNowOAuthClient
-            
-            client = ServiceNowOAuthClient()
-            self.assertIsInstance(client, ServiceNowOAuthClient)
-            self.assertIsNotNone(client.token_endpoint)
-            self.assertIn("oauth_token.do", client.token_endpoint)
-            
         except ImportError:
             self.skipTest("oauth_client module not available")
-        except Exception as e:
-            self.fail(f"Failed to create OAuth client: {str(e)}")
+
+        client = ServiceNowOAuthClient()
+        self.assertIsInstance(client, ServiceNowOAuthClient)
+        self.assertIsNotNone(client.token_endpoint)
+        self.assertIn("oauth_token.do", client.token_endpoint)
 
     @patch.dict(os.environ, {
         'SERVICENOW_INSTANCE': 'https://test.service-now.com',


### PR DESCRIPTION
test_oauth_client_creation_success wrapped its assertions in a try whose `except Exception` (a superclass of AssertionError) caught real assertion failures and reworded them via self.fail. Narrow the try to the import only (skipTest on ImportError); run client creation and the assertions outside so AssertionError and unexpected errors propagate.

Resolves SonarQube findings on L81-83.