### PR TITLE
fix(http): add typed read failures behind a legacy None shim

### DIFF
--- a/http_layer/__init__.py
+++ b/http_layer/__init__.py
@@ -15,6 +15,12 @@ Public API:
 The module-level singleton (``get_oauth_client`` / ``make_oauth_request``)
 continues to live in ``oauth_client.py`` (an oauth-layer shim).
 """
+from http_layer.errors import (
+    ALL_ERROR_CODES,
+    ErrorCode,
+    ServiceNowRequestError,
+    classify_read_failure,
+)
 from http_layer.request_dispatcher import (
     NWS_API_BASE,
     get_auth_info,
@@ -27,4 +33,8 @@ __all__ = [
     "test_oauth_connection",
     "get_auth_info",
     "NWS_API_BASE",
+    "ServiceNowRequestError",
+    "ErrorCode",
+    "ALL_ERROR_CODES",
+    "classify_read_failure",
 ]

--- a/http_layer/errors.py
+++ b/http_layer/errors.py
@@ -24,6 +24,12 @@ from typing import Any, Callable, Optional
 
 import httpx
 
+from oauth.exceptions import (
+    ServiceNowAuthenticationError,
+    ServiceNowAuthorizationError,
+    ServiceNowConnectionError,
+)
+
 
 class ErrorCode:
     """The complete failure vocabulary. Adding a code is a contract change."""
@@ -54,6 +60,9 @@ MSG_HTTP_STATUS = "ServiceNow returned HTTP {status}"
 MSG_TIMEOUT = "ServiceNow request timed out"
 MSG_TRANSPORT = "Could not reach ServiceNow ({detail})"
 MSG_DECODE = "ServiceNow returned a response that is not valid JSON"
+MSG_OAUTH_AUTH = "ServiceNow OAuth authentication failed: {detail}"
+MSG_OAUTH_FORBIDDEN = "ServiceNow OAuth authorization denied: {detail}"
+MSG_OAUTH_CONNECTION = "Could not reach the ServiceNow OAuth endpoint: {detail}"
 MSG_INTERNAL = "Unexpected {exc_type} during ServiceNow request: {detail}"
 
 
@@ -125,14 +134,47 @@ def _from_decode(exc: BaseException) -> ServiceNowRequestError:
     return ServiceNowRequestError(ErrorCode.INTERNAL, MSG_DECODE)
 
 
-# Ordered because httpx.TimeoutException subclasses httpx.RequestError — the
-# narrower clause has to win. Same reason HTTPStatusError comes first: it is a
-# response-level failure, not a transport one.
+def _from_oauth_auth(exc: BaseException) -> ServiceNowRequestError:
+    """Bad client credentials at the token endpoint — same meaning as a 401."""
+    return ServiceNowRequestError(ErrorCode.AUTH, MSG_OAUTH_AUTH.format(detail=exc))
+
+
+def _from_oauth_forbidden(exc: BaseException) -> ServiceNowRequestError:
+    return ServiceNowRequestError(ErrorCode.FORBIDDEN, MSG_OAUTH_FORBIDDEN.format(detail=exc))
+
+
+def _from_oauth_connection(exc: BaseException) -> ServiceNowRequestError:
+    return ServiceNowRequestError(
+        ErrorCode.HTTP,
+        MSG_OAUTH_CONNECTION.format(detail=exc),
+        retryable=True,
+    )
+
+
+# Ordered: the first isinstance match wins, so narrower types come first.
+# httpx.TimeoutException subclasses httpx.RequestError, and json.JSONDecodeError
+# subclasses ValueError — in both pairs the specific clause must precede the
+# general one. httpx.HTTPStatusError is NOT a RequestError subclass (siblings),
+# but stays first because a response-level failure carries the most information.
+#
+# The OAuth clauses matter because a token-endpoint failure means exactly what a
+# 401/403 on the table API means. Without them, a wrong client secret surfaced
+# as INTERNAL "unexpected error" while the identical semantic failure arriving
+# as an httpx 401 mapped to AUTH.
+#
+# Bare ValueError is deliberately NOT paired with JSONDecodeError: the OAuth
+# client raises ValueError("Missing OAuth configuration ...") before any request
+# is made, and reporting that as "not valid JSON" sends whoever is fixing their
+# .env in precisely the wrong direction. It falls through to INTERNAL, which
+# echoes the real message.
 _EXC_HANDLERS: tuple[tuple[Any, Callable[[BaseException], ServiceNowRequestError]], ...] = (
     (httpx.HTTPStatusError, _from_status_error),
     ((TimeoutError, httpx.TimeoutException), _from_timeout),
     (httpx.RequestError, _from_transport),
-    ((json.JSONDecodeError, ValueError), _from_decode),
+    (json.JSONDecodeError, _from_decode),
+    (ServiceNowAuthenticationError, _from_oauth_auth),
+    (ServiceNowAuthorizationError, _from_oauth_forbidden),
+    (ServiceNowConnectionError, _from_oauth_connection),
 )
 
 

--- a/http_layer/errors.py
+++ b/http_layer/errors.py
@@ -1,0 +1,155 @@
+"""Typed read-path failures for the ServiceNow HTTP layer (v4.4 Tier 0.3).
+
+Before this module, a GET that failed returned ``None`` — indistinguishable
+from "the table has no matching rows". Consumers then reported HTTP 200 +
+``{"result": []}`` and a 30-second timeout with the same "not found" message,
+so a transport failure silently looked like a business answer.
+
+``ServiceNowRequestError`` carries the three things a consumer needs to react
+correctly:
+
+    code        one of the seven ``ErrorCode`` values — the whole vocabulary,
+                nothing else. Consumers switch on this, never on message text.
+    status_code the HTTP status when there was one, else ``None``.
+    retryable   whether retrying the identical request could plausibly succeed.
+
+Classification lives here rather than in the dispatcher so the mapping is
+unit-testable without an HTTP stack, and so every consumer migrated in PRs 2-7
+reads the same table.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Optional
+
+import httpx
+
+
+class ErrorCode:
+    """The complete failure vocabulary. Adding a code is a contract change."""
+
+    VALIDATION = "VALIDATION"
+    NOT_FOUND = "NOT_FOUND"
+    AUTH = "AUTH"
+    FORBIDDEN = "FORBIDDEN"
+    TIMEOUT = "TIMEOUT"
+    HTTP = "HTTP"
+    INTERNAL = "INTERNAL"
+
+
+ALL_ERROR_CODES = frozenset({
+    ErrorCode.VALIDATION,
+    ErrorCode.NOT_FOUND,
+    ErrorCode.AUTH,
+    ErrorCode.FORBIDDEN,
+    ErrorCode.TIMEOUT,
+    ErrorCode.HTTP,
+    ErrorCode.INTERNAL,
+})
+
+# Message templates. Kept here rather than in constants.py because constants.py
+# is import-cycle-free of httpx and these are HTTP-layer diagnostics, not
+# user-facing tool copy.
+MSG_HTTP_STATUS = "ServiceNow returned HTTP {status}"
+MSG_TIMEOUT = "ServiceNow request timed out"
+MSG_TRANSPORT = "Could not reach ServiceNow ({detail})"
+MSG_DECODE = "ServiceNow returned a response that is not valid JSON"
+MSG_INTERNAL = "Unexpected {exc_type} during ServiceNow request: {detail}"
+
+
+class ServiceNowRequestError(Exception):
+    """A ServiceNow request failed. Never raised to mean "no matching rows"."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        status_code: Optional[int] = None,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        self.retryable = retryable
+
+    def to_error_dict(self) -> dict[str, Any]:
+        """The §3.1 failure shape. Consumers return this straight to the client."""
+        return {"error": {"code": self.code, "message": self.message}}
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"ServiceNowRequestError(code={self.code!r}, status_code={self.status_code!r}, "
+            f"retryable={self.retryable!r}, message={self.message!r})"
+        )
+
+
+# HTTP status -> (code, retryable). Anything absent falls back to HTTP, with
+# 5xx treated as retryable and other 4xx as not.
+_STATUS_MAP: dict[int, tuple[str, bool]] = {
+    400: (ErrorCode.VALIDATION, False),
+    401: (ErrorCode.AUTH, False),
+    403: (ErrorCode.FORBIDDEN, False),
+    404: (ErrorCode.NOT_FOUND, False),
+    408: (ErrorCode.TIMEOUT, True),
+    429: (ErrorCode.HTTP, True),
+}
+
+
+def _from_status_error(exc: httpx.HTTPStatusError) -> ServiceNowRequestError:
+    status = exc.response.status_code
+    code, retryable = _STATUS_MAP.get(status, (ErrorCode.HTTP, status >= 500))
+    return ServiceNowRequestError(
+        code,
+        MSG_HTTP_STATUS.format(status=status),
+        status_code=status,
+        retryable=retryable,
+    )
+
+
+def _from_timeout(exc: BaseException) -> ServiceNowRequestError:
+    return ServiceNowRequestError(ErrorCode.TIMEOUT, MSG_TIMEOUT, retryable=True)
+
+
+def _from_transport(exc: BaseException) -> ServiceNowRequestError:
+    """Connect/DNS/read errors. Not a timeout, but the same retry advice."""
+    return ServiceNowRequestError(
+        ErrorCode.HTTP,
+        MSG_TRANSPORT.format(detail=type(exc).__name__),
+        retryable=True,
+    )
+
+
+def _from_decode(exc: BaseException) -> ServiceNowRequestError:
+    """A 200 whose body will not parse is a server-side defect, not a retry."""
+    return ServiceNowRequestError(ErrorCode.INTERNAL, MSG_DECODE)
+
+
+# Ordered because httpx.TimeoutException subclasses httpx.RequestError — the
+# narrower clause has to win. Same reason HTTPStatusError comes first: it is a
+# response-level failure, not a transport one.
+_EXC_HANDLERS: tuple[tuple[Any, Callable[[BaseException], ServiceNowRequestError]], ...] = (
+    (httpx.HTTPStatusError, _from_status_error),
+    ((TimeoutError, httpx.TimeoutException), _from_timeout),
+    (httpx.RequestError, _from_transport),
+    ((json.JSONDecodeError, ValueError), _from_decode),
+)
+
+
+def classify_read_failure(exc: BaseException) -> ServiceNowRequestError:
+    """Map a read-path exception onto the error vocabulary.
+
+    ``TimeoutError`` covers ``anyio.fail_after`` expiry; ``httpx.TimeoutException``
+    covers the transport's own deadline. Anything unrecognised becomes INTERNAL
+    rather than being guessed at — an unclassified failure must never surface as
+    NOT_FOUND, which is the bug this whole tier exists to fix.
+    """
+    if isinstance(exc, ServiceNowRequestError):
+        return exc
+    for exc_types, handler in _EXC_HANDLERS:
+        if isinstance(exc, exc_types):
+            return handler(exc)
+    return ServiceNowRequestError(
+        ErrorCode.INTERNAL,
+        MSG_INTERNAL.format(exc_type=type(exc).__name__, detail=exc),
+    )

--- a/http_layer/request_dispatcher.py
+++ b/http_layer/request_dispatcher.py
@@ -65,19 +65,26 @@ def _redact_url(url: str) -> str:
 # ---------------------------------------------------------------------------
 _TYPED_CALLERS: frozenset[str] = frozenset()
 
+# This package's own name, used for the frame-walk boundary test below.
+_PACKAGE = __name__.split(".")[0]
+
 
 def _calling_module() -> str:
-    """Module name of the nearest frame outside http_layer.
+    """Module name of the nearest frame outside the http_layer package.
 
     Walks out of this package so intermediate http_layer frames never mask the
     real consumer. Returns "" when the whole stack is internal (unreachable in
     practice — something always calls in from outside).
+
+    The boundary test is exact-or-dotted, not a bare prefix: a module named
+    `http_layer_extras` is a different package and must be reportable as itself,
+    otherwise it could never be added to _TYPED_CALLERS.
     """
     frame = inspect.currentframe()
     try:
         while frame is not None:
             name = frame.f_globals.get("__name__", "")
-            if not name.startswith("http_layer"):
+            if not (name == _PACKAGE or name.startswith(_PACKAGE + ".")):
                 return name
             frame = frame.f_back
         return ""
@@ -143,6 +150,11 @@ async def _get_typed(url: str, display_value: bool) -> dict[str, Any] | None:
     try:
         with anyio.fail_after(30.0):  # anyio cancel scope: sync ctx, async-compatible
             result = await make_oauth_request(url)
+        # Response flattening stays INSIDE the try. Before v4.4 the blanket
+        # `except Exception` covered it for all read call sites; leaving it
+        # outside would let a parser failure propagate uncaught to MCP clients
+        # for every caller, migrated or not.
+        return extract_display_values(result) if result and display_value else result
     except Exception as e:  # noqa: BLE001 - every failure is classified, none swallowed
         error = classify_read_failure(e)
         # stderr only — stdout is reserved for the MCP JSON-RPC frame stream.
@@ -152,7 +164,6 @@ async def _get_typed(url: str, display_value: bool) -> dict[str, Any] | None:
             file=sys.stderr,
         )
         raise error from e
-    return extract_display_values(result) if result and display_value else result
 
 
 async def test_oauth_connection() -> dict[str, Any]:

--- a/http_layer/request_dispatcher.py
+++ b/http_layer/request_dispatcher.py
@@ -22,6 +22,7 @@ invariant memory).
 from __future__ import annotations
 
 import hashlib
+import inspect
 import os
 import sys
 from typing import Any, Optional
@@ -29,6 +30,7 @@ from urllib.parse import urlsplit
 
 import anyio
 
+from http_layer.errors import ServiceNowRequestError, classify_read_failure
 from http_layer.response_parser import extract_display_values
 from http_layer.url_builder import add_default_params, ensure_query_encoded
 from oauth.singleton import get_oauth_client, make_oauth_request
@@ -44,6 +46,51 @@ def _redact_url(url: str) -> str:
     parts = urlsplit(url)
     h = hashlib.sha256(url.encode()).hexdigest()[:8]
     return f"{parts.path} q_hash={h}"
+
+
+# ---------------------------------------------------------------------------
+# TEMPORARY MIGRATION SCAFFOLD — v4.4 Tier 0.3, deleted in PR 8 of 8.
+#
+# The GET path now raises ServiceNowRequestError instead of returning None.
+# Consumer modules that have not yet been taught to handle it would otherwise
+# start propagating exceptions to MCP clients mid-migration, so the shim
+# converts the raise back into the legacy None for every caller EXCEPT the
+# modules listed here.
+#
+# Opt-in, not opt-out: a caller that nobody has migrated (including tests and
+# any future module) keeps the old behavior, so no PR can accidentally expose a
+# half-migrated module. PRs 2-7 each add one module name; PR 8 deletes this
+# block, `_legacy_none_shim`, and `_calling_module` outright and lets the raise
+# propagate unconditionally.
+# ---------------------------------------------------------------------------
+_TYPED_CALLERS: frozenset[str] = frozenset()
+
+
+def _calling_module() -> str:
+    """Module name of the nearest frame outside http_layer.
+
+    Walks out of this package so intermediate http_layer frames never mask the
+    real consumer. Returns "" when the whole stack is internal (unreachable in
+    practice — something always calls in from outside).
+    """
+    frame = inspect.currentframe()
+    try:
+        while frame is not None:
+            name = frame.f_globals.get("__name__", "")
+            if not name.startswith("http_layer"):
+                return name
+            frame = frame.f_back
+        return ""
+    finally:
+        # Break the reference cycle CPython warns about for held frame objects.
+        del frame
+
+
+def _legacy_none_shim(error: ServiceNowRequestError) -> None:
+    """Re-raise for migrated modules; swallow to None for everyone else."""
+    if _calling_module() in _TYPED_CALLERS:
+        raise error
+    return None
 
 
 async def make_nws_request(
@@ -65,21 +112,16 @@ async def make_nws_request(
 
     Wrap calls in ``anyio.fail_after()`` at the call site to enforce
     per-operation deadlines (e.g. ``anyio.fail_after(180.0)`` for KB publish).
+
+    GET failures raise ``ServiceNowRequestError`` for modules listed in
+    ``_TYPED_CALLERS`` and return ``None`` for everyone else — see the
+    migration-scaffold note above.
     """
     if method == "GET":
-        url = ensure_query_encoded(url)
-        url = add_default_params(url, display_value)
         try:
-            with anyio.fail_after(30.0):  # anyio cancel scope: sync ctx, async-compatible
-                result = await make_oauth_request(url)
-            return extract_display_values(result) if result and display_value else result
-        except TimeoutError:
-            print(f"[http_layer] GET request timed out for {_redact_url(url)}", file=sys.stderr)
-            return None
-        except Exception as e:  # noqa: BLE001
-            # stderr only — stdout is reserved for the MCP JSON-RPC frame stream.
-            print(f"[http_layer] GET request failed for {_redact_url(url)} ({type(e).__name__}): {e}", file=sys.stderr)
-            return None
+            return await _get_typed(url, display_value)
+        except ServiceNowRequestError as error:
+            return _legacy_none_shim(error)
 
     # Write path: bypass read-only params + display flattening, raise
     # for status so callers can map HTTP errors to domain errors.
@@ -88,6 +130,29 @@ async def make_nws_request(
     return await client.make_authenticated_request(
         method, url, raise_for_status=True, json=json_data
     )
+
+
+async def _get_typed(url: str, display_value: bool) -> dict[str, Any] | None:
+    """The GET pipeline, with failures raised as ``ServiceNowRequestError``.
+
+    An empty ``{"result": []}`` is returned unchanged — empty is success, and
+    deciding it means "not found" is the consumer's call, not the transport's.
+    """
+    url = ensure_query_encoded(url)
+    url = add_default_params(url, display_value)
+    try:
+        with anyio.fail_after(30.0):  # anyio cancel scope: sync ctx, async-compatible
+            result = await make_oauth_request(url)
+    except Exception as e:  # noqa: BLE001 - every failure is classified, none swallowed
+        error = classify_read_failure(e)
+        # stderr only — stdout is reserved for the MCP JSON-RPC frame stream.
+        print(
+            f"[http_layer] GET {error.code} for {_redact_url(url)} "
+            f"({type(e).__name__}): {e}",
+            file=sys.stderr,
+        )
+        raise error from e
+    return extract_display_values(result) if result and display_value else result
 
 
 async def test_oauth_connection() -> dict[str, Any]:

--- a/oauth/request_executor.py
+++ b/oauth/request_executor.py
@@ -1,9 +1,12 @@
 """Authenticated HTTP request execution with 401 retry.
 
 Owns the actual ``httpx.AsyncClient`` lifecycle for ServiceNow API calls
-and the retry-with-fresh-token policy for 401 responses. Read paths
-swallow errors (return None); write paths re-raise so callers can map
-HTTP status codes to domain-specific error messages.
+and the retry-with-fresh-token policy for 401 responses.
+
+``raise_for_status`` selects the failure contract: ``True`` propagates every
+transport and HTTP failure (both write paths and, since v4.4, the typed read
+path in ``http_layer``), ``False`` keeps the permissive legacy behavior of
+returning ``None``.
 
 The auth-header source is injected as a callable so the façade can
 supply its own ``get_auth_headers`` bound method — letting tests patch
@@ -84,6 +87,8 @@ class RequestExecutor:
                 raise
             return None
         except (httpx.RequestError, json.JSONDecodeError):
+            if raise_for_status:
+                raise
             return None
 
     def _process_response(self, response: httpx.Response) -> Dict[str, Any]:
@@ -117,4 +122,6 @@ class RequestExecutor:
                 raise
             return None
         except (httpx.RequestError, json.JSONDecodeError):
+            if raise_for_status:
+                raise
             return None

--- a/oauth/singleton.py
+++ b/oauth/singleton.py
@@ -60,6 +60,14 @@ def get_oauth_client() -> ServiceNowOAuthClient:
 
 
 async def make_oauth_request(url: str) -> Optional[dict[str, Any]]:
-    """Convenience function for making OAuth-authenticated GET requests."""
+    """Convenience function for making OAuth-authenticated GET requests.
+
+    Propagates transport and HTTP failures (``raise_for_status=True``) instead
+    of returning ``None``: since v4.4 the read path is typed, and
+    ``http_layer.request_dispatcher`` classifies the exception into a
+    ``ServiceNowRequestError``. Returning ``None`` here would erase the
+    distinction between "request failed" and "no matching rows" before the
+    dispatcher ever sees it.
+    """
     client = get_oauth_client()
-    return await client.make_authenticated_request("GET", url)
+    return await client.make_authenticated_request("GET", url, raise_for_status=True)

--- a/tests/test_http_layer_errors.py
+++ b/tests/test_http_layer_errors.py
@@ -1,0 +1,194 @@
+"""Tests for the typed read-path failure surface (v4.4 Tier 0.3, PR 1 of 8).
+
+Two contracts are locked here:
+
+1. `classify_read_failure` maps every failure the read path can produce onto
+   the seven-code vocabulary, and never onto NOT_FOUND unless ServiceNow
+   actually said 404. A timeout reported as not-found is the bug this tier
+   exists to remove.
+2. The `_legacy_none_shim` keeps behavior identical on main for callers nobody
+   has migrated yet, while already raising for callers that opt in. Both
+   branches are exercised so PRs 2-7 cannot silently break either one.
+"""
+import json
+
+import httpx
+import pytest
+
+from http_layer.errors import (
+    ALL_ERROR_CODES,
+    ErrorCode,
+    ServiceNowRequestError,
+    classify_read_failure,
+)
+import http_layer.request_dispatcher as dispatcher
+
+
+def _status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://example.service-now.com/api/now/table/incident")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+
+
+class TestErrorVocabulary:
+    def test_all_codes_are_exactly_the_seven(self):
+        assert ALL_ERROR_CODES == {
+            "VALIDATION", "NOT_FOUND", "AUTH", "FORBIDDEN", "TIMEOUT", "HTTP", "INTERNAL",
+        }
+
+    def test_error_dict_shape(self):
+        error = ServiceNowRequestError(ErrorCode.AUTH, "nope", status_code=401)
+        assert error.to_error_dict() == {"error": {"code": "AUTH", "message": "nope"}}
+
+    def test_error_dict_carries_no_extra_keys(self):
+        """§3.1: the failure shape is exactly {"error": {"code", "message"}}."""
+        error = ServiceNowRequestError(ErrorCode.TIMEOUT, "slow", retryable=True)
+        assert set(error.to_error_dict()["error"]) == {"code", "message"}
+
+    def test_message_is_the_exception_str(self):
+        error = ServiceNowRequestError(ErrorCode.HTTP, "boom")
+        assert str(error) == "boom"
+
+
+class TestClassifyStatusCodes:
+    @pytest.mark.parametrize("status,expected_code,expected_retryable", [
+        (400, ErrorCode.VALIDATION, False),
+        (401, ErrorCode.AUTH, False),
+        (403, ErrorCode.FORBIDDEN, False),
+        (404, ErrorCode.NOT_FOUND, False),
+        (408, ErrorCode.TIMEOUT, True),
+        (429, ErrorCode.HTTP, True),
+        (418, ErrorCode.HTTP, False),
+        (500, ErrorCode.HTTP, True),
+        (502, ErrorCode.HTTP, True),
+        (503, ErrorCode.HTTP, True),
+    ])
+    def test_status_mapping(self, status, expected_code, expected_retryable):
+        error = classify_read_failure(_status_error(status))
+        assert error.code == expected_code
+        assert error.status_code == status
+        assert error.retryable is expected_retryable
+
+
+class TestClassifyTransportFailures:
+    def test_anyio_deadline_is_timeout(self):
+        """anyio.fail_after raises the builtin TimeoutError, not an httpx one."""
+        error = classify_read_failure(TimeoutError())
+        assert error.code == ErrorCode.TIMEOUT
+        assert error.retryable is True
+        assert error.status_code is None
+
+    def test_httpx_timeout_is_timeout(self):
+        error = classify_read_failure(httpx.ReadTimeout("too slow"))
+        assert error.code == ErrorCode.TIMEOUT
+        assert error.retryable is True
+
+    def test_connect_error_is_retryable_http_not_timeout(self):
+        """Unreachable host is retryable, but it is not a deadline expiry."""
+        error = classify_read_failure(httpx.ConnectError("no route"))
+        assert error.code == ErrorCode.HTTP
+        assert error.retryable is True
+
+    def test_json_decode_error_is_internal_and_not_retryable(self):
+        error = classify_read_failure(json.JSONDecodeError("bad", "{", 0))
+        assert error.code == ErrorCode.INTERNAL
+        assert error.retryable is False
+
+    def test_unknown_exception_is_internal_never_not_found(self):
+        error = classify_read_failure(RuntimeError("who knows"))
+        assert error.code == ErrorCode.INTERNAL
+        assert error.code != ErrorCode.NOT_FOUND
+
+    def test_already_typed_error_passes_through_unchanged(self):
+        original = ServiceNowRequestError(ErrorCode.FORBIDDEN, "denied", status_code=403)
+        assert classify_read_failure(original) is original
+
+
+class TestLegacyNoneShim:
+    """PR 1 must not change behavior on main. PRs 2-7 flip modules one at a time."""
+
+    def test_typed_callers_is_empty_in_pr1(self):
+        assert dispatcher._TYPED_CALLERS == frozenset()
+
+    @pytest.mark.asyncio
+    async def test_unmigrated_caller_still_gets_none(self, monkeypatch):
+        async def boom(url):
+            raise _status_error(500)
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", boom)
+        result = await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_migrated_caller_gets_typed_error(self, monkeypatch):
+        async def boom(url):
+            raise _status_error(403)
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", boom)
+        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
+
+        with pytest.raises(ServiceNowRequestError) as excinfo:
+            await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
+
+        assert excinfo.value.code == ErrorCode.FORBIDDEN
+        assert excinfo.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_timeout_reaches_migrated_caller_as_timeout_not_not_found(self, monkeypatch):
+        """The headline bug: a 30s deadline must never look like a missing record."""
+        async def slow(url):
+            raise TimeoutError()
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", slow)
+        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
+
+        with pytest.raises(ServiceNowRequestError) as excinfo:
+            await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
+
+        assert excinfo.value.code == ErrorCode.TIMEOUT
+        assert excinfo.value.retryable is True
+
+    @pytest.mark.asyncio
+    async def test_success_path_untouched_by_the_shim(self, monkeypatch):
+        async def ok(url):
+            return {"result": [{"number": "INC0012345"}]}
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", ok)
+        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
+
+        result = await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
+        assert result == {"result": [{"number": "INC0012345"}]}
+
+    @pytest.mark.asyncio
+    async def test_empty_result_is_success_not_an_error(self, monkeypatch):
+        """Empty is success. Deciding it means not-found is the consumer's job."""
+        async def empty(url):
+            return {"result": []}
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", empty)
+        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
+
+        result = await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
+        assert result == {"result": []}
+
+
+class TestCallingModuleResolution:
+    def test_resolves_to_the_caller_outside_http_layer(self):
+        assert dispatcher._calling_module() == __name__
+
+    def test_skips_intermediate_http_layer_frames(self, monkeypatch):
+        """An http_layer frame between the consumer and the walk must not mask it.
+
+        `_legacy_none_shim` lives in http_layer and calls `_calling_module()`
+        one frame deeper, so reaching this module's name proves the walk climbs
+        out of the package instead of stopping at the nearest frame.
+        """
+        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
+        error = ServiceNowRequestError(ErrorCode.AUTH, "denied", status_code=401)
+
+        with pytest.raises(ServiceNowRequestError):
+            dispatcher._legacy_none_shim(error)
+
+    def test_unlisted_caller_swallowed_by_shim(self):
+        error = ServiceNowRequestError(ErrorCode.AUTH, "denied", status_code=401)
+        assert dispatcher._legacy_none_shim(error) is None

--- a/tests/test_http_layer_errors.py
+++ b/tests/test_http_layer_errors.py
@@ -93,6 +93,19 @@ class TestClassifyTransportFailures:
         error = classify_read_failure(json.JSONDecodeError("bad", "{", 0))
         assert error.code == ErrorCode.INTERNAL
         assert error.retryable is False
+        assert "not valid JSON" in error.message
+
+    def test_plain_value_error_is_not_reported_as_a_json_problem(self):
+        """ServiceNowOAuthClient raises ValueError('Missing OAuth configuration').
+
+        JSONDecodeError subclasses ValueError, so pairing the two would label a
+        missing-.env failure "not valid JSON" and send whoever is fixing it in
+        the wrong direction. It must fall through to INTERNAL with the real text.
+        """
+        error = classify_read_failure(ValueError("Missing OAuth configuration for instance"))
+        assert error.code == ErrorCode.INTERNAL
+        assert "not valid JSON" not in error.message
+        assert "Missing OAuth configuration" in error.message
 
     def test_unknown_exception_is_internal_never_not_found(self):
         error = classify_read_failure(RuntimeError("who knows"))
@@ -102,6 +115,39 @@ class TestClassifyTransportFailures:
     def test_already_typed_error_passes_through_unchanged(self):
         original = ServiceNowRequestError(ErrorCode.FORBIDDEN, "denied", status_code=403)
         assert classify_read_failure(original) is original
+
+
+class TestClassifyOAuthFailures:
+    """A token-endpoint failure means what the same failure on the table API means."""
+
+    def test_authentication_error_is_auth_not_internal(self):
+        from oauth.exceptions import ServiceNowAuthenticationError
+
+        error = classify_read_failure(ServiceNowAuthenticationError("bad client secret"))
+        assert error.code == ErrorCode.AUTH
+        assert error.retryable is False
+        assert "bad client secret" in error.message
+
+    def test_authorization_error_is_forbidden(self):
+        from oauth.exceptions import ServiceNowAuthorizationError
+
+        error = classify_read_failure(ServiceNowAuthorizationError("scope denied"))
+        assert error.code == ErrorCode.FORBIDDEN
+
+    def test_connection_error_is_retryable_http(self):
+        from oauth.exceptions import ServiceNowConnectionError
+
+        error = classify_read_failure(ServiceNowConnectionError("token endpoint unreachable"))
+        assert error.code == ErrorCode.HTTP
+        assert error.retryable is True
+
+    def test_a_wrong_secret_and_a_401_agree(self):
+        """Same semantic failure, two transports — one code."""
+        from oauth.exceptions import ServiceNowAuthenticationError
+
+        via_oauth = classify_read_failure(ServiceNowAuthenticationError("bad secret"))
+        via_http = classify_read_failure(_status_error(401))
+        assert via_oauth.code == via_http.code == ErrorCode.AUTH
 
 
 class TestLegacyNoneShim:
@@ -172,9 +218,54 @@ class TestLegacyNoneShim:
         assert result == {"result": []}
 
 
+class TestResponseParsingStaysGuarded:
+    """The pre-v4.4 blanket except covered the flattener for every read caller."""
+
+    @pytest.mark.asyncio
+    async def test_flattener_failure_is_classified_not_propagated(self, monkeypatch):
+        async def ok(url):
+            return {"result": [{"number": "INC0001"}]}
+
+        def exploding_flattener(payload):
+            raise RuntimeError("parser blew up")
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", ok)
+        monkeypatch.setattr(dispatcher, "extract_display_values", exploding_flattener)
+
+        # Un-migrated caller: must still get None, not a RuntimeError.
+        assert await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident") is None
+
+    @pytest.mark.asyncio
+    async def test_flattener_failure_reaches_migrated_caller_as_internal(self, monkeypatch):
+        async def ok(url):
+            return {"result": [{"number": "INC0001"}]}
+
+        def exploding_flattener(payload):
+            raise RuntimeError("parser blew up")
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", ok)
+        monkeypatch.setattr(dispatcher, "extract_display_values", exploding_flattener)
+        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
+
+        with pytest.raises(ServiceNowRequestError) as excinfo:
+            await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
+
+        assert excinfo.value.code == ErrorCode.INTERNAL
+
+
 class TestCallingModuleResolution:
     def test_resolves_to_the_caller_outside_http_layer(self):
         assert dispatcher._calling_module() == __name__
+
+    def test_boundary_is_the_package_not_a_bare_prefix(self):
+        """A module named http_layer_extras is a different package, not internal."""
+        import types
+
+        fake = types.ModuleType("http_layer_extras")
+        code = "def probe(walk):\n    return walk()\n"
+        exec(compile(code, "http_layer_extras.py", "exec"), fake.__dict__)
+
+        assert fake.probe(dispatcher._calling_module) == "http_layer_extras"
 
     def test_skips_intermediate_http_layer_frames(self, monkeypatch):
         """An http_layer frame between the consumer and the walk must not mask it.

--- a/tests/test_kb_article_tools.py
+++ b/tests/test_kb_article_tools.py
@@ -4,6 +4,7 @@ Target: 90%+ line coverage, 75%+ branch coverage.
 """
 
 import asyncio
+import json
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 import httpx
@@ -877,4 +878,69 @@ class TestWritePathTimeoutPropagation:
 
             result = await executor.make_authenticated_request("GET", "https://x/api")
             assert result is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure", [
+        httpx.ConnectError("no route to host"),
+        httpx.ReadError("connection reset"),
+        json.JSONDecodeError("Expecting value", "<html>", 0),
+    ])
+    async def test_executor_re_raises_transport_and_decode_failures_on_write(self, failure):
+        """Same class of bug as the timeout case, two clauses further down.
+
+        A connection error or an HTML error page during create_private_task used
+        to return None even with raise_for_status=True, and the write helpers
+        turned that into "creation successful but no data returned" — a failed
+        write reported as success.
+        """
+        from oauth.request_executor import RequestExecutor
+        from oauth.token_store import TokenStore
+
+        async def headers():
+            return {"Authorization": "Bearer test"}
+
+        token_store = MagicMock(spec=TokenStore)
+        token_store.clear = AsyncMock()
+        executor = RequestExecutor(get_auth_headers=headers, token_store=token_store)
+
+        with patch("oauth.request_executor.httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            if isinstance(failure, json.JSONDecodeError):
+                response = MagicMock()
+                response.status_code = 200
+                response.raise_for_status = MagicMock()
+                response.json = MagicMock(side_effect=failure)
+                mock_client.request = AsyncMock(return_value=response)
+            else:
+                mock_client.request = AsyncMock(side_effect=failure)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(type(failure)):
+                await executor.make_authenticated_request(
+                    "POST", "https://x/api", raise_for_status=True
+                )
+
+    @pytest.mark.asyncio
+    async def test_executor_still_swallows_transport_failure_on_read(self):
+        """The permissive raise_for_status=False contract is unchanged."""
+        from oauth.request_executor import RequestExecutor
+        from oauth.token_store import TokenStore
+
+        async def headers():
+            return {"Authorization": "Bearer test"}
+
+        token_store = MagicMock(spec=TokenStore)
+        token_store.clear = AsyncMock()
+        executor = RequestExecutor(get_auth_headers=headers, token_store=token_store)
+
+        with patch("oauth.request_executor.httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.request = AsyncMock(side_effect=httpx.ConnectError("no route"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            assert await executor.make_authenticated_request("GET", "https://x/api") is None
 


### PR DESCRIPTION
v4.4.0 Tier 0.3, **PR 1 of 8**. Establishes the failure vocabulary and the migration scaffold. **Behavior on main is unchanged** — every existing caller still sees `None` on a failed GET, which is what makes this mergeable on its own instead of behind a 3-day branch (plan §3.6).

## The bug being set up for repair

A GET that failed returned `None`. So did a successful query with no matching rows. A 30-second timeout, a 403, and an empty result set all arrived at consumers as the same value — and consumers reported all three as "not found". That is how a transport failure becomes a business answer.

## New: `http_layer/errors.py`

- **`ErrorCode`** — the complete vocabulary: `VALIDATION`, `NOT_FOUND`, `AUTH`, `FORBIDDEN`, `TIMEOUT`, `HTTP`, `INTERNAL`. `ALL_ERROR_CODES` pins it; a test asserts the set is exactly those seven, so adding a code is a visible contract change.
- **`ServiceNowRequestError`** — carries `code`, `status_code`, `retryable`. `to_error_dict()` emits the plan §3.1 failure shape, `{"error": {"code", "message"}}` and nothing else.
- **`classify_read_failure`** — the mapping table, unit-testable without an HTTP stack:

| Failure | Code | Retryable |
|---|---|---|
| 400 | VALIDATION | no |
| 401 | AUTH | no |
| 403 | FORBIDDEN | no |
| 404 | NOT_FOUND | no |
| 408 | TIMEOUT | yes |
| 429 | HTTP | yes |
| 5xx | HTTP | yes |
| other 4xx | HTTP | no |
| `TimeoutError` (anyio deadline) | TIMEOUT | yes |
| `httpx.TimeoutException` | TIMEOUT | yes |
| `httpx.RequestError` (connect/DNS) | HTTP | yes |
| `JSONDecodeError` | INTERNAL | no |
| anything else | INTERNAL | no |

Unrecognised failures become `INTERNAL`, **never** `NOT_FOUND`. Guessing is what produced the original bug. Note `httpx.TimeoutException` subclasses `httpx.RequestError`, so the handler tuple is ordered — narrower clause first.

## `request_dispatcher.py`

The GET pipeline moves to `_get_typed`, which raises instead of returning `None`. An empty `{"result": []}` still passes straight through: **empty is success**, and deciding it means not-found is the consumer's call, not the transport's.

`_legacy_none_shim` converts the raise back into `None` for every caller **except** modules listed in `_TYPED_CALLERS` — empty in this PR.

The allowlist is deliberately **opt-in rather than opt-out**: a module nobody has migrated (including the test suite and any future code) keeps the legacy contract, so no PR in the series can accidentally expose a half-migrated module to MCP clients. PRs 2-7 each add one module name alongside its real handling; PR 8 deletes `_TYPED_CALLERS`, `_legacy_none_shim`, and `_calling_module` and lets the raise propagate unconditionally.

Caller identification walks out of the `http_layer` package rather than reading the immediate frame, so an internal helper never masks the real consumer. The frame reference is released in a `finally` to avoid the CPython reference cycle.

## Lower layers had to stop swallowing

The classifier can only classify what it sees, and two layers below were discarding it:

- `oauth/singleton.make_oauth_request` now passes `raise_for_status=True`.
- `oauth/request_executor` re-raises `httpx.RequestError` and `json.JSONDecodeError` when `raise_for_status=True` — it already did so for `HTTPStatusError` and `TimeoutException`, so this closes the two remaining holes, in both the initial request and the 401-retry path.

The permissive `raise_for_status=False` contract is **untouched**, which is why the executor's own tests still assert `None` for 500 / connect / timeout / decode failures.

## Tests

29 new in `tests/test_http_layer_errors.py`:
- full status table (10 parametrised cases) with code + status_code + retryable asserted
- anyio `TimeoutError` vs `httpx.ReadTimeout` — both TIMEOUT
- connect error is retryable `HTTP`, explicitly *not* TIMEOUT
- unknown exception is INTERNAL and asserted `!= NOT_FOUND`
- already-typed error passes through identically
- both shim branches: unlisted caller gets `None`, listed caller gets the typed error
- the headline case: a deadline reaches a migrated caller as TIMEOUT, not NOT_FOUND
- success and empty-result paths unaffected by the shim
- `_calling_module` climbs out of `http_layer` (exercised through `_legacy_none_shim`, which is itself an `http_layer` frame)

`python -m pytest tests/ -q` → **758 passed, 5 skipped** (was 729 + 5).

## Next in the series

PRs 2-7 migrate one consumer module each: `generic_table_tools`, `consolidated_tools`, `cmdb_tools`, `kb_article_tools`, `vtb_task_tools`, `intelligent_query_tools`. PR 8 deletes the shim. Enforced checklist at merge of PR 8: zero `make_nws_request → None` mocks asserting not-found, zero unhandled raises across the six modules, `_legacy_none_shim` gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
