### PR TITLE
fix(search): restore search_field plumbing lost in the #58/#61 merge

### DIFF
--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -16,6 +16,7 @@ from constants import (
     NO_VALID_PRIORITIES_ERROR,
     TABLE_NO_PRIORITY_SUPPORT_ERROR,
     MONTH_NAME_TO_NUMBER,
+    text_search_field_for,
     LOGICMONITOR_CALLER_SYS_ID,
     ENABLE_COMPLETE_QUERY,
     TABLE_CONFIGS
@@ -63,7 +64,12 @@ def _is_safe_record_number(record_number: str) -> bool:
     return True
 
 
-async def query_table_by_text(table_name: str, input_text: str, detailed: bool = False) -> dict[str, Any]:
+async def query_table_by_text(
+    table_name: str,
+    input_text: str,
+    detailed: bool = False,
+    search_field: Optional[str] = None,
+) -> dict[str, Any]:
     """Generic function to query any ServiceNow table by text similarity.
 
     Builds ONE OR-combined query across every extracted keyword
@@ -91,7 +97,7 @@ async def query_table_by_text(table_name: str, input_text: str, detailed: bool =
         return {"result": [], "message": NO_RECORDS_FOUND}
 
     # OR-group the keyword conditions so one request matches any keyword.
-    query = "^OR".join(f"short_descriptionLIKE{keyword}" for keyword in keywords)
+    query = "^OR".join(f"{search_field}LIKE{keyword}" for keyword in keywords)
     base_url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields={','.join(fields)}&sysparm_query={query}"
     # Single paginated request; text searches capped at 50 results.
     all_results = await _make_paginated_request(base_url, max_results=50)


### PR DESCRIPTION
**main is currently red — 8 failures.** This is the fix.

The #61-into-main merge resolved the `generic_table_tools.py` conflict by keeping #61's *docstrings and call sites* while taking the pre-#61 *code*. Three pieces of the `search_field` mechanism went missing while everything referencing them stayed:

| Lost | Symptom |
|---|---|
| `search_field: Optional[str] = None` in the signature | `UnboundLocalError` on every `query_table_by_text` call; `TypeError` from `similar_slas_for_text`, which passes it by keyword |
| the `text_search_field_for` import | `NameError` at line 92, which still calls it |
| `{search_field}LIKE` in the OR-join, reverted to hardcoded `short_descriptionLIKE` | even with the above fixed, `task_sla` text search goes back to the silently-dropped filter the whole item exists to prevent |

`constants.py` and `filter/intelligence.py` came through intact, which is why this presented as a signature problem rather than a lost feature.

**822 passed, 5 skipped** with the fix.

One thing worth carrying forward: docstrings surviving a conflict resolution is not evidence the code did. The tests that caught this assert on the **outbound URL**; the ones asserting on return values passed throughout.