### PR TITLE
fix(read): stop reporting a failed read as a missing record

### DIFF
--- a/Table_Tools/consolidated_tools.py
+++ b/Table_Tools/consolidated_tools.py
@@ -17,6 +17,7 @@ from .generic_table_tools import (
     query_table_with_generic_filters,
     TableFilterParams
 )
+from .read_helpers import carry_partial, is_read_failure
 from .date_utils import (
     validate_date_format,
     build_date_filter,
@@ -155,7 +156,16 @@ async def get_priority_incidents(
     if not include_metadata:
         return result
 
-    return _build_metadata(result, priorities, start_date, end_date, additional_filters, query_timestamp)
+    # A failed read has no rows to count. Wrapping it in metadata would report
+    # "Found 0 priority 1 incident(s)" for a timeout, which is the not-found
+    # mislabelling v4.4 Tier 0.3 exists to remove.
+    if is_read_failure(result):
+        return result
+
+    enriched = _build_metadata(
+        result, priorities, start_date, end_date, additional_filters, query_timestamp
+    )
+    return carry_partial(enriched, result)
 
 
 def _build_priority_result_message(
@@ -297,6 +307,10 @@ async def get_kb_articles_by_state(
         max_results=max_results,
     )
     raw = await query_table_with_filters("kb_knowledge", params)
+    # De-duplicating a failure would answer "No matching KB articles." for a
+    # read that never happened. Pass the failure through untouched.
+    if is_read_failure(raw):
+        return raw
     rows = raw.get("result", []) or []
 
     by_number = _pick_canonical_kb_row(rows)
@@ -310,18 +324,18 @@ async def get_kb_articles_by_state(
         deduped.append(formatted)
 
     if not deduped:
-        return {
+        return carry_partial({
             "result": [],
             "message": "No matching KB articles.",
             "returned_count": 0,
             "truncated": raw.get("truncated", False),
-        }
+        }, raw)
 
-    return {
+    return carry_partial({
         "result": deduped,
         "returned_count": len(deduped),
         "truncated": raw.get("truncated", False),
-    }
+    }, raw)
 
 
 # ---------------------------------------------------------------------------

--- a/Table_Tools/consolidated_tools.py
+++ b/Table_Tools/consolidated_tools.py
@@ -17,7 +17,7 @@ from .generic_table_tools import (
     query_table_with_generic_filters,
     TableFilterParams
 )
-from .read_helpers import carry_partial, is_read_failure
+from .read_helpers import carry_partial, carry_partial_after_filter, is_read_failure
 from .date_utils import (
     validate_date_format,
     build_date_filter,
@@ -323,8 +323,11 @@ async def get_kb_articles_by_state(
             continue
         deduped.append(formatted)
 
+    # Dedup + the workflow_state filter can empty a partial set. Answering
+    # "No matching KB articles." from pages that never arrived would be the same
+    # confident-wrong answer this tier removes, so that case reports the failure.
     if not deduped:
-        return carry_partial({
+        return carry_partial_after_filter({
             "result": [],
             "message": "No matching KB articles.",
             "returned_count": 0,

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -1,5 +1,5 @@
 import sys
-from http_layer import make_nws_request, NWS_API_BASE
+from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
 from utils import extract_keywords
 from typing import Any, Dict, Optional, List
 import re
@@ -21,6 +21,7 @@ from constants import (
     ENABLE_COMPLETE_QUERY,
     TABLE_CONFIGS
 )
+from .read_helpers import carry_partial, is_read_failure
 from filter import (
     QueryExplainer,
     QueryIntelligence,
@@ -32,6 +33,55 @@ from filter import (
     validate_query_filters,
     validate_result_count,
 )
+
+
+# ---------------------------------------------------------------------------
+# Read-failure contract (v4.4 Tier 0.3). This module is the first entry in
+# `http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET arrives here
+# as a raised `ServiceNowRequestError` instead of `None`. The rules below are
+# settled here and reused by every other consumer module migrated after it:
+#
+#   1. A raise returns `error.to_error_dict()` -> {"error": {code, message}}
+#      and nothing else. `retryable` is for our own retry logic, not the client,
+#      and the code is never translated into prose.
+#   2. An empty result stays not-found. HTTP 200 + {"result": []} keeps the
+#      existing RECORD_NOT_FOUND / NO_RECORDS_FOUND message: empty is success.
+#      The only thing that changes is that a *failure* no longer shares it.
+#   3. A page failing mid-pagination keeps the rows already collected and marks
+#      the response `partial` (see `PartialPageReadError` / `_partial_envelope`).
+#      Page 1 failing has no rows to keep, so it is a plain error with no
+#      `partial` key.
+#   4. `except ServiceNowRequestError` always precedes a bare `except Exception`
+#      so the typed failure is never flattened into a message string.
+# ---------------------------------------------------------------------------
+
+
+class PartialPageReadError(Exception):
+    """A page after the first failed; the rows already collected are attached.
+
+    Deliberately NOT a `ServiceNowRequestError` subclass. If it were, every
+    `except ServiceNowRequestError` arm would silently absorb it and throw away
+    the rows it carries — the exact "discard 250 good rows because page 2 died"
+    behavior this replaces. Being a separate type means a call site that forgets
+    it degrades to a plain error rather than to a wrong-looking empty result.
+
+    Only raised when at least one row was already collected; a first-page
+    failure propagates as `ServiceNowRequestError`.
+    """
+
+    def __init__(self, rows: List[Dict[str, Any]], error: ServiceNowRequestError) -> None:
+        super().__init__(error.message)
+        self.rows = rows
+        self.error = error
+
+
+def _partial_envelope(base: Dict[str, Any], partial: PartialPageReadError) -> Dict[str, Any]:
+    """Mark an otherwise-normal response as a partial read.
+
+    The one sanctioned shape where rows and `error` coexist (plan §3.1): the
+    rows are real and usable, and the error says why the set is incomplete.
+    """
+    return {**base, "partial": True, **partial.error.to_error_dict()}
 
 
 def _validate_regex_input(text: str) -> bool:
@@ -100,17 +150,27 @@ async def query_table_by_text(
     query = "^OR".join(f"{search_field}LIKE{keyword}" for keyword in keywords)
     base_url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields={','.join(fields)}&sysparm_query={query}"
     # Single paginated request; text searches capped at 50 results.
-    all_results = await _make_paginated_request(base_url, max_results=50)
+    try:
+        all_results = await _make_paginated_request(base_url, max_results=50)
+    except PartialPageReadError as partial:
+        return _partial_envelope(_text_search_envelope(partial.rows, input_text), partial)
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
 
-    if all_results:
-        result_count = len(all_results)
-        limit_note = " (limited to 50)" if result_count == 50 else ""
-        return {
-            "result": all_results,
-            "message": f"Found {result_count} records matching '{input_text}'{limit_note}",
-        }
-    # Return consistent dict format for no results
-    return {"result": [], "message": NO_RECORDS_FOUND}
+    return _text_search_envelope(all_results, input_text)
+
+
+def _text_search_envelope(rows: List[Dict[str, Any]], input_text: str) -> dict[str, Any]:
+    """Response shape for a text search. No rows is not-found, never a failure."""
+    if not rows:
+        return {"result": [], "message": NO_RECORDS_FOUND}
+    result_count = len(rows)
+    limit_note = " (limited to 50)" if result_count == 50 else ""
+    return {
+        "result": rows,
+        "message": f"Found {result_count} records matching '{input_text}'{limit_note}",
+    }
+
 
 async def get_record_description(table_name: str, record_number: str) -> dict[str, Any]:
     """Generic function to get short_description for any record."""
@@ -118,8 +178,13 @@ async def get_record_description(table_name: str, record_number: str) -> dict[st
         return {"result": [], "message": RECORD_NOT_FOUND}
     query = f"number={record_number}"
     url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields=short_description&sysparm_query={query}"
-    data = await make_nws_request(url)
-    return data if data else {"result": [], "message": RECORD_NOT_FOUND}
+    try:
+        data = await make_nws_request(url)
+    except ServiceNowRequestError as error:
+        # A failed lookup is not a missing record. RECORD_NOT_FOUND below is
+        # reserved for a successful read that returned no rows.
+        return error.to_error_dict()
+    return _record_envelope(data)
 
 async def get_record_details(table_name: str, record_number: str) -> dict[str, Any]:
     """Generic function to get detailed information for any record."""
@@ -128,39 +193,74 @@ async def get_record_details(table_name: str, record_number: str) -> dict[str, A
     fields = DETAIL_FIELDS.get(table_name, ["number", "short_description"])
     query = f"number={record_number}"
     url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields={','.join(fields)}&sysparm_query={query}&sysparm_display_value=true"
-    data = await make_nws_request(url)
-    return data if data else {"result": [], "message": RECORD_NOT_FOUND}
+    try:
+        data = await make_nws_request(url)
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
+    return _record_envelope(data)
+
+
+def _record_envelope(data: Optional[dict[str, Any]]) -> dict[str, Any]:
+    """Single-record read shape. A successful read with no rows is not-found.
+
+    Before v4.4 this label was also produced when the request itself failed
+    (the read path returned `None` for both). Failures are mapped by the caller
+    now, so RECORD_NOT_FOUND means only what it says.
+    """
+    if not data or not data.get("result"):
+        return {"result": [], "message": RECORD_NOT_FOUND}
+    return data
+
+
+def _first_short_description(desc_data: dict[str, Any]) -> str:
+    """Pull the first row's short_description out of a description response."""
+    rows = desc_data.get('result') or []
+    if not rows:
+        return ""
+    return (rows[0].get('short_description') or "").strip()
+
+
+def _exclude_original_record(similar_data: dict[str, Any], record_number: str) -> dict[str, Any]:
+    """Drop the source record from a text-search result, preserving partial state."""
+    rows = similar_data.get('result') or []
+    if not rows:
+        return similar_data  # nothing to filter — pass the inner response through
+    filtered_results = [record for record in rows if record.get('number') != record_number]
+    if filtered_results:
+        response = {
+            "result": filtered_results,
+            "message": f"Found {len(filtered_results)} similar records (excluding original record)",
+        }
+    else:
+        response = {"result": [], "message": NO_SIMILAR_RECORDS_FOUND}
+    return carry_partial(response, similar_data)
+
 
 async def find_similar_records(table_name: str, record_number: str) -> dict[str, Any]:
-    """Generic function to find similar records based on a given record's description."""
+    """Generic function to find similar records based on a given record's description.
+
+    Both inner calls return their own failure dicts now, so a transport failure
+    is passed through as-is rather than being reported as "no description found"
+    or as the generic CONNECTION_ERROR string.
+    """
     try:
         desc_data = await get_record_description(table_name, record_number)
-        
-        # Extract description text from the response
-        if desc_data and desc_data.get('result') and len(desc_data['result']) > 0:
-            desc_text = desc_data['result'][0].get('short_description', '')
-            if desc_text and desc_text.strip():
-                # Get similar records using text search
-                similar_data = await query_table_by_text(table_name, desc_text)
-                
-                # Filter out the original record from results
-                if similar_data and similar_data.get('result'):
-                    filtered_results = [
-                        record for record in similar_data['result'] 
-                        if record.get('number') != record_number
-                    ]
-                    
-                    result_count = len(filtered_results)
-                    if filtered_results:
-                        return {
-                            "result": filtered_results,
-                            "message": f"Found {result_count} similar records (excluding original record)"
-                        }
-                    else:
-                        return {"result": [], "message": NO_SIMILAR_RECORDS_FOUND}
+        if is_read_failure(desc_data):
+            return desc_data
 
-                return similar_data  # Return original result if no filtering needed
-        return {"result": [], "message": NO_DESCRIPTION_FOUND}
+        desc_text = _first_short_description(desc_data)
+        if not desc_text:
+            return {"result": [], "message": NO_DESCRIPTION_FOUND}
+
+        similar_data = await query_table_by_text(table_name, desc_text)
+        if is_read_failure(similar_data):
+            return similar_data
+        return _exclude_original_record(similar_data, record_number)
+    except ServiceNowRequestError as error:
+        # Defensive: the calls above map their own failures, so reaching this
+        # arm means a new raise path appeared. Map it into the error vocabulary
+        # rather than letting CONNECTION_ERROR become a fourth error dialect.
+        return error.to_error_dict()
     except Exception:
         return {"result": [], "message": CONNECTION_ERROR}
 
@@ -654,7 +754,15 @@ async def _make_paginated_request(
     page_size: int = 250,
     default_sort: str = "ORDERBYDESCsys_created_on"
 ) -> List[Dict[str, Any]]:
-    """Make paginated requests to get complete result sets."""
+    """Make paginated requests to get complete result sets.
+
+    Raises:
+        PartialPageReadError: a page after the first failed. Carries the rows
+            collected so far — they are real records and are not discarded
+            because a later page timed out.
+        ServiceNowRequestError: the first page failed, so there is nothing to
+            keep and the whole read is a failure.
+    """
     if default_sort:
         url = _inject_sort_order(url, default_sort)
     all_results = []
@@ -662,11 +770,17 @@ async def _make_paginated_request(
 
     while len(all_results) < max_results:
         paginated_url = f"{url}&sysparm_offset={offset}&sysparm_limit={page_size}"
-        data = await make_nws_request(paginated_url)
-        
+        try:
+            data = await make_nws_request(paginated_url)
+        except ServiceNowRequestError as error:
+            if all_results:
+                raise PartialPageReadError(all_results[:max_results], error) from error
+            raise
+
+        # A 200 with no rows ends the walk normally — empty is success.
         if not data or not data.get('result'):
             break
-        
+
         batch_results = data['result']
         if not batch_results:
             break
@@ -698,6 +812,10 @@ async def query_table_with_filters(table_name: str, params: TableFilterParams) -
     caller can detect silent caps. truncated=True is a heuristic — it fires when
     returned_count == max_results (may be a false positive on exact-boundary
     result sets, but never a false negative).
+
+    A read failure returns {"error": {code, message}}. A failure *after* some
+    pages succeeded returns the collected rows plus `partial: true` and the
+    error, so the caller can use the rows and still know the set is incomplete.
     """
     fields = params.fields or ESSENTIAL_FIELDS.get(table_name, ["number", "short_description"])
 
@@ -718,7 +836,13 @@ async def query_table_with_filters(table_name: str, params: TableFilterParams) -
         base_url += f"&sysparm_query={encoded_query}"
 
     max_results = params.max_results
-    all_results = await _make_paginated_request(base_url, max_results=max_results)
+    partial_read: Optional[PartialPageReadError] = None
+    try:
+        all_results = await _make_paginated_request(base_url, max_results=max_results)
+    except PartialPageReadError as partial:
+        all_results, partial_read = partial.rows, partial
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
     returned_count = len(all_results)
     truncated = returned_count >= max_results
 
@@ -728,12 +852,13 @@ async def query_table_with_filters(table_name: str, params: TableFilterParams) -
         if result_validation.has_issues():
             print(f"[generic_table_tools] Result validation warnings: {result_validation.warnings}", file=sys.stderr)
 
-        return {
+        response = {
             "result": all_results,
             "returned_count": returned_count,
             "truncated": truncated,
             "max_results": max_results,
         }
+        return _partial_envelope(response, partial_read) if partial_read else response
 
     empty_response = {
         "result": [],
@@ -890,17 +1015,29 @@ async def query_table_intelligently(
 
         query_result = await query_table_with_filters(table_name, params)
 
+        # A failed query is not a reason to fall back to a keyword search: the
+        # transport just failed, so the second request would fail the same way
+        # and the client would be told "no filters matched" instead of why.
+        if is_read_failure(query_result):
+            return query_result
+
         # Return successful response if we got results
         if isinstance(query_result, dict) and query_result.get('result'):
             debug_extras = (
                 _build_debug_extras(intelligence_result, natural_language_query, table_name, context)
                 if debug else None
             )
-            return _build_intelligence_response(query_result, intelligence_result, debug_extras)
+            response = _build_intelligence_response(query_result, intelligence_result, debug_extras)
+            return carry_partial(response, query_result)
 
     # Fallback to keyword-based search
     fallback_result = await query_table_by_text(table_name, natural_language_query)
-    return _build_fallback_response(fallback_result, natural_language_query, table_name, context, debug=debug)
+    if is_read_failure(fallback_result):
+        return fallback_result
+    response = _build_fallback_response(
+        fallback_result, natural_language_query, table_name, context, debug=debug
+    )
+    return carry_partial(response, fallback_result)
 
 
 def explain_filter_query(
@@ -1054,6 +1191,12 @@ async def get_records_by_priority(
     try:
         all_results = await _make_paginated_request(base_url, max_results=max_results)
         return _format_priority_results(all_results, max_results)
+    except PartialPageReadError as partial:
+        return _partial_envelope(_format_priority_results(partial.rows, max_results), partial)
+    except ServiceNowRequestError as error:
+        # Must precede the bare `except Exception` below, or the typed failure
+        # is flattened into the REQUEST_FAILED_ERROR string and the code is lost.
+        return error.to_error_dict()
     except Exception as e:
         return {"error": REQUEST_FAILED_ERROR.format(error=str(e))}
 
@@ -1079,14 +1222,21 @@ async def query_table_with_generic_filters(
     try:
         # Use pagination to prevent excessive results
         all_results = await _make_paginated_request(base_url, max_results=75)  # Limit generic filters to 75 results
-        
-        if all_results:
-            result_count = len(all_results)
-            return {
-                "result": all_results,
-                "message": f"Found {result_count} records" + (" (limited to 75)" if result_count == 75 else "")
-            }
-        else:
-            return {"result": [], "message": NO_RECORDS_FOUND}
+        return _generic_filter_envelope(all_results)
+    except PartialPageReadError as partial:
+        return _partial_envelope(_generic_filter_envelope(partial.rows), partial)
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
     except Exception as e:
         return {"error": REQUEST_FAILED_ERROR.format(error=str(e))}
+
+
+def _generic_filter_envelope(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Response shape for query_table_with_generic_filters. Empty stays not-found."""
+    if not rows:
+        return {"result": [], "message": NO_RECORDS_FOUND}
+    result_count = len(rows)
+    return {
+        "result": rows,
+        "message": f"Found {result_count} records" + (" (limited to 75)" if result_count == 75 else ""),
+    }

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -21,7 +21,7 @@ from constants import (
     ENABLE_COMPLETE_QUERY,
     TABLE_CONFIGS
 )
-from .read_helpers import carry_partial, is_read_failure
+from .read_helpers import carry_partial, carry_partial_after_filter, is_read_failure
 from filter import (
     QueryExplainer,
     QueryIntelligence,
@@ -221,7 +221,13 @@ def _first_short_description(desc_data: dict[str, Any]) -> str:
 
 
 def _exclude_original_record(similar_data: dict[str, Any], record_number: str) -> dict[str, Any]:
-    """Drop the source record from a text-search result, preserving partial state."""
+    """Drop the source record from a text-search result, preserving partial state.
+
+    Filtering can empty a partial set, in which case NO_SIMILAR_RECORDS_FOUND
+    would be a confident answer drawn from an unfinished read — the pages that
+    failed could hold similar records. `carry_partial_after_filter` returns the
+    failure instead.
+    """
     rows = similar_data.get('result') or []
     if not rows:
         return similar_data  # nothing to filter — pass the inner response through
@@ -233,7 +239,7 @@ def _exclude_original_record(similar_data: dict[str, Any], record_number: str) -
         }
     else:
         response = {"result": [], "message": NO_SIMILAR_RECORDS_FOUND}
-    return carry_partial(response, similar_data)
+    return carry_partial_after_filter(response, similar_data)
 
 
 async def find_similar_records(table_name: str, record_number: str) -> dict[str, Any]:
@@ -773,8 +779,10 @@ async def _make_paginated_request(
         try:
             data = await make_nws_request(paginated_url)
         except ServiceNowRequestError as error:
+            # No slicing needed: the loop condition guarantees
+            # len(all_results) < max_results at the top of every iteration.
             if all_results:
-                raise PartialPageReadError(all_results[:max_results], error) from error
+                raise PartialPageReadError(all_results, error) from error
             raise
 
         # A 200 with no rows ends the walk normally — empty is success.

--- a/Table_Tools/intelligent_query_tools.py
+++ b/Table_Tools/intelligent_query_tools.py
@@ -10,7 +10,9 @@ from Table_Tools.generic_table_tools import (
     explain_filter_query,
     build_and_validate_smart_filter
 )
+from Table_Tools.read_helpers import carry_partial, is_read_failure
 from filter import get_filter_templates
+from http_layer import ServiceNowRequestError
 from constants import SERVICENOW_QUERY_OPERATORS, QUERY_SYNTAX_NOTES
 from param_coercion import coerce_json_dict
 
@@ -41,25 +43,39 @@ async def intelligent_search(params: IntelligentQueryParams) -> Dict[str, Any]:
     Converts NL (e.g. "high priority incidents from last week", "unassigned
     P1 changes today") to ServiceNow filter syntax, validates it, and returns
     results with an explanation of what was searched.
+
+    A read failure returns success=False with the structured
+    {"code", "message"} error object from the query layer rather than
+    success=True and an empty record list. A partial read returns the rows it
+    got, success=True, and partial=True alongside the error.
     """
+    query_info = {
+        "original_query": params.query,
+        "table_searched": params.table,
+        "context_used": params.context is not None,
+    }
     try:
         result = await query_table_intelligently(
             table_name=params.table,
             natural_language_query=params.query,
             context=params.context
         )
-        
-        return {
+
+        if is_read_failure(result):
+            return {"success": False, "error": result["error"], "query_info": query_info}
+
+        response = {
             "success": True,
             "records": result.get("result", []),
             "record_count": len(result.get("result", [])),
             "intelligence": result.get("intelligence", {}),
-            "query_info": {
-                "original_query": params.query,
-                "table_searched": params.table,
-                "context_used": params.context is not None
-            }
+            "query_info": query_info,
         }
+        return carry_partial(response, result)
+    except ServiceNowRequestError as e:
+        # Must precede `except Exception`: str(e) would drop the error code and
+        # a caller could no longer tell a timeout from a validation failure.
+        return {"success": False, **e.to_error_dict(), "query_info": query_info}
     except Exception as e:
         return {
             "success": False,

--- a/Table_Tools/read_helpers.py
+++ b/Table_Tools/read_helpers.py
@@ -1,0 +1,44 @@
+"""Shared read-response helpers for the typed-read consumers (v4.4 Tier 0.3).
+
+`http_layer` raises `ServiceNowRequestError` on a failed GET, and each consumer
+maps it to `error.to_error_dict()`. Two shapes then travel back up through the
+modules that re-wrap each other's responses:
+
+    failure   {"error": {"code": ..., "message": ...}}
+              No rows. The read did not happen — this is NOT "no records match".
+
+    partial   {"result": [...], "partial": true, "error": {...}}
+              Rows plus the reason the set is incomplete (a page after the first
+              failed). The rows are real and must not be thrown away.
+
+Every module that re-wraps another module's response has to keep both shapes
+intact. Re-wrapping a failure as an empty result — "Found 0 records", "No
+matching KB articles." — is exactly the mislabelling this tier removes, and it
+is easy to reintroduce because the mistake reads as ordinary code.
+"""
+from typing import Any, Dict
+
+
+def is_read_failure(response: Any) -> bool:
+    """True when *response* is a read failure carrying no usable rows.
+
+    A partial read (rows AND error) is deliberately not a failure: its rows are
+    usable and the caller should keep them, marked incomplete.
+    """
+    return (
+        isinstance(response, dict)
+        and bool(response.get("error"))
+        and not response.get("result")
+    )
+
+
+def carry_partial(response: Dict[str, Any], source: Any) -> Dict[str, Any]:
+    """Propagate *source*'s partial-read marker onto *response*.
+
+    Used wherever one response is re-wrapped into another, so an incomplete set
+    is never presented as a complete one. No-op when *source* carries no error.
+    """
+    if isinstance(source, dict) and source.get("error"):
+        response["partial"] = True
+        response["error"] = source["error"]
+    return response

--- a/Table_Tools/read_helpers.py
+++ b/Table_Tools/read_helpers.py
@@ -35,10 +35,28 @@ def is_read_failure(response: Any) -> bool:
 def carry_partial(response: Dict[str, Any], source: Any) -> Dict[str, Any]:
     """Propagate *source*'s partial-read marker onto *response*.
 
-    Used wherever one response is re-wrapped into another, so an incomplete set
-    is never presented as a complete one. No-op when *source* carries no error.
+    Used wherever one response is re-shaped into another without dropping rows,
+    so an incomplete set is never presented as a complete one. No-op when
+    *source* carries no error.
+
+    If the re-wrap FILTERS rows out, use `carry_partial_after_filter` instead —
+    an emptied-out partial must not keep its not-found message.
     """
     if isinstance(source, dict) and source.get("error"):
         response["partial"] = True
         response["error"] = source["error"]
     return response
+
+
+def carry_partial_after_filter(response: Dict[str, Any], source: Any) -> Dict[str, Any]:
+    """`carry_partial` for a response whose rows were filtered down.
+
+    When the filter removes every row of a partial read, marking the result
+    `partial` would ship a self-contradicting answer: a confident "no matching
+    records" message next to an error saying the read never finished. The rows
+    that would have matched may well be in the pages that failed, so the honest
+    answer is the failure, not an empty set.
+    """
+    if isinstance(source, dict) and source.get("error") and not response.get("result"):
+        return {"error": source["error"]}
+    return carry_partial(response, source)

--- a/http_layer/request_dispatcher.py
+++ b/http_layer/request_dispatcher.py
@@ -63,7 +63,9 @@ def _redact_url(url: str) -> str:
 # block, `_legacy_none_shim`, and `_calling_module` outright and lets the raise
 # propagate unconditionally.
 # ---------------------------------------------------------------------------
-_TYPED_CALLERS: frozenset[str] = frozenset()
+_TYPED_CALLERS: frozenset[str] = frozenset({
+    "Table_Tools.generic_table_tools",
+})
 
 # This package's own name, used for the frame-walk boundary test below.
 _PACKAGE = __name__.split(".")[0]

--- a/tests/test_generic_table_tools.py
+++ b/tests/test_generic_table_tools.py
@@ -577,14 +577,21 @@ class TestAsyncTableOperations:
 
     @pytest.mark.asyncio
     async def test_get_record_description_not_found(self):
-        """Test getting record description when not found."""
+        """A successful read with no rows is not-found.
+
+        v4.4 Tier 0.3 inverted this test: it used to mock `None` — the value the
+        read path returned for BOTH "no such record" and "the request failed" —
+        and assert the not-found message. A failed read now raises, so the
+        not-found label is reached only by an actual empty result set.
+        """
         with patch("Table_Tools.generic_table_tools.make_nws_request") as mock_request:
-            mock_request.return_value = None
+            mock_request.return_value = {"result": []}
 
             result = await get_record_description("incident", "INC999")
 
             assert result["result"] == []
             assert "message" in result
+            assert "error" not in result
 
     @pytest.mark.asyncio
     async def test_get_record_details_success(self):

--- a/tests/test_http_layer_errors.py
+++ b/tests/test_http_layer_errors.py
@@ -153,8 +153,26 @@ class TestClassifyOAuthFailures:
 class TestLegacyNoneShim:
     """PR 1 must not change behavior on main. PRs 2-7 flip modules one at a time."""
 
-    def test_typed_callers_is_empty_in_pr1(self):
-        assert dispatcher._TYPED_CALLERS == frozenset()
+    def test_typed_callers_matches_the_migration_state(self):
+        """Updated deliberately, once per PR — the assertion IS the migration record.
+
+        PR E deletes this class along with the shim.
+        """
+        assert dispatcher._TYPED_CALLERS == frozenset({
+            "Table_Tools.generic_table_tools",
+        })
+
+    def test_typed_caller_names_are_real_module_names(self):
+        """A typo'd dotted name silently leaves a module unmigrated, suite still green.
+
+        `_calling_module()` compares against `frame.f_globals["__name__"]`, so
+        "Table_Tools.generic_tables_tools" would never match anything and the
+        module would keep receiving None with nothing failing to say so.
+        """
+        import importlib
+
+        for name in dispatcher._TYPED_CALLERS:
+            assert importlib.import_module(name).__name__ == name
 
     @pytest.mark.asyncio
     async def test_unmigrated_caller_still_gets_none(self, monkeypatch):

--- a/tests/test_typed_read_generic_table_tools.py
+++ b/tests/test_typed_read_generic_table_tools.py
@@ -358,6 +358,59 @@ class TestConsumersThatReWrap:
         _assert_plain_failure(result, ErrorCode.TIMEOUT)
 
     @pytest.mark.asyncio
+    async def test_kb_by_state_reports_failure_when_the_filter_empties_a_partial(self):
+        """A partial set filtered down to nothing must not answer "no matches".
+
+        Two pages requested, page 1 returns 250 draft articles, page 2 times out.
+        Asking for `published` filters all 250 away — but the articles that would
+        have matched could be in the page that never arrived, so "No matching KB
+        articles." would be a confident answer built from an unfinished read.
+        """
+        from Table_Tools.consolidated_tools import get_kb_articles_by_state
+
+        page_one = {"result": [
+            {"number": f"KB{i:07d}", "sys_id": f"{i:032x}", "workflow_state": "draft"}
+            for i in range(250)
+        ]}
+        with patch(
+            "Table_Tools.generic_table_tools.make_nws_request",
+            side_effect=[page_one, TIMEOUT],
+        ):
+            result = await get_kb_articles_by_state(workflow_state="published", max_results=500)
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+        assert "message" not in result
+
+    @pytest.mark.asyncio
+    async def test_kb_by_state_genuine_empty_still_says_no_matching_articles(self):
+        """The complete-read case is untouched: empty stays not-found."""
+        from Table_Tools.consolidated_tools import get_kb_articles_by_state
+
+        with patch("Table_Tools.generic_table_tools.make_nws_request") as mock_request:
+            mock_request.return_value = {"result": []}
+            result = await get_kb_articles_by_state(workflow_state="published")
+        assert result["result"] == []
+        assert result["message"] == "No matching KB articles."
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_find_similar_reports_failure_when_the_only_match_was_the_original(self):
+        """Same invariant on the similar-records filter."""
+        similar = {
+            "result": [{"number": "INC0012345"}],
+            "partial": True,
+            **TIMEOUT.to_error_dict(),
+        }
+        with patch(
+            "Table_Tools.generic_table_tools.get_record_description",
+            new=AsyncMock(return_value={"result": [{"short_description": "db down"}]}),
+        ), patch(
+            "Table_Tools.generic_table_tools.query_table_by_text",
+            new=AsyncMock(return_value=similar),
+        ):
+            result = await find_similar_records("incident", "INC0012345")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
     async def test_intelligent_search_keeps_the_error_code(self):
         from Table_Tools.intelligent_query_tools import (
             IntelligentQueryParams,

--- a/tests/test_typed_read_generic_table_tools.py
+++ b/tests/test_typed_read_generic_table_tools.py
@@ -1,0 +1,458 @@
+"""Typed read failures through the generic read path (v4.4 Tier 0.3, PR A).
+
+`Table_Tools.generic_table_tools` is the first module in
+`http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET arrives as a
+raised `ServiceNowRequestError` instead of `None`. What is locked here:
+
+* a failure returns `{"error": {"code", "message"}}` and nothing else — never a
+  not-found message, never a bare error string;
+* an empty result set still returns the not-found message (empty is success);
+* a page failing mid-pagination keeps the rows already collected and marks the
+  response `partial`, while a first-page failure is a plain error;
+* the modules that re-wrap these responses (`consolidated_tools`,
+  `intelligent_query_tools`) do not relabel a failure as "0 records found".
+
+The end-to-end test at the bottom goes through the real dispatcher, which is
+the only test that would catch a typo in the `_TYPED_CALLERS` module name.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from http_layer.errors import ErrorCode, ServiceNowRequestError
+from Table_Tools.generic_table_tools import (
+    PartialPageReadError,
+    _make_paginated_request,
+    find_similar_records,
+    get_record_description,
+    get_record_details,
+    get_records_by_priority,
+    query_table_by_text,
+    query_table_intelligently,
+    query_table_with_filters,
+    query_table_with_generic_filters,
+    TableFilterParams,
+)
+
+TIMEOUT = ServiceNowRequestError(
+    ErrorCode.TIMEOUT, "ServiceNow request timed out", retryable=True
+)
+FORBIDDEN = ServiceNowRequestError(
+    ErrorCode.FORBIDDEN, "ServiceNow returned HTTP 403", status_code=403
+)
+
+
+def _rows(count, prefix="INC"):
+    return [{"number": f"{prefix}{i:07d}", "short_description": "db down"} for i in range(count)]
+
+
+def _assert_plain_failure(response, code):
+    """The §3.1 failure shape: exactly {"error": {"code", "message"}}."""
+    assert set(response) == {"error"}, response
+    assert set(response["error"]) == {"code", "message"}
+    assert response["error"]["code"] == code
+    assert "result" not in response
+
+
+class TestSingleRecordReads:
+    """The two inverted labels: a transport failure reported as a missing record."""
+
+    @pytest.mark.asyncio
+    async def test_description_timeout_is_not_record_not_found(self):
+        with patch("Table_Tools.generic_table_tools.make_nws_request", side_effect=TIMEOUT):
+            result = await get_record_description("incident", "INC0012345")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_details_timeout_is_not_record_not_found(self):
+        with patch("Table_Tools.generic_table_tools.make_nws_request", side_effect=TIMEOUT):
+            result = await get_record_details("incident", "INC0012345")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_forbidden_keeps_its_own_code(self):
+        """Codes are not collapsed: a 403 must not read as a timeout or a 404."""
+        with patch("Table_Tools.generic_table_tools.make_nws_request", side_effect=FORBIDDEN):
+            result = await get_record_details("incident", "INC0012345")
+        _assert_plain_failure(result, ErrorCode.FORBIDDEN)
+
+    @pytest.mark.asyncio
+    async def test_empty_result_still_says_not_found(self):
+        with patch("Table_Tools.generic_table_tools.make_nws_request") as mock_request:
+            mock_request.return_value = {"result": []}
+            result = await get_record_details("incident", "INC0099999")
+        assert result["result"] == []
+        assert "message" in result
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_rows_pass_through_untouched(self):
+        payload = {"result": [{"number": "INC0012345", "short_description": "db down"}]}
+        with patch("Table_Tools.generic_table_tools.make_nws_request") as mock_request:
+            mock_request.return_value = payload
+            result = await get_record_details("incident", "INC0012345")
+        assert result == payload
+
+
+class TestPaginationPartialReads:
+    """Collected rows survive a later page failing."""
+
+    @pytest.mark.asyncio
+    async def test_first_page_failure_propagates_plain(self):
+        with patch("Table_Tools.generic_table_tools.make_nws_request", side_effect=TIMEOUT):
+            with pytest.raises(ServiceNowRequestError) as excinfo:
+                await _make_paginated_request("https://x/api/now/table/incident?a=b", max_results=500)
+        assert excinfo.value.code == ErrorCode.TIMEOUT
+        assert not isinstance(excinfo.value, PartialPageReadError)
+
+    @pytest.mark.asyncio
+    async def test_second_page_failure_keeps_first_page_rows(self):
+        page_one = {"result": _rows(250)}
+        with patch(
+            "Table_Tools.generic_table_tools.make_nws_request",
+            side_effect=[page_one, TIMEOUT],
+        ):
+            with pytest.raises(PartialPageReadError) as excinfo:
+                await _make_paginated_request("https://x/api/now/table/incident?a=b", max_results=500)
+        assert len(excinfo.value.rows) == 250
+        assert excinfo.value.error.code == ErrorCode.TIMEOUT
+
+    def test_partial_error_is_not_a_request_error_subclass(self):
+        """Otherwise every `except ServiceNowRequestError` arm would eat the rows."""
+        assert not issubclass(PartialPageReadError, ServiceNowRequestError)
+
+    @pytest.mark.asyncio
+    async def test_every_page_collected_before_the_failure_is_kept(self):
+        """Two good pages then a failure keeps 500 rows, not just the last page."""
+        page = {"result": _rows(250)}
+        with patch(
+            "Table_Tools.generic_table_tools.make_nws_request",
+            side_effect=[page, page, TIMEOUT],
+        ):
+            with pytest.raises(PartialPageReadError) as excinfo:
+                await _make_paginated_request("https://x/api/now/table/incident?a=b", max_results=600)
+        assert len(excinfo.value.rows) == 500
+
+
+class TestFilteredQueryEnvelopes:
+    @pytest.mark.asyncio
+    async def test_failure_returns_error_not_no_records_found(self):
+        with patch(
+            "Table_Tools.generic_table_tools._make_paginated_request", side_effect=TIMEOUT
+        ):
+            result = await query_table_with_filters("incident", TableFilterParams(filters={"priority": "1"}))
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_partial_keeps_rows_and_flags_incompleteness(self):
+        partial = PartialPageReadError(_rows(250), TIMEOUT)
+        with patch(
+            "Table_Tools.generic_table_tools._make_paginated_request", side_effect=partial
+        ):
+            result = await query_table_with_filters(
+                "incident", TableFilterParams(filters={"priority": "1"}, max_results=500)
+            )
+        assert len(result["result"]) == 250
+        assert result["returned_count"] == 250
+        assert result["partial"] is True
+        assert result["error"]["code"] == ErrorCode.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_successful_query_has_no_partial_key(self):
+        with patch("Table_Tools.generic_table_tools._make_paginated_request") as mock_request:
+            mock_request.return_value = _rows(3)
+            result = await query_table_with_filters("incident", TableFilterParams(filters={"priority": "1"}))
+        assert "partial" not in result
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_text_search_failure_returns_error(self):
+        with patch(
+            "Table_Tools.generic_table_tools._make_paginated_request", side_effect=TIMEOUT
+        ):
+            result = await query_table_by_text("incident", "database down")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_text_search_partial_keeps_rows(self):
+        partial = PartialPageReadError(_rows(20), TIMEOUT)
+        with patch(
+            "Table_Tools.generic_table_tools._make_paginated_request", side_effect=partial
+        ):
+            result = await query_table_by_text("incident", "database down")
+        assert len(result["result"]) == 20
+        assert result["partial"] is True
+        assert result["error"]["code"] == ErrorCode.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_generic_filters_failure_is_not_the_request_failed_string(self):
+        """The bare `except Exception` must not flatten the code into a message."""
+        with patch(
+            "Table_Tools.generic_table_tools._make_paginated_request", side_effect=FORBIDDEN
+        ):
+            result = await query_table_with_generic_filters("incident", {"priority": "1"})
+        _assert_plain_failure(result, ErrorCode.FORBIDDEN)
+
+    @pytest.mark.asyncio
+    async def test_priority_query_failure_is_not_the_request_failed_string(self):
+        with patch(
+            "Table_Tools.generic_table_tools._make_paginated_request", side_effect=TIMEOUT
+        ):
+            result = await get_records_by_priority("incident", ["1", "2"])
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_priority_query_partial_keeps_rows(self):
+        partial = PartialPageReadError(_rows(30), TIMEOUT)
+        with patch(
+            "Table_Tools.generic_table_tools._make_paginated_request", side_effect=partial
+        ):
+            result = await get_records_by_priority("incident", ["1", "2"])
+        assert len(result["result"]) == 30
+        assert result["partial"] is True
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_still_maps_to_request_failed(self):
+        """Narrowing the except must not remove the catch-all for real bugs."""
+        with patch(
+            "Table_Tools.generic_table_tools._make_paginated_request",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = await get_records_by_priority("incident", ["1", "2"])
+        assert "error" in result
+        assert isinstance(result["error"], str)
+
+
+class TestFindSimilarRecords:
+    """`except Exception: return CONNECTION_ERROR` must not become a 4th dialect."""
+
+    @pytest.mark.asyncio
+    async def test_description_failure_is_not_no_description_found(self):
+        with patch("Table_Tools.generic_table_tools.make_nws_request", side_effect=TIMEOUT):
+            result = await find_similar_records("incident", "INC0012345")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_search_failure_is_not_connection_error_string(self):
+        with patch(
+            "Table_Tools.generic_table_tools.get_record_description",
+            new=AsyncMock(return_value={"result": [{"short_description": "db down"}]}),
+        ), patch(
+            "Table_Tools.generic_table_tools.query_table_by_text",
+            new=AsyncMock(return_value=FORBIDDEN.to_error_dict()),
+        ):
+            result = await find_similar_records("incident", "INC0012345")
+        _assert_plain_failure(result, ErrorCode.FORBIDDEN)
+
+    @pytest.mark.asyncio
+    async def test_partial_search_survives_the_original_record_filter(self):
+        similar = {
+            "result": [{"number": "INC0012345"}, {"number": "INC0099999"}],
+            "partial": True,
+            **TIMEOUT.to_error_dict(),
+        }
+        with patch(
+            "Table_Tools.generic_table_tools.get_record_description",
+            new=AsyncMock(return_value={"result": [{"short_description": "db down"}]}),
+        ), patch(
+            "Table_Tools.generic_table_tools.query_table_by_text",
+            new=AsyncMock(return_value=similar),
+        ):
+            result = await find_similar_records("incident", "INC0012345")
+        assert [r["number"] for r in result["result"]] == ["INC0099999"]
+        assert result["partial"] is True
+        assert result["error"]["code"] == ErrorCode.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_genuinely_empty_description_still_says_no_description(self):
+        with patch("Table_Tools.generic_table_tools.make_nws_request") as mock_request:
+            mock_request.return_value = {"result": []}
+            result = await find_similar_records("incident", "INC0099999")
+        assert result["result"] == []
+        assert "error" not in result
+
+
+class TestIntelligentQueryPath:
+    @pytest.mark.asyncio
+    async def test_failed_filter_query_does_not_fall_back_to_keyword_search(self):
+        """A second doomed request would report "no filters matched" for a timeout."""
+        fallback = AsyncMock(return_value={"result": [], "message": "none"})
+        with patch(
+            "Table_Tools.generic_table_tools.query_table_with_filters",
+            new=AsyncMock(return_value=TIMEOUT.to_error_dict()),
+        ), patch("Table_Tools.generic_table_tools.query_table_by_text", new=fallback):
+            result = await query_table_intelligently("incident", "critical incidents from last week")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+        fallback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_fallback_search_returns_the_error(self):
+        with patch(
+            "Table_Tools.generic_table_tools.query_table_with_filters",
+            new=AsyncMock(return_value={"result": [], "message": "none"}),
+        ), patch(
+            "Table_Tools.generic_table_tools.query_table_by_text",
+            new=AsyncMock(return_value=TIMEOUT.to_error_dict()),
+        ):
+            result = await query_table_intelligently("incident", "critical incidents from last week")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_partial_filter_query_marks_the_intelligence_response(self):
+        partial_payload = {
+            "result": _rows(5),
+            "returned_count": 5,
+            "truncated": False,
+            "max_results": 100,
+            "partial": True,
+            **TIMEOUT.to_error_dict(),
+        }
+        with patch(
+            "Table_Tools.generic_table_tools.query_table_with_filters",
+            new=AsyncMock(return_value=partial_payload),
+        ):
+            result = await query_table_intelligently("incident", "critical incidents from last week")
+        assert len(result["result"]) == 5
+        assert result["partial"] is True
+        assert result["error"]["code"] == ErrorCode.TIMEOUT
+        assert "intelligence" in result
+
+
+class TestConsumersThatReWrap:
+    """A re-wrapper must not relabel a failure as an empty result set."""
+
+    @pytest.mark.asyncio
+    async def test_priority_incidents_with_metadata_does_not_report_zero_found(self):
+        from Table_Tools.consolidated_tools import get_priority_incidents
+
+        with patch(
+            "Table_Tools.consolidated_tools.get_records_by_priority",
+            new=AsyncMock(return_value=TIMEOUT.to_error_dict()),
+        ):
+            result = await get_priority_incidents(["1"], include_metadata=True)
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+        assert "metadata" not in result
+
+    @pytest.mark.asyncio
+    async def test_priority_incidents_partial_is_flagged_in_metadata_response(self):
+        from Table_Tools.consolidated_tools import get_priority_incidents
+
+        payload = {"result": _rows(4), "partial": True, **TIMEOUT.to_error_dict()}
+        with patch(
+            "Table_Tools.consolidated_tools.get_records_by_priority",
+            new=AsyncMock(return_value=payload),
+        ):
+            result = await get_priority_incidents(["1"], include_metadata=True)
+        assert result["metadata"]["count"] == 4
+        assert result["partial"] is True
+        assert result["error"]["code"] == ErrorCode.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_kb_by_state_does_not_report_no_matching_articles(self):
+        from Table_Tools.consolidated_tools import get_kb_articles_by_state
+
+        with patch(
+            "Table_Tools.consolidated_tools.query_table_with_filters",
+            new=AsyncMock(return_value=TIMEOUT.to_error_dict()),
+        ):
+            result = await get_kb_articles_by_state()
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_intelligent_search_keeps_the_error_code(self):
+        from Table_Tools.intelligent_query_tools import (
+            IntelligentQueryParams,
+            intelligent_search,
+        )
+
+        with patch(
+            "Table_Tools.intelligent_query_tools.query_table_intelligently",
+            new=AsyncMock(return_value=TIMEOUT.to_error_dict()),
+        ):
+            result = await intelligent_search(
+                IntelligentQueryParams(query="critical incidents", table="incident")
+            )
+        assert result["success"] is False
+        assert result["error"]["code"] == ErrorCode.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_intelligent_search_partial_is_success_with_a_marker(self):
+        from Table_Tools.intelligent_query_tools import (
+            IntelligentQueryParams,
+            intelligent_search,
+        )
+
+        payload = {"result": _rows(2), "intelligence": {}, "partial": True, **TIMEOUT.to_error_dict()}
+        with patch(
+            "Table_Tools.intelligent_query_tools.query_table_intelligently",
+            new=AsyncMock(return_value=payload),
+        ):
+            result = await intelligent_search(
+                IntelligentQueryParams(query="critical incidents", table="incident")
+            )
+        assert result["success"] is True
+        assert result["record_count"] == 2
+        assert result["partial"] is True
+        assert result["error"]["code"] == ErrorCode.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_intelligent_search_still_stringifies_unexpected_errors(self):
+        from Table_Tools.intelligent_query_tools import (
+            IntelligentQueryParams,
+            intelligent_search,
+        )
+
+        with patch(
+            "Table_Tools.intelligent_query_tools.query_table_intelligently",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            result = await intelligent_search(
+                IntelligentQueryParams(query="critical incidents", table="incident")
+            )
+        assert result["success"] is False
+        assert result["error"] == "boom"
+
+
+class TestEndToEndThroughTheRealDispatcher:
+    """The only test that would catch a typo in the _TYPED_CALLERS module name.
+
+    Everything above patches `make_nws_request` inside the consumer module, so
+    it would pass even if `_TYPED_CALLERS` never matched this module and the
+    shim kept returning None. These go through the real dispatcher.
+    """
+
+    @pytest.mark.asyncio
+    async def test_timeout_reaches_search_records_as_a_timeout(self, monkeypatch):
+        import http_layer.request_dispatcher as dispatcher
+        from Table_Tools.generic_tool_wrappers import search_records
+
+        async def slow(url):
+            raise TimeoutError()
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", slow)
+        result = await search_records("incident", "database down")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_timeout_reaches_get_record_as_a_timeout(self, monkeypatch):
+        import http_layer.request_dispatcher as dispatcher
+        from Table_Tools.generic_tool_wrappers import get_record
+
+        async def slow(url):
+            raise TimeoutError()
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", slow)
+        result = await get_record("incident", "INC0012345")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_empty_result_through_the_real_dispatcher_is_not_found(self, monkeypatch):
+        import http_layer.request_dispatcher as dispatcher
+        from Table_Tools.generic_tool_wrappers import get_record
+
+        async def empty(url):
+            return {"result": []}
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", empty)
+        result = await get_record("incident", "INC0099999")
+        assert result["result"] == []
+        assert "error" not in result


### PR DESCRIPTION
PR 2 of the v4.4 Tier 0.3 typed-read chain (PR 1 was #59). One consumer module:
`Table_Tools.generic_table_tools` joins `_TYPED_CALLERS`, so a failed GET reaches
it as a raised `ServiceNowRequestError` instead of the `None` that meant both
"the request failed" and "the table has no matching rows".

## Client-visible behavior changes

| Call | Before, on a failure | After |
|---|---|---|
| `get_record` / `get_record_summary` | `RECORD_NOT_FOUND` | `{"error": {"code", "message"}}` |
| `search_records` | `NO_RECORDS_FOUND` | same failure shape |
| `filter_records` | `NO_RECORDS_FOUND` | same |
| `get_priority_incidents` | `REQUEST_FAILED_ERROR` string, or `Found 0 priority 1 incident(s)` with `include_metadata=True` | same |
| `find_similar` | `CONNECTION_ERROR` / `NO_DESCRIPTION_FOUND` | same |
| `get_kb_articles_by_state` | `No matching KB articles.` | same |
| `intelligent_search` | `success: true`, `records: []` | `success: false` + the structured error |

An **empty result set is unchanged** — a 200 with `{"result": []}` still returns
`RECORD_NOT_FOUND` / `NO_RECORDS_FOUND`. Empty is success. The only thing that
stops sharing that outcome is failure.

## Partial reads

`_make_paginated_request` no longer discards the rows it already collected when a
later page fails. It raises `PartialPageReadError` carrying them, and the caller
returns the rows plus `partial: true` and the error — the one sanctioned shape
where data and `error` coexist (plan §3.1). A **first-page** failure has no rows
to keep, so it is a plain error with no `partial` key.

`query_table_intelligently` also stops falling back to a keyword search after a
failed filter query: the second request fails the same way, and the client would
be told "no filters matched" for what was a timeout.

## The five consistency decisions (0.3-HANDOFF §2), settled here for B–E

1. **A raise returns `error.to_error_dict()` and nothing else.** `retryable` is
   for our own retry logic, not the client. The code is never turned into prose.
2. **Empty stays not-found**, as above.
3. **`except ServiceNowRequestError` always precedes a bare `except Exception`.**
   Added in `find_similar_records`, `get_records_by_priority`,
   `query_table_with_generic_filters`, `intelligent_search`. Without it the code
   is flattened into a message string and the caller cannot tell a timeout from a
   validation error. The catch-all is kept for real bugs, with a test.
4. **`PartialPageReadError` is deliberately not a `ServiceNowRequestError`
   subclass.** If it were, every typed arm would absorb it and silently throw
   away the rows — the behavior being fixed. As a separate type, a call site that
   forgets it degrades to a plain error rather than a wrong-looking empty result.
5. **Re-wrappers must keep both shapes intact.** New `Table_Tools/read_helpers.py`
   holds that vocabulary (`is_read_failure`, `carry_partial`) so B–E don't each
   open-code the check and drift into a fourth dialect.

Decisions (c) and (d) from the handoff don't apply to this module: it returns no
bare strings and does no pre-write `sys_id` reads. They land in PRs B and C/D.

## Two re-wrappers were mislabelling failures

Neither `consolidated_tools` nor `intelligent_query_tools` calls
`make_nws_request` — they inherit this PR's behavior. But both re-wrap the
responses, and both turned a failure into a business answer:
`get_priority_incidents(include_metadata=True)` reported
`Found 0 priority 1 incident(s)` for a timeout, and `get_kb_articles_by_state`
de-duplicated a failure into `No matching KB articles.` The mislabel lived in the
wrapper, not in a read.

## Tests

857 passed, 5 skipped (was 822).

`tests/test_typed_read_generic_table_tools.py` covers failure / partial / empty
per function plus the re-wrappers. Two tests exist specifically because the rest
would not catch a broken `_TYPED_CALLERS` entry:

- `TestEndToEndThroughTheRealDispatcher` drives `search_records` / `get_record`
  through the real dispatcher. Every other test patches `make_nws_request`
  *inside* the consumer, so all of them would pass even if the module name in
  `_TYPED_CALLERS` were misspelled and the shim kept returning `None`.
- `test_typed_caller_names_are_real_module_names` imports every name in the
  frozenset and checks `__name__` matches, closing the same gap from the other
  side.

`test_get_record_description_not_found` is inverted: it mocked `None` and
asserted the not-found message, which is precisely the conflation this removes.

Tier 0's exit criterion — *timeout is never reportable as not-found* — is still
false until PR E deletes the shim; three consumer modules still receive `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
