### PR TITLE
fix(cmdb): stop reporting a failed CMDB read as an absent CI

### DIFF
--- a/Table_Tools/cmdb_tools.py
+++ b/Table_Tools/cmdb_tools.py
@@ -373,6 +373,12 @@ async def similar_cis_for_ci(ci_number: str) -> dict[str, Any] | str:
         return NO_SIMILAR_CIS_FOUND.format(ci_number=ci_number)
 
     except ServiceNowRequestError as error:
+        # Unreachable on today's call graph, and kept deliberately: both callees
+        # above convert a classified failure to a dict rather than raising, so
+        # this arm has nothing to catch. It exists so that a later change making
+        # either of them propagate cannot silently fall through to the
+        # ERROR_FINDING_SIMILAR_CIS string below and drop the code. Decision (e)
+        # of the Tier 0.3 contract asks for the arm in every function touched.
         return error.to_error_dict()
     except Exception:
         return ERROR_FINDING_SIMILAR_CIS

--- a/Table_Tools/cmdb_tools.py
+++ b/Table_Tools/cmdb_tools.py
@@ -8,9 +8,10 @@ Provides CI discovery, search, and analysis functionality.
 import asyncio
 import re
 from urllib.parse import quote
-from http_layer import make_nws_request, NWS_API_BASE
+from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
 from utils import extract_keywords
 from typing import Any, Dict, Optional, List
+from .read_helpers import is_read_failure
 from constants import (
     NO_CIS_FOUND_FOR_TYPE,
     NO_CIS_FOUND_MATCHING_CRITERIA,
@@ -46,6 +47,23 @@ DEFAULT_CI_PROBE_TABLES = [
 # before a single trailing newline, so match() would accept
 # "cmdb_ci_server\n". fullmatch() requires the whole string to be consumed.
 _CI_TYPE_PATTERN = re.compile(r'cmdb_ci[a-z0-9_]*')
+
+# ---------------------------------------------------------------------------
+# Read-failure contract (v4.4 Tier 0.3). This module is in
+# `http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET raises
+# `ServiceNowRequestError` instead of returning None. Rules, as settled in the
+# generic_table_tools migration:
+#
+#   * A raise returns `error.to_error_dict()` -> {"error": {code, message}}.
+#     Every other return here is a bare string; the union is deliberate and
+#     temporary (Tier 3.1 removes all 16 strings). Inventing an error *string*
+#     to keep the return type uniform would ship a lie to preserve tidiness.
+#   * An empty result set keeps its existing not-found string. Empty is success.
+#   * `except ServiceNowRequestError` precedes every bare `except Exception`,
+#     or the ERROR_* string swallows the code.
+#   * These reads are single-request (sysparm_limit, no pagination), so there is
+#     no `partial` shape in this module.
+# ---------------------------------------------------------------------------
 
 
 def _ci_type_error(ci_type: str) -> Optional[str]:
@@ -111,6 +129,10 @@ async def find_cis_by_type(ci_type: str, detailed: bool = False) -> dict[str, An
             }
         return NO_CIS_FOUND_FOR_TYPE.format(ci_type=ci_type)
 
+    except ServiceNowRequestError as error:
+        # Ahead of the bare except below: a failed read is not "this type has
+        # no CIs", and ERROR_SEARCHING_CIS_BY_TYPE would drop the code.
+        return error.to_error_dict()
     except Exception:
         return ERROR_SEARCHING_CIS_BY_TYPE
 
@@ -184,16 +206,23 @@ async def search_cis_by_attributes(
             }
         return NO_CIS_FOUND_MATCHING_CRITERIA
 
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
     except Exception:
         return ERROR_SEARCHING_CIS
 
 async def _probe_ci_table(table: str, ci_number: str) -> Optional[Dict[str, Any]]:
-    """Fetch a CI by number from one table; return the first row or None."""
+    """Fetch a CI by number from one table; return the first row, or None if absent.
+
+    None means "probed this table, the CI is not in it" and nothing else. The
+    previous `except Exception: return None` made a failed probe identical to an
+    absent CI: under the concurrent gather in `get_ci_details`, a timeout on
+    cmdb_ci_server made a server CI look like it lives in the base cmdb_ci table
+    — the wrong table, reported confidently. Failures propagate now and
+    `get_ci_details` decides what a missing probe means.
+    """
     url = f"{NWS_API_BASE}/api/now/table/{table}?sysparm_fields={','.join(DETAILED_CI_FIELDS)}&sysparm_query=number={ci_number}&sysparm_display_value=true"
-    try:
-        data = await make_nws_request(url)
-    except Exception:
-        return None
+    data = await make_nws_request(url)
     if data and data.get('result'):
         return data['result'][0]
     return None
@@ -214,7 +243,8 @@ async def get_ci_details(ci_number: str, ci_type: Optional[str] = None) -> dict[
 
     When ci_type is not given, the candidate tables are probed concurrently
     (bounded) instead of one-at-a-time; the most-specific-first priority is
-    preserved by returning the first table (in order) that yields a row.
+    preserved by returning the first table (in order) that yields a row. If a
+    probe fails before any table yields a row, the failure is returned.
     """
     if not ci_number:
         return CI_NUMBER_REQUIRED
@@ -233,13 +263,31 @@ async def get_ci_details(ci_number: str, ci_type: Optional[str] = None) -> dict[
         async with semaphore:
             return await _probe_ci_table(table, ci_number)
 
-    rows = await asyncio.gather(*(_bounded(table) for table in tables_to_search))
-    for table, row in zip(tables_to_search, rows):
-        if row:
+    # A failed probe ends the lookup rather than counting as absence: every CI
+    # also lives in the base cmdb_ci table, so treating a failure as "not in
+    # this table" let a timeout on cmdb_ci_server attribute a server to cmdb_ci
+    # — the wrong table, reported confidently. An incomplete probe set supports
+    # neither "not found anywhere" nor attribution to a less specific table. A
+    # failure *after* a hit is irrelevant: the higher-priority table already
+    # decided the answer, which is why this loop runs in priority order.
+    #
+    # return_exceptions keeps the results positional so a failure stays attached
+    # to the table it belongs to instead of aborting the whole gather.
+    outcomes = await asyncio.gather(
+        *(_bounded(table) for table in tables_to_search), return_exceptions=True
+    )
+    for table, outcome in zip(tables_to_search, outcomes):
+        if isinstance(outcome, ServiceNowRequestError):
+            return outcome.to_error_dict()
+        if isinstance(outcome, BaseException):
+            # Not a classified read failure — a real bug. Propagate as before
+            # rather than silently degrading it to a not-found string.
+            raise outcome
+        if outcome:
             return {
                 "ci_table": table,
                 "ci_number": ci_number,
-                "result": row,
+                "result": outcome,
             }
 
     return CI_NOT_FOUND.format(ci_number=ci_number)
@@ -290,21 +338,31 @@ async def similar_cis_for_ci(ci_number: str) -> dict[str, Any] | str:
 
     Complexity: 8 (reduced from ~15-17)
     """
-    # First get the CI details
-    ci_details = await get_ci_details(ci_number)
-
-    if isinstance(ci_details, str):
-        return ci_details
-
-    ci_data = ci_details['result']
-    ci_table = ci_details['ci_table']
-
-    # Extract key attributes for similarity search
-    search_attrs = _extract_ci_search_attributes(ci_data, ci_table)
-
-    # Search for similar CIs
     try:
+        # The lookup is inside this try, not before it: get_ci_details converts
+        # a classified read failure to a dict but re-raises anything else, and a
+        # bug in the lookup half should read the same as a bug in the search
+        # half rather than escaping to the client from one arm of one function.
+        ci_details = await get_ci_details(ci_number)
+
+        if isinstance(ci_details, str):
+            return ci_details
+        # get_ci_details can now answer with a failure dict, which has no
+        # 'result' key — pass it through instead of indexing into it.
+        if is_read_failure(ci_details):
+            return ci_details
+
+        # Extract key attributes for similarity search
+        search_attrs = _extract_ci_search_attributes(
+            ci_details['result'], ci_details['ci_table']
+        )
+
         similar_cis = await search_cis_by_attributes(**search_attrs, detailed=True)
+        # A failed search has no rows to filter. Without this,
+        # _filter_and_limit_ci_results returns [] and the caller is told there
+        # are no similar CIs for a search that never ran.
+        if is_read_failure(similar_cis):
+            return similar_cis
 
         # Filter and limit results
         filtered_results = _filter_and_limit_ci_results(similar_cis, ci_number, limit=20)
@@ -314,6 +372,8 @@ async def similar_cis_for_ci(ci_number: str) -> dict[str, Any] | str:
 
         return NO_SIMILAR_CIS_FOUND.format(ci_number=ci_number)
 
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
     except Exception:
         return ERROR_FINDING_SIMILAR_CIS
 
@@ -356,6 +416,8 @@ async def get_all_ci_types() -> dict[str, Any] | str:
         
         return NO_CI_TYPES_FOUND
 
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
     except Exception:
         return ERROR_GETTING_CI_TYPES
 
@@ -393,5 +455,7 @@ async def quick_ci_search(search_term: str) -> dict[str, Any] | str:
         
         return NO_CIS_FOUND_FOR_SEARCH.format(search_term=search_term)
 
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
     except Exception:
         return ERROR_QUICK_CI_SEARCH

--- a/http_layer/request_dispatcher.py
+++ b/http_layer/request_dispatcher.py
@@ -65,6 +65,7 @@ def _redact_url(url: str) -> str:
 # ---------------------------------------------------------------------------
 _TYPED_CALLERS: frozenset[str] = frozenset({
     "Table_Tools.generic_table_tools",
+    "Table_Tools.cmdb_tools",
 })
 
 # This package's own name, used for the frame-walk boundary test below.

--- a/tests/test_http_layer_errors.py
+++ b/tests/test_http_layer_errors.py
@@ -160,6 +160,7 @@ class TestLegacyNoneShim:
         """
         assert dispatcher._TYPED_CALLERS == frozenset({
             "Table_Tools.generic_table_tools",
+            "Table_Tools.cmdb_tools",
         })
 
     def test_typed_caller_names_are_real_module_names(self):

--- a/tests/test_typed_read_cmdb_tools.py
+++ b/tests/test_typed_read_cmdb_tools.py
@@ -14,10 +14,11 @@ of returning None. Two things are locked here:
    gather in `get_ci_details`, a timeout on cmdb_ci_server made a server CI
    appear to live in the base cmdb_ci table.
 
-`TestEndToEndThroughTheRealDispatcher` matters more here than in PR A: the probes
-run under `asyncio.gather`, and `_calling_module()` resolves the caller by
-walking the stack. A Task boundary severs the frame chain, so the wiring is
-verified against the real dispatcher rather than argued about.
+`TestEndToEndThroughTheRealDispatcher` checks the wiring against the real
+dispatcher instead of the module seam, since `_calling_module()` resolves the
+caller by walking the stack and a mocked `make_nws_request` would never exercise
+it. See that class's docstring for why the concurrent probes turned out not to
+threaten the walk.
 """
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -25,8 +26,11 @@ from unittest.mock import AsyncMock, patch
 from constants import (
     CI_NOT_FOUND,
     ERROR_FINDING_SIMILAR_CIS,
+    ERROR_GETTING_CI_TYPES,
     ERROR_QUICK_CI_SEARCH,
+    ERROR_SEARCHING_CIS,
     ERROR_SEARCHING_CIS_BY_TYPE,
+    NO_CI_TYPES_FOUND,
     NO_CIS_FOUND_FOR_TYPE,
     NO_CIS_FOUND_MATCHING_CRITERIA,
     NO_SIMILAR_CIS_FOUND,
@@ -114,6 +118,14 @@ class TestSingleRequestReads:
         assert result == NO_CIS_FOUND_MATCHING_CRITERIA
 
     @pytest.mark.asyncio
+    async def test_search_by_attributes_unexpected_error_still_returns_its_string(self):
+        with patch(
+            "Table_Tools.cmdb_tools.make_nws_request", side_effect=RuntimeError("boom")
+        ):
+            result = await search_cis_by_attributes(name="srv-app")
+        assert result == ERROR_SEARCHING_CIS
+
+    @pytest.mark.asyncio
     async def test_quick_search_failure_is_not_no_cis_found(self):
         with patch("Table_Tools.cmdb_tools.make_nws_request", side_effect=TIMEOUT):
             result = await quick_ci_search("srv-app-01")
@@ -132,6 +144,21 @@ class TestSingleRequestReads:
         with patch("Table_Tools.cmdb_tools.make_nws_request", side_effect=TIMEOUT):
             result = await get_all_ci_types()
         _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_get_all_ci_types_empty_keeps_its_not_found_string(self):
+        with patch("Table_Tools.cmdb_tools.make_nws_request") as mock_request:
+            mock_request.return_value = {"result": []}
+            result = await get_all_ci_types()
+        assert result == NO_CI_TYPES_FOUND
+
+    @pytest.mark.asyncio
+    async def test_get_all_ci_types_unexpected_error_still_returns_its_string(self):
+        with patch(
+            "Table_Tools.cmdb_tools.make_nws_request", side_effect=RuntimeError("boom")
+        ):
+            result = await get_all_ci_types()
+        assert result == ERROR_GETTING_CI_TYPES
 
 
 class TestProbeFailuresAreNotAbsence:
@@ -265,11 +292,19 @@ class TestSimilarCis:
 
 
 class TestEndToEndThroughTheRealDispatcher:
-    """Proves the _TYPED_CALLERS entry resolves — including across asyncio.gather.
+    """Proves the `_TYPED_CALLERS` entry actually resolves, gather included.
 
-    `_calling_module()` walks frames outward from the dispatcher. The probes in
-    `get_ci_details` each run in their own Task, so this is the case where a
-    frame-walk could plausibly fail to find `Table_Tools.cmdb_tools`.
+    These exercise the real `make_nws_request`, not the module seam: without the
+    `"Table_Tools.cmdb_tools"` entry the shim hands back None and every
+    assertion here reverts to a not-found string.
+
+    On the frame walk specifically — `_calling_module()` returns at the *first*
+    frame outside `http_layer`, which is `_probe_ci_table`, reached by an
+    ordinary direct await. The Task boundary that `asyncio.gather` introduces
+    sits several frames further out, past where the walk has already stopped, so
+    concurrency is not what puts the resolution at risk. Keep the gathered case
+    anyway: it costs nothing and pins the behavior against a future dispatcher
+    change that walks further.
     """
 
     @pytest.mark.asyncio

--- a/tests/test_typed_read_cmdb_tools.py
+++ b/tests/test_typed_read_cmdb_tools.py
@@ -1,0 +1,306 @@
+"""Typed read failures in the CMDB tools (v4.4 Tier 0.3, PR B).
+
+`Table_Tools.cmdb_tools` joins `_TYPED_CALLERS`, so a failed GET raises instead
+of returning None. Two things are locked here:
+
+1. Every public function returns `{"error": {"code", "message"}}` on a failure
+   instead of one of its not-found strings (NO_CIS_FOUND_FOR_TYPE, CI_NOT_FOUND,
+   ...) or its ERROR_* string, which dropped the code. Empty result sets keep
+   their existing strings — empty is success. The module's return type is
+   `dict | str` for the duration; Tier 3.1 removes the strings.
+
+2. `_probe_ci_table` no longer reports a failed probe as "this table has no such
+   CI". That conflation was worse than a wrong message: under the concurrent
+   gather in `get_ci_details`, a timeout on cmdb_ci_server made a server CI
+   appear to live in the base cmdb_ci table.
+
+`TestEndToEndThroughTheRealDispatcher` matters more here than in PR A: the probes
+run under `asyncio.gather`, and `_calling_module()` resolves the caller by
+walking the stack. A Task boundary severs the frame chain, so the wiring is
+verified against the real dispatcher rather than argued about.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from constants import (
+    CI_NOT_FOUND,
+    ERROR_FINDING_SIMILAR_CIS,
+    ERROR_QUICK_CI_SEARCH,
+    ERROR_SEARCHING_CIS_BY_TYPE,
+    NO_CIS_FOUND_FOR_TYPE,
+    NO_CIS_FOUND_MATCHING_CRITERIA,
+    NO_SIMILAR_CIS_FOUND,
+)
+from http_layer.errors import ErrorCode, ServiceNowRequestError
+from Table_Tools.cmdb_tools import (
+    DEFAULT_CI_PROBE_TABLES,
+    find_cis_by_type,
+    get_all_ci_types,
+    get_ci_details,
+    quick_ci_search,
+    search_cis_by_attributes,
+    similar_cis_for_ci,
+)
+
+TIMEOUT = ServiceNowRequestError(
+    ErrorCode.TIMEOUT, "ServiceNow request timed out", retryable=True
+)
+FORBIDDEN = ServiceNowRequestError(
+    ErrorCode.FORBIDDEN, "ServiceNow returned HTTP 403", status_code=403
+)
+
+CI_ROW = {"number": "CI0001000", "name": "srv-app-01", "sys_class_name": "Server"}
+
+
+def _assert_plain_failure(response, code):
+    assert isinstance(response, dict), response
+    assert set(response) == {"error"}, response
+    assert set(response["error"]) == {"code", "message"}
+    assert response["error"]["code"] == code
+
+
+def _by_table(mapping, default=None):
+    """Fake make_nws_request that answers per table name in the URL.
+
+    Values are either a payload dict or an exception to raise, so a test can say
+    "cmdb_ci_server times out, cmdb_ci has the row" without ordering assumptions
+    about how the concurrent probes interleave.
+    """
+    async def fake(url, *args, **kwargs):
+        table = url.split("/api/now/table/")[1].split("?")[0]
+        outcome = mapping.get(table, default)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome if outcome is not None else {"result": []}
+
+    return fake
+
+
+class TestSingleRequestReads:
+    @pytest.mark.asyncio
+    async def test_find_by_type_failure_is_not_no_cis_found(self):
+        with patch("Table_Tools.cmdb_tools.make_nws_request", side_effect=TIMEOUT):
+            result = await find_cis_by_type("cmdb_ci_server")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+        assert result != NO_CIS_FOUND_FOR_TYPE.format(ci_type="cmdb_ci_server")
+
+    @pytest.mark.asyncio
+    async def test_find_by_type_empty_keeps_its_not_found_string(self):
+        with patch("Table_Tools.cmdb_tools.make_nws_request") as mock_request:
+            mock_request.return_value = {"result": []}
+            result = await find_cis_by_type("cmdb_ci_server")
+        assert result == NO_CIS_FOUND_FOR_TYPE.format(ci_type="cmdb_ci_server")
+
+    @pytest.mark.asyncio
+    async def test_find_by_type_unexpected_error_still_returns_its_string(self):
+        """Narrowing the except must not remove the catch-all for real bugs."""
+        with patch(
+            "Table_Tools.cmdb_tools.make_nws_request", side_effect=RuntimeError("boom")
+        ):
+            result = await find_cis_by_type("cmdb_ci_server")
+        assert result == ERROR_SEARCHING_CIS_BY_TYPE
+
+    @pytest.mark.asyncio
+    async def test_search_by_attributes_failure_is_not_no_cis_matching(self):
+        with patch("Table_Tools.cmdb_tools.make_nws_request", side_effect=FORBIDDEN):
+            result = await search_cis_by_attributes(name="srv-app")
+        _assert_plain_failure(result, ErrorCode.FORBIDDEN)
+
+    @pytest.mark.asyncio
+    async def test_search_by_attributes_empty_keeps_its_not_found_string(self):
+        with patch("Table_Tools.cmdb_tools.make_nws_request") as mock_request:
+            mock_request.return_value = {"result": []}
+            result = await search_cis_by_attributes(name="srv-app")
+        assert result == NO_CIS_FOUND_MATCHING_CRITERIA
+
+    @pytest.mark.asyncio
+    async def test_quick_search_failure_is_not_no_cis_found(self):
+        with patch("Table_Tools.cmdb_tools.make_nws_request", side_effect=TIMEOUT):
+            result = await quick_ci_search("srv-app-01")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_quick_search_unexpected_error_still_returns_its_string(self):
+        with patch(
+            "Table_Tools.cmdb_tools.make_nws_request", side_effect=RuntimeError("boom")
+        ):
+            result = await quick_ci_search("srv-app-01")
+        assert result == ERROR_QUICK_CI_SEARCH
+
+    @pytest.mark.asyncio
+    async def test_get_all_ci_types_failure_is_not_no_types_found(self):
+        with patch("Table_Tools.cmdb_tools.make_nws_request", side_effect=TIMEOUT):
+            result = await get_all_ci_types()
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+
+class TestProbeFailuresAreNotAbsence:
+    """The headline bug: one timed-out probe attributing a CI to the wrong table."""
+
+    @pytest.mark.asyncio
+    async def test_failed_probe_does_not_attribute_the_ci_to_a_broader_table(self):
+        """cmdb_ci_server times out; the base cmdb_ci row must NOT be the answer.
+
+        cmdb_ci holds every CI, so the base table almost always has a row. If a
+        failed probe counted as absence, `get_ci_details` would confidently
+        report ci_table="cmdb_ci" for a machine that is a server.
+        """
+        fake = _by_table({
+            "cmdb_ci_server": TIMEOUT,
+            "cmdb_ci": {"result": [CI_ROW]},
+        })
+        with patch("Table_Tools.cmdb_tools.make_nws_request", new=fake):
+            result = await get_ci_details("CI0001000")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_failure_after_a_hit_does_not_spoil_the_answer(self):
+        """A higher-priority table already decided; later failures are irrelevant."""
+        assert DEFAULT_CI_PROBE_TABLES[0] == "cmdb_ci_server"
+        fake = _by_table({
+            "cmdb_ci_server": {"result": [CI_ROW]},
+            "cmdb_ci_database": TIMEOUT,
+            "cmdb_ci": TIMEOUT,
+        })
+        with patch("Table_Tools.cmdb_tools.make_nws_request", new=fake):
+            result = await get_ci_details("CI0001000")
+        assert result["ci_table"] == "cmdb_ci_server"
+        assert result["result"] == CI_ROW
+
+    @pytest.mark.asyncio
+    async def test_priority_order_is_still_most_specific_first(self):
+        fake = _by_table({
+            "cmdb_ci_computer": {"result": [CI_ROW]},
+            "cmdb_ci": {"result": [CI_ROW]},
+        })
+        with patch("Table_Tools.cmdb_tools.make_nws_request", new=fake):
+            result = await get_ci_details("CI0001000")
+        assert result["ci_table"] == "cmdb_ci_computer"
+
+    @pytest.mark.asyncio
+    async def test_all_probes_empty_still_says_ci_not_found(self):
+        with patch("Table_Tools.cmdb_tools.make_nws_request", new=_by_table({})):
+            result = await get_ci_details("CI0009999")
+        assert result == CI_NOT_FOUND.format(ci_number="CI0009999")
+
+    @pytest.mark.asyncio
+    async def test_explicit_ci_type_failure_returns_the_error(self):
+        with patch("Table_Tools.cmdb_tools.make_nws_request", side_effect=TIMEOUT):
+            result = await get_ci_details("CI0001000", ci_type="cmdb_ci_server")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_unexpected_probe_exception_still_propagates(self):
+        """A real bug must not be laundered into a not-found string."""
+        fake = _by_table({"cmdb_ci_server": RuntimeError("boom")})
+        with patch("Table_Tools.cmdb_tools.make_nws_request", new=fake):
+            with pytest.raises(RuntimeError):
+                await get_ci_details("CI0001000")
+
+
+class TestSimilarCis:
+    @pytest.mark.asyncio
+    async def test_lookup_failure_is_passed_through_not_indexed_into(self):
+        """get_ci_details can answer with a failure dict, which has no 'result'."""
+        with patch(
+            "Table_Tools.cmdb_tools.get_ci_details",
+            new=AsyncMock(return_value=TIMEOUT.to_error_dict()),
+        ):
+            result = await similar_cis_for_ci("CI0001000")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_search_failure_is_not_no_similar_cis(self):
+        details = {"ci_table": "cmdb_ci_server", "ci_number": "CI0001000", "result": {
+            "sys_class_name": "Server", "location": "Brussels", "operational_status": "1",
+        }}
+        with patch(
+            "Table_Tools.cmdb_tools.get_ci_details", new=AsyncMock(return_value=details)
+        ), patch(
+            "Table_Tools.cmdb_tools.search_cis_by_attributes",
+            new=AsyncMock(return_value=FORBIDDEN.to_error_dict()),
+        ):
+            result = await similar_cis_for_ci("CI0001000")
+        _assert_plain_failure(result, ErrorCode.FORBIDDEN)
+        assert result != NO_SIMILAR_CIS_FOUND.format(ci_number="CI0001000")
+
+    @pytest.mark.asyncio
+    async def test_genuine_no_similar_cis_keeps_its_string(self):
+        details = {"ci_table": "cmdb_ci_server", "ci_number": "CI0001000", "result": {
+            "sys_class_name": "Server", "location": "Brussels", "operational_status": "1",
+        }}
+        with patch(
+            "Table_Tools.cmdb_tools.get_ci_details", new=AsyncMock(return_value=details)
+        ), patch(
+            "Table_Tools.cmdb_tools.search_cis_by_attributes",
+            new=AsyncMock(return_value=NO_CIS_FOUND_MATCHING_CRITERIA),
+        ):
+            result = await similar_cis_for_ci("CI0001000")
+        assert result == NO_SIMILAR_CIS_FOUND.format(ci_number="CI0001000")
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_in_the_lookup_half_returns_its_string(self):
+        """get_ci_details re-raises real bugs; this function still answers with
+        its own ERROR_* string, the same as for a bug in the search half."""
+        with patch(
+            "Table_Tools.cmdb_tools.get_ci_details",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            result = await similar_cis_for_ci("CI0001000")
+        assert result == ERROR_FINDING_SIMILAR_CIS
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_still_returns_its_string(self):
+        details = {"ci_table": "cmdb_ci_server", "ci_number": "CI0001000", "result": {
+            "sys_class_name": "Server",
+        }}
+        with patch(
+            "Table_Tools.cmdb_tools.get_ci_details", new=AsyncMock(return_value=details)
+        ), patch(
+            "Table_Tools.cmdb_tools.search_cis_by_attributes",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            result = await similar_cis_for_ci("CI0001000")
+        assert result == ERROR_FINDING_SIMILAR_CIS
+
+
+class TestEndToEndThroughTheRealDispatcher:
+    """Proves the _TYPED_CALLERS entry resolves — including across asyncio.gather.
+
+    `_calling_module()` walks frames outward from the dispatcher. The probes in
+    `get_ci_details` each run in their own Task, so this is the case where a
+    frame-walk could plausibly fail to find `Table_Tools.cmdb_tools`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_timeout_reaches_find_cis_by_type(self, monkeypatch):
+        import http_layer.request_dispatcher as dispatcher
+
+        async def slow(url):
+            raise TimeoutError()
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", slow)
+        result = await find_cis_by_type("cmdb_ci_server")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_timeout_inside_a_gathered_probe_reaches_get_ci_details(self, monkeypatch):
+        import http_layer.request_dispatcher as dispatcher
+
+        async def slow(url):
+            raise TimeoutError()
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", slow)
+        result = await get_ci_details("CI0001000")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_empty_probes_through_the_real_dispatcher_say_not_found(self, monkeypatch):
+        import http_layer.request_dispatcher as dispatcher
+
+        async def empty(url):
+            return {"result": []}
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", empty)
+        result = await get_ci_details("CI0009999")
+        assert result == CI_NOT_FOUND.format(ci_number="CI0009999")


### PR DESCRIPTION
PR B of the v4.4 Tier 0.3 typed-read chain (after #64). One module: `Table_Tools/cmdb_tools.py`.

## What changed

`Table_Tools.cmdb_tools` joins `_TYPED_CALLERS`, so a failed GET raises `ServiceNowRequestError` here instead of returning `None`.

**Five not-found guards inverted.** `find_cis_by_type`, `search_cis_by_attributes`, `get_ci_details`, `get_all_ci_types`, `quick_ci_search` each did `if data and data.get('result')`, so a `None` from a failed read fell through to `NO_CIS_FOUND_FOR_TYPE` / `NO_CIS_FOUND_MATCHING_CRITERIA` / `CI_NOT_FOUND` / `NO_CI_TYPES_FOUND` / `NO_CIS_FOUND_FOR_SEARCH`. A timeout answered "no CIs of this type". Each now returns `error.to_error_dict()`. An empty result set keeps its existing string — empty is success, and that is unchanged.

**`_probe_ci_table` — the more interesting bug, not in the plan.** It caught every exception and returned `None`, which under the concurrent `gather` in `get_ci_details` is indistinguishable from "the CI is not in this table". Every CI also lives in the base `cmdb_ci` table, so a timeout on `cmdb_ci_server` made a server CI appear to live in `cmdb_ci` — the wrong table, reported confidently. Probes propagate now; the gather uses `return_exceptions=True` so a failure stays positionally attached to its own table; the priority-ordered loop returns the failure when it precedes any hit.

Answering the handoff's open question: **a failed probe fails the whole lookup**, it does not report partial coverage. An incomplete probe set supports neither "not found in any CMDB table" nor attribution to a less specific one. A failure *after* a hit is ignored — the higher-priority table already decided the answer.

**Two response re-wraps in `similar_cis_for_ci`.** A failure dict from `get_ci_details` has no `'result'` key to index into. A failure dict from `search_cis_by_attributes` would have gone through `_filter_and_limit_ci_results` and come out `[]`, reporting "no similar CIs" for a search that never ran.

**`except ServiceNowRequestError` precedes every bare `except Exception`** (settled decision (e)) — otherwise the `ERROR_*` string swallows the code. The catch-all stays for genuine bugs; tests assert both arms.

## Settled decisions applied

Per `0.3-HANDOFF.md` §2, reused from PR A rather than re-decided:

- **(a)** A raise returns `to_error_dict()` → `{"error": {"code", "message"}}`. Nothing else — no `retryable` in the payload, no prose translation of the code.
- **(b)** Empty result stays not-found. Only *failure* stops sharing that outcome.
- **(c)** This module now returns **`dict | str`**. Deliberate, and called out here so it does not read as sloppiness: every other return is a bare string and Tier 3.1 deletes all 16 of them. Inventing an error *string* to keep the return type uniform would ship a lie to preserve tidiness.
- **(e)** Applied to all five public functions.

Decision (d) (pre-write `sys_id` reads) has no site in this module — no writes here. It lands in PRs C and D.

## Behavior changes for the 4.4.0 CHANGELOG

- CMDB tools return `{"error": {"code", "message"}}` on a read failure instead of a not-found string or an `ERROR_*` string.
- `get_ci_details` **propagates** an unexpected (unclassified) probe exception rather than silently treating that table as a miss. `similar_cis_for_ci` maps such a bug to `ERROR_FINDING_SIMILAR_CIS`, matching how it already handled a bug in its search half — the lookup call was moved inside its `try` for exactly that consistency.

## Tests

`tests/test_typed_read_cmdb_tools.py` (new, 25 tests). Coverage on `Table_Tools/cmdb_tools.py`: **62.63% → 88.64%**, measured on the real parent `b79fa76`.

The migration inventory's 10.86% figure is stale — it was measured at `e7d78fc`, before #60 added `tests/test_cmdb_citype_validation.py`. Re-measured rather than quoted.

Per the inventory's coverage warning, this does not extend `tests/test_cmdb_tools.py` — that file patches its own bound attributes and asserts nothing about the real functions.

`TestEndToEndThroughTheRealDispatcher` exercises the real `make_nws_request`, not just the module seam: `_calling_module()` resolves the caller by walking frames, and the probes run in separate Tasks, so a Task boundary severing the frame chain is a real failure mode that deserved a test rather than an argument. It resolves correctly.

Suite: **885 passed, 5 skipped**.

## Known cosmetic item

The `except ServiceNowRequestError` arm in `similar_cis_for_ci` is unreachable — both helpers it calls convert typed failures to dicts internally. Kept deliberately under decision (e) (uniform arm in every function touched) so a later change to either helper cannot silently reintroduce the flattening, and commented as such in the code so it does not read as tested defense.

## Review

Reviewed; three substantiated findings fixed in `fd8cb77` — the unreachable arm now documents itself, three untested catch-all arms got regression tests, and a frame-walk justification that described a mechanism which does not apply was corrected. A fourth item, the stale coverage baseline above, was caught by the review flagging it as unverified. See the review-response comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
