### PR TITLE
fix(kb): fail closed when the duplicate check cannot answer

### DIFF
--- a/Table_Tools/kb_article_tools.py
+++ b/Table_Tools/kb_article_tools.py
@@ -1,11 +1,30 @@
+"""Knowledge-article reads and writes.
+
+Read-failure contract (v4.4 Tier 0.3). This module is in
+`http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET raises
+`ServiceNowRequestError` rather than returning None:
+
+  * A raise surfaces as `error.to_error_dict()` -> {"error": {code, message}}.
+  * An empty result set keeps its existing not-found message. Empty is success.
+  * The pre-write `sys_id` / meta reads return None ONLY for a genuinely absent
+    article. A failed read propagates, so a write never again reports "article
+    not found" because the lookup timed out (decision (d)).
+
+The publish guard is FAIL-CLOSED. `_check_kb_duplicates` has three outcomes, not
+two — clear, duplicates-found, and inconclusive — and only *clear* permits a
+publish. Before v4.4 a failed duplicate-check read returned `[]`, which read as
+a clean bill of health, and the article published with the guard silently
+skipped. "Could not check" is not "nothing found".
+"""
 import asyncio
 import sys
 import time
-from http_layer import make_nws_request, NWS_API_BASE
-from typing import Any, Dict, List
+from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
+from typing import Any, Dict, List, Optional
 import anyio
 import httpx
 import structlog
+from .read_helpers import is_read_failure
 from .write_helpers import map_http_error, unwrap_write_response
 from param_coercion import JsonList
 from constants import (
@@ -18,6 +37,13 @@ from constants import (
     ERROR_KB_ARTICLE_NOT_FOUND,
     ERROR_KB_ARTICLE_SERVER_ERROR,
     ERROR_KB_PUBLISH_NOT_CONFIRMED,
+    ERROR_KB_WRITE_UNCONFIRMED,
+    ERROR_KB_DUPLICATE_CHECK_INCONCLUSIVE,
+    ERROR_KB_PUBLISH_VERIFY_UNREADABLE,
+    KB_DEDUP_QUERY_LIMIT,
+    KB_DEDUP_REASON_TRUNCATED,
+    KB_DEDUP_REASON_UNSAFE_CHARS,
+    KB_QUERY_UNSAFE_CHARS,
     KB_WRITE_RESPONSE_FIELDS,
     KB_META_FIELDS,
     KB_DEDUP_FIELDS,
@@ -34,6 +60,21 @@ from constants import (
 )
 
 _log = structlog.get_logger("kb_write")
+
+
+class KbDuplicateCheckInconclusive(Exception):
+    """The duplicate check could not produce a trustworthy answer.
+
+    Distinct from "no duplicates found", and deliberately not a
+    `ServiceNowRequestError` — nothing went wrong at the transport layer. The
+    query either could not be expressed faithfully or came back possibly
+    truncated, so returning `[]` would report a clean bill of health for a check
+    that did not really run. Callers fail closed and do not publish.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
 
 def _handle_kb_error(error: httpx.HTTPStatusError, operation: str) -> str:
@@ -56,7 +97,7 @@ def _handle_kb_error(error: httpx.HTTPStatusError, operation: str) -> str:
 def _unwrap_kb_write_response(result: Any, operation: str) -> Dict[str, Any] | str:
     return unwrap_write_response(
         result,
-        f"Knowledge article {operation} successful but no data returned.",
+        ERROR_KB_WRITE_UNCONFIRMED.format(operation=operation),
         fields=KB_WRITE_RESPONSE_FIELDS,
     )
 
@@ -81,6 +122,12 @@ async def _write_kb_article(
 
 
 async def _get_kb_article_sys_id(article_number: str, workflow_state: str | None = None) -> str | None:
+    """Return the article's sys_id, or None if no such article exists.
+
+    None means "looked, absent" and nothing else (decision (d)). A failed read
+    raises `ServiceNowRequestError` and the caller maps it, so a write can no
+    longer report "article not found" because the lookup timed out.
+    """
     query = f"number={article_number}"
     if workflow_state:
         query += f"^workflow_state={workflow_state}"
@@ -92,7 +139,11 @@ async def _get_kb_article_sys_id(article_number: str, workflow_state: str | None
 
 
 async def _get_kb_article_meta(article_number: str, workflow_state: str | None = None) -> Dict[str, Any] | None:
-    """Fetch sys_id + short_description in one GET — avoids a second round-trip in publish."""
+    """Fetch sys_id + short_description in one GET — avoids a second round-trip in publish.
+
+    Same boundary as `_get_kb_article_sys_id`: None means absent, a failed read
+    raises (decision (d)).
+    """
     query = f"number={article_number}"
     if workflow_state:
         query += f"^workflow_state={workflow_state}"
@@ -107,6 +158,11 @@ async def _get_kb_article_meta(article_number: str, workflow_state: str | None =
     return data['result'][0]
 
 
+def _dedup_unsafe_chars(short_description: str) -> list[str]:
+    """Characters in *short_description* that the encoded query cannot carry."""
+    return [c for c in KB_QUERY_UNSAFE_CHARS if c in short_description]
+
+
 async def _check_kb_duplicates(short_description: str, exclude_number: str) -> list:
     """Return KB articles matching short_description exactly across live workflow states.
 
@@ -115,22 +171,52 @@ async def _check_kb_duplicates(short_description: str, exclude_number: str) -> l
     Retired + outdated articles are skipped — retired = explicitly killed,
     outdated = prior version after a newer publish (ServiceNow versioning
     artefact). Excludes the article being published (exclude_number) from results.
+
+    An empty list means the check ran and found nothing. It never means the check
+    could not run — that is the whole point of the two raises below, because the
+    caller's only safe reading of `[]` is "clear to publish".
+
+    Raises:
+        ServiceNowRequestError: the read failed. Previously this arrived as None
+            and became `[]`, so a timeout published the article unchecked.
+        KbDuplicateCheckInconclusive: the query could not be trusted — either the
+            title carries a character the encoded query mangles, or the result
+            page hit its row cap and the duplicate may be off the end of it.
     """
+    unsafe = _dedup_unsafe_chars(short_description)
+    if unsafe:
+        # Refused before the request: the query that would run is broader than
+        # the one asked for, so a "no duplicates" answer would be meaningless.
+        raise KbDuplicateCheckInconclusive(
+            KB_DEDUP_REASON_UNSAFE_CHARS.format(chars=" ".join(unsafe))
+        )
+
     url = (
         f"{NWS_API_BASE}/api/now/table/kb_knowledge"
         f"?sysparm_fields={','.join(KB_DEDUP_FIELDS)}"
         f"&sysparm_query=short_descriptionLIKE{short_description}"
+        f"&sysparm_limit={KB_DEDUP_QUERY_LIMIT}"
     )
     data = await make_nws_request(url)
     if not data or not data.get('result'):
         return []
+    rows = data['result']
     needle = short_description.strip().lower()
-    return [
-        r for r in data['result']
+    matches = [
+        r for r in rows
         if r.get('short_description', '').strip().lower() == needle
         and r.get('number') != exclude_number
         and r.get('workflow_state', '').strip().lower() not in KB_DUPLICATE_IGNORED_STATES
     ]
+    if matches:
+        # A definite answer beats an inconclusive one, and both block the
+        # publish — so report the duplicates even off a truncated page.
+        return matches
+    if len(rows) >= KB_DEDUP_QUERY_LIMIT:
+        raise KbDuplicateCheckInconclusive(
+            KB_DEDUP_REASON_TRUNCATED.format(limit=KB_DEDUP_QUERY_LIMIT)
+        )
+    return []
 
 
 async def _call_kb_workflow(sys_id: str, action: str) -> Dict[str, Any] | str:
@@ -158,6 +244,10 @@ async def _verify_kb_published(article_number: str) -> Dict[str, Any] | None:
     ServiceNow KB versioning produces (draft, published) row pairs after a
     successful publish. Any row in the Published state confirms the workflow
     committed — that is the only authoritative success signal.
+
+    None means "read succeeded, no Published row yet". A failed read raises: it
+    is not evidence the publish did not commit, and treating it as such is what
+    made an unreadable verify re-fire the publish write.
     """
     query = f"number={article_number}^workflow_state={KB_PUBLISHED_STATE}"
     url = (
@@ -202,16 +292,51 @@ async def _publish_with_verify(sys_id: str, article_number: str) -> Dict[str, An
         last_fire_error = await _fire_publish(current_sys_id)
 
         await asyncio.sleep(KB_VERIFY_DELAY_SECONDS)
-        published = await _verify_kb_published(article_number)
+        try:
+            published = await _verify_kb_published(article_number)
+        except ServiceNowRequestError as error:
+            # Do NOT retry. The publish write has already gone out; re-firing it
+            # on the strength of a failed *read* is how one unreadable verify
+            # became two publish workflows and a second published version.
+            return _publish_unconfirmed(article_number, error)
         if published:
             return published
 
         if attempt < KB_PUBLISH_MAX_RETRIES:
-            refreshed = await _get_kb_article_sys_id(article_number, workflow_state="draft")
-            if refreshed:
-                current_sys_id = refreshed
+            current_sys_id = await _refresh_draft_sys_id(article_number, current_sys_id)
 
     return last_fire_error or ERROR_KB_PUBLISH_NOT_CONFIRMED.format(number=article_number)
+
+
+def _publish_unconfirmed(article_number: str, error: ServiceNowRequestError) -> Dict[str, Any]:
+    """The publish fired but the confirming read failed — neither success nor failure.
+
+    Carries `publish_confirmed: False` so a batch row can be labelled
+    `unconfirmed` rather than `blocked` (nothing blocked it) or `error` (the write
+    may well have landed).
+    """
+    return {
+        "success": False,
+        "publish_confirmed": False,
+        "message": ERROR_KB_PUBLISH_VERIFY_UNREADABLE.format(
+            number=article_number, message=error.message
+        ),
+        "error": error.to_error_dict()["error"],
+    }
+
+
+async def _refresh_draft_sys_id(article_number: str, current_sys_id: str) -> str:
+    """Re-read the draft sys_id between publish attempts, best effort.
+
+    ServiceNow versioning can hand the draft a new sys_id, so the retry re-reads
+    it. A failed re-read is not worth abandoning the retry over — keep the sys_id
+    already in hand rather than propagating.
+    """
+    try:
+        refreshed = await _get_kb_article_sys_id(article_number, workflow_state="draft")
+    except ServiceNowRequestError:
+        return current_sys_id
+    return refreshed or current_sys_id
 
 
 async def update_knowledge_article(article_number: str, update_data: Dict[str, Any]) -> Dict[str, Any] | str:
@@ -235,7 +360,12 @@ async def update_knowledge_article(article_number: str, update_data: Dict[str, A
     # Per-step stderr timing — localises a stall to the sys_id GET vs the PATCH
     # when an update hangs. stdout is reserved for the MCP JSON-RPC frame stream.
     t0 = time.monotonic()
-    sys_id = await _get_kb_article_sys_id(article_number, workflow_state="draft")
+    try:
+        sys_id = await _get_kb_article_sys_id(article_number, workflow_state="draft")
+    except ServiceNowRequestError as error:
+        # A failed lookup is not a missing article, and reporting it as one sent
+        # people looking for an article that was there all along (decision (d)).
+        return error.to_error_dict()
     t1 = time.monotonic()
     print(f"[kb] {article_number} sys_id GET took {t1 - t0:.1f}s", file=sys.stderr)
     if not sys_id:
@@ -258,12 +388,25 @@ async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str
 
     Returns:
         Updated article record dict, duplicate warning dict, or error string on failure.
+
+    Fail-closed: the publish only proceeds on a duplicate check that positively
+    came back clear. A check that could not run blocks the publish and writes
+    nothing.
     """
-    meta = await _get_kb_article_meta(article_number, workflow_state="draft")
+    try:
+        meta = await _get_kb_article_meta(article_number, workflow_state="draft")
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
     if not meta:
         return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
 
-    duplicates = await _check_kb_duplicates(meta['short_description'], article_number)
+    try:
+        duplicates = await _check_kb_duplicates(meta['short_description'], article_number)
+    except ServiceNowRequestError as error:
+        return _duplicate_check_inconclusive(article_number, error.message)
+    except KbDuplicateCheckInconclusive as inconclusive:
+        return _duplicate_check_inconclusive(article_number, inconclusive.reason)
+
     if duplicates:
         return {
             "success": False,
@@ -274,17 +417,60 @@ async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str
     return await _publish_with_verify(meta['sys_id'], article_number)
 
 
+def _duplicate_check_inconclusive(article_number: str, reason: str) -> Dict[str, Any]:
+    """Refuse the publish because the duplicate check could not answer.
+
+    Same `success: False` shape as a found-duplicate block — in both cases nothing
+    was written and the caller must resolve something first. `duplicate_check`
+    distinguishes "the guard said no" from "the guard could not say".
+    """
+    return {
+        "success": False,
+        "duplicate_check": "inconclusive",
+        "message": ERROR_KB_DUPLICATE_CHECK_INCONCLUSIVE.format(
+            number=article_number, reason=reason
+        ),
+        "duplicates": [],
+    }
+
+
+def _duplicate_row_inconclusive(article_number: str, reason: str) -> Dict[str, Any]:
+    """A row for an article whose duplicate status could not be determined.
+
+    Deliberately carries NO `has_duplicate` key. The old shape reported
+    `has_duplicate: False` with no error when the read had failed — a clean bill
+    of health from a check that never ran, and the exact reading that let a
+    publish through. A consumer that reaches for `has_duplicate` here should fail
+    loudly rather than read the absence of a duplicate into a missing answer.
+    """
+    return {
+        "number": article_number,
+        "duplicate_check": "inconclusive",
+        "duplicates": [],
+        "error": reason,
+    }
+
+
 async def _check_single_kb_duplicate(article_number: str) -> Dict[str, Any]:
     """Lookup meta then check duplicates for one article. Used by check_kb_duplicates fan-out."""
-    meta = await _get_kb_article_meta(article_number)
+    try:
+        meta = await _get_kb_article_meta(article_number)
+    except ServiceNowRequestError as error:
+        return _duplicate_row_inconclusive(article_number, error.message)
     if not meta:
+        # A genuinely absent article: the check did run, so has_duplicate stands.
         return {
             "number": article_number,
             "has_duplicate": False,
             "duplicates": [],
             "error": ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number),
         }
-    duplicates = await _check_kb_duplicates(meta["short_description"], article_number)
+    try:
+        duplicates = await _check_kb_duplicates(meta["short_description"], article_number)
+    except ServiceNowRequestError as error:
+        return _duplicate_row_inconclusive(article_number, error.message)
+    except KbDuplicateCheckInconclusive as inconclusive:
+        return _duplicate_row_inconclusive(article_number, inconclusive.reason)
     return {
         "number": article_number,
         "has_duplicate": bool(duplicates),
@@ -293,6 +479,32 @@ async def _check_single_kb_duplicate(article_number: str) -> Dict[str, Any]:
             for d in duplicates
         ],
     }
+
+
+def _outcome_error_message(outcome: BaseException) -> str:
+    """Message for an exception that escaped a per-article coroutine."""
+    if isinstance(outcome, ServiceNowRequestError):
+        return outcome.message
+    if isinstance(outcome, KbDuplicateCheckInconclusive):
+        return outcome.reason
+    return f"{type(outcome).__name__}: {outcome}"
+
+
+def _rows_from_outcomes(numbers, outcomes, error_row) -> List[Dict[str, Any]]:
+    """Zip gathered outcomes back onto their article numbers, exceptions included.
+
+    `asyncio.gather(..., return_exceptions=True)` keeps results positional, so a
+    failure stays attached to the article it belongs to instead of aborting the
+    batch and discarding every sibling row — including rows for articles that
+    were already written.
+    """
+    rows: List[Dict[str, Any]] = []
+    for number, outcome in zip(numbers, outcomes):
+        if isinstance(outcome, BaseException):
+            rows.append(error_row(number, _outcome_error_message(outcome)))
+        else:
+            rows.append(outcome)
+    return rows
 
 
 async def check_kb_duplicates(
@@ -313,6 +525,12 @@ async def check_kb_duplicates(
 
     Returns:
         {"result": [{"number", "has_duplicate", "duplicates": [{"number", "workflow_state"}], "error"?}, ...]}
+
+        A row whose check could not be completed instead carries
+        `{"number", "duplicate_check": "inconclusive", "duplicates": [], "error"}`
+        and NO `has_duplicate` key — a missing answer must not be readable as
+        "no duplicates". Treat such a row the way `publish_knowledge_article`
+        does: as a reason not to publish, not as a clean result.
     """
     if not article_numbers:
         return {"result": []}
@@ -325,23 +543,59 @@ async def check_kb_duplicates(
         async with semaphore:
             return await _check_single_kb_duplicate(num)
 
-    results = await asyncio.gather(*(_bounded(n) for n in article_numbers))
-    return {"result": results}
+    outcomes = await asyncio.gather(
+        *(_bounded(n) for n in article_numbers), return_exceptions=True
+    )
+    return {"result": _rows_from_outcomes(article_numbers, outcomes, _duplicate_row_inconclusive)}
 
 
 def _normalize_publish_result(article_number: str, result: Dict[str, Any] | str) -> Dict[str, Any]:
-    """Normalize publish_knowledge_article output into a flat batch-result row."""
+    """Normalize publish_knowledge_article output into a flat batch-result row.
+
+    Four statuses: `published`, `blocked` (a guard said no — nothing written),
+    `unconfirmed` (the write went out, the confirming read did not come back), and
+    `error`.
+
+    Note the ordering. `published` is the FALL-THROUGH, so every non-success shape
+    has to be recognised before it: a bare `{"error": ...}` failure dict would
+    otherwise be reported as a successful publish with `workflow_state: None`,
+    turning the typed failure this tier introduced into a false success — the
+    precise mislabelling the tier exists to remove.
+    """
     if isinstance(result, str):
         return {"number": article_number, "status": "error", "message": result}
-    if isinstance(result, dict) and result.get("success") is False:
+    if not isinstance(result, dict):
+        return {"number": article_number, "status": "error", "message": str(result)}
+    if result.get("publish_confirmed") is False:
         return {
+            "number": article_number,
+            "status": "unconfirmed",
+            "message": result.get("message"),
+            "error": result.get("error"),
+        }
+    if is_read_failure(result):
+        error = result.get("error") or {}
+        return {
+            "number": article_number,
+            "status": "error",
+            "message": error.get("message"),
+            "code": error.get("code"),
+        }
+    if result.get("success") is False:
+        row = {
             "number": article_number,
             "status": "blocked",
             "message": result.get("message"),
             "blockers": result.get("duplicates", []),
         }
-    workflow_state = result.get("workflow_state") if isinstance(result, dict) else None
-    return {"number": article_number, "status": "published", "workflow_state": workflow_state}
+        if result.get("duplicate_check"):
+            row["duplicate_check"] = result["duplicate_check"]
+        return row
+    return {
+        "number": article_number,
+        "status": "published",
+        "workflow_state": result.get("workflow_state"),
+    }
 
 
 async def publish_knowledge_articles(
@@ -360,7 +614,12 @@ async def publish_knowledge_articles(
             (default KB_PUBLISH_BATCH_CONCURRENCY = 2).
 
     Returns:
-        {"result": [{"number", "status": "published"|"blocked"|"error", ...}, ...]}
+        {"result": [{"number", "status": "published"|"blocked"|"unconfirmed"|"error", ...}, ...]}
+
+        `blocked` — a guard refused (duplicates found, or the duplicate check
+        could not answer). Nothing was written.
+        `unconfirmed` — the publish was submitted but the confirming read failed.
+        It may have committed; do not blind-retry.
     """
     if not article_numbers:
         return {"result": []}
@@ -374,8 +633,16 @@ async def publish_knowledge_articles(
             outcome = await publish_knowledge_article(num)
             return _normalize_publish_result(num, outcome)
 
-    results = await asyncio.gather(*(_bounded(n) for n in article_numbers))
-    return {"result": results}
+    def _error_row(number: str, message: str) -> Dict[str, Any]:
+        return {"number": number, "status": "error", "message": message}
+
+    # return_exceptions: one article's failure must not discard the batch. Some
+    # of these articles have already been PUBLISHED by the time a later one
+    # fails, and aborting the gather threw away the only record of which.
+    outcomes = await asyncio.gather(
+        *(_bounded(n) for n in article_numbers), return_exceptions=True
+    )
+    return {"result": _rows_from_outcomes(article_numbers, outcomes, _error_row)}
 
 
 async def retire_knowledge_article(article_number: str) -> Dict[str, Any] | str:
@@ -387,7 +654,10 @@ async def retire_knowledge_article(article_number: str) -> Dict[str, Any] | str:
     Returns:
         Updated article record dict, or error string on failure.
     """
-    sys_id = await _get_kb_article_sys_id(article_number, workflow_state="published")
+    try:
+        sys_id = await _get_kb_article_sys_id(article_number, workflow_state="published")
+    except ServiceNowRequestError as error:
+        return error.to_error_dict()
     if not sys_id:
         return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
     return await _call_kb_workflow(sys_id, "retire")

--- a/Table_Tools/kb_article_tools.py
+++ b/Table_Tools/kb_article_tools.py
@@ -19,6 +19,7 @@ skipped. "Could not check" is not "nothing found".
 import asyncio
 import sys
 import time
+from urllib.parse import unquote
 from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
 from typing import Any, Dict, List, Optional
 import anyio
@@ -41,6 +42,7 @@ from constants import (
     ERROR_KB_DUPLICATE_CHECK_INCONCLUSIVE,
     ERROR_KB_PUBLISH_VERIFY_UNREADABLE,
     KB_DEDUP_QUERY_LIMIT,
+    KB_DEDUP_REASON_PERCENT_ESCAPE,
     KB_DEDUP_REASON_TRUNCATED,
     KB_DEDUP_REASON_UNSAFE_CHARS,
     KB_QUERY_UNSAFE_CHARS,
@@ -158,9 +160,24 @@ async def _get_kb_article_meta(article_number: str, workflow_state: str | None =
     return data['result'][0]
 
 
-def _dedup_unsafe_chars(short_description: str) -> list[str]:
-    """Characters in *short_description* that the encoded query cannot carry."""
-    return [c for c in KB_QUERY_UNSAFE_CHARS if c in short_description]
+def _dedup_query_defect(short_description: str) -> Optional[str]:
+    """Why the dedup query would not faithfully carry *short_description*, if so.
+
+    Two independent failures, both ending with ServiceNow running a query nobody
+    asked for. See the constants for the mechanics.
+
+    The percent check is a round trip rather than a character blacklist: it is
+    exactly the condition that matters (`unquote` is what corrupts the value), it
+    does not refuse an ordinary "50% off" title, and it keeps holding if the
+    encoder's safe-set changes. Verified against every character in that safe-set
+    — only ^ and & break structure; = < > ( ) : @ ! survive intact.
+    """
+    unsafe = [c for c in KB_QUERY_UNSAFE_CHARS if c in short_description]
+    if unsafe:
+        return KB_DEDUP_REASON_UNSAFE_CHARS.format(chars=" ".join(unsafe))
+    if unquote(short_description) != short_description:
+        return KB_DEDUP_REASON_PERCENT_ESCAPE
+    return None
 
 
 async def _check_kb_duplicates(short_description: str, exclude_number: str) -> list:
@@ -183,13 +200,11 @@ async def _check_kb_duplicates(short_description: str, exclude_number: str) -> l
             title carries a character the encoded query mangles, or the result
             page hit its row cap and the duplicate may be off the end of it.
     """
-    unsafe = _dedup_unsafe_chars(short_description)
-    if unsafe:
-        # Refused before the request: the query that would run is broader than
-        # the one asked for, so a "no duplicates" answer would be meaningless.
-        raise KbDuplicateCheckInconclusive(
-            KB_DEDUP_REASON_UNSAFE_CHARS.format(chars=" ".join(unsafe))
-        )
+    defect = _dedup_query_defect(short_description)
+    if defect:
+        # Refused before the request: the query that would run is not the one
+        # asked for, so a "no duplicates" answer from it would be meaningless.
+        raise KbDuplicateCheckInconclusive(defect)
 
     url = (
         f"{NWS_API_BASE}/api/now/table/kb_knowledge"

--- a/Table_Tools/vtb_task_tools.py
+++ b/Table_Tools/vtb_task_tools.py
@@ -13,6 +13,7 @@ from constants import (
     ERROR_PRIVATE_TASK_INVALID_REQUEST,
     ERROR_PRIVATE_TASK_NOT_FOUND,
     ERROR_PRIVATE_TASK_SERVER_ERROR,
+    ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED,
     VTB_WRITE_TIMEOUT_SECONDS,
     VTB_UPDATABLE_FIELDS
 )
@@ -32,7 +33,7 @@ def _handle_http_error(error: httpx.HTTPStatusError, operation: str) -> str:
 def _unwrap_write_response(result: Any, operation: str) -> Dict[str, Any] | str:
     """Extract the inner result payload from a write response."""
     return unwrap_write_response(
-        result, f"Private Task {operation} successful but no data returned."
+        result, ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation=operation)
     )
 
 async def _write_private_task(

--- a/Table_Tools/write_helpers.py
+++ b/Table_Tools/write_helpers.py
@@ -51,14 +51,22 @@ def map_http_error(
 
 def unwrap_write_response(
     result: Any,
-    success_message: str,
+    unconfirmed_message: str,
     *,
     fields: Optional[Iterable[str]] = None,
 ) -> Dict[str, Any] | str:
     """Extract the single-record payload from a write response.
 
     fields: when given, filter a dict record down to these keys (KB write).
-    success_message: returned when the response carried no data.
+    unconfirmed_message: returned when the response carried no record.
+
+    An empty response is UNCONFIRMED, not successful (v4.4 Tier 0.3). This
+    previously returned a message reading "<operation> successful but no data
+    returned" — it asserted the write had landed on the strength of an empty
+    response, which is the one thing an empty response cannot establish. #59
+    fixed the transport half (a failed write now raises instead of returning
+    None), so a falsy value reaching here means ServiceNow answered 2xx with no
+    record: real, rare, and not a success.
     """
     if result and isinstance(result, dict) and result.get("result"):
         record = result["result"]
@@ -66,4 +74,4 @@ def unwrap_write_response(
             allowed = set(fields)
             return {k: v for k, v in record.items() if k in allowed}
         return record
-    return result if result else success_message
+    return result if result else unconfirmed_message

--- a/constants.py
+++ b/constants.py
@@ -304,16 +304,36 @@ KB_DUPLICATE_IGNORED_STATES = {"retired", "outdated"}
 # indistinguishable from a complete answer.
 KB_DEDUP_QUERY_LIMIT = 200
 
-# Characters that cannot be carried inside an encoded-query value. The read path
-# percent-encodes sysparm_query but keeps the ServiceNow operator characters in
-# its safe-set (http_layer/url_builder.ensure_query_encoded), and it unquotes
-# before re-quoting, so pre-encoding these at the call site does not survive:
+# Characters that break the STRUCTURE of an encoded query when they appear
+# inside a value. The read path percent-encodes sysparm_query but keeps the
+# ServiceNow operator characters in its safe-set
+# (http_layer/url_builder.ensure_query_encoded), and it unquotes before
+# re-quoting, so pre-encoding these at the call site does not survive:
 #   "Cost^Center"  ->  short_descriptionLIKECost ^ Center   (two conditions)
 #   "A&B"          ->  short_descriptionLIKEA & B           (a second URL param)
 # Either way the query that runs is not the query that was asked for, and it
 # runs BROADER. A duplicate check cannot be trusted for such a value, so the
 # publish guard treats it as inconclusive rather than clean.
+#
+# Measured against the whole safe-set: only these two break anything. A value
+# containing = < > ( ) : @ ! survives the round trip intact.
 KB_QUERY_UNSAFE_CHARS = ("^", "&")
+
+# The other, quieter way a value fails to survive: `ensure_query_encoded`
+# unquotes before re-quoting, so any "%" followed by two hex digits in the value
+# is decoded as a percent-escape and ServiceNow searches for a DIFFERENT string.
+# "Deal 20%2C off" becomes "Deal 20, off"; "%41dmin" becomes "Admin"; "20%DB"
+# becomes an invalid byte and then U+FFFD. `unquote` never raises, so nothing
+# announces it.
+#
+# Detected by round trip (unquote(value) == value) rather than by blacklisting
+# "%", which would needlessly refuse an ordinary title like "50% off" — a bare
+# "%" not followed by hex digits survives fine. The round trip is also general:
+# it keeps holding if the encoder's safe-set ever changes.
+KB_DEDUP_REASON_PERCENT_ESCAPE = (
+    "the title contains a '%' sequence that the read path decodes as a "
+    "percent-escape, so ServiceNow would be searched for a different string"
+)
 
 # The duplicate check could not produce a trustworthy answer, so the publish did
 # not happen. Fail-closed: "could not check" is not "nothing found".

--- a/constants.py
+++ b/constants.py
@@ -137,6 +137,12 @@ ERROR_PRIVATE_TASK_ACCESS_DENIED = "Error during private task {operation}: Acces
 ERROR_PRIVATE_TASK_INVALID_REQUEST = "Error during private task {operation}: Invalid request data"
 ERROR_PRIVATE_TASK_NOT_FOUND = "Error during private task {operation}: Task not found"
 ERROR_PRIVATE_TASK_SERVER_ERROR = "Error during private task {operation}: Server error"
+# A write that came back with no record is unconfirmed, not successful. See
+# ERROR_KB_WRITE_UNCONFIRMED for why this stopped being phrased as a success.
+ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED = (
+    "Private task {operation} could not be confirmed: ServiceNow accepted the request "
+    "but returned no record. Check the task before retrying."
+)
 
 # Write allowlist for update_private_task — blocks writes to sys_* metadata,
 # number, or other fields that should never be caller-settable.
@@ -154,6 +160,14 @@ ERROR_KB_ARTICLE_ACCESS_DENIED = "Error during knowledge article {operation}: Ac
 ERROR_KB_ARTICLE_INVALID_REQUEST = "Error during knowledge article {operation}: Invalid request data"
 ERROR_KB_ARTICLE_NOT_FOUND = "Error during knowledge article {operation}: Article not found"
 ERROR_KB_ARTICLE_SERVER_ERROR = "Error during knowledge article {operation}: Server error"
+# A write that came back with no record is unconfirmed, not successful. The old
+# wording ("... successful but no data returned") asserted the write had landed
+# on the strength of the response being empty, which is the one thing an empty
+# response cannot establish.
+ERROR_KB_WRITE_UNCONFIRMED = (
+    "Knowledge article {operation} could not be confirmed: ServiceNow accepted the "
+    "request but returned no record. Check the article before retrying."
+)
 ERROR_KB_PUBLISH_NOT_CONFIRMED = (
     "Publish for {number} could not be confirmed (workflow endpoint may have "
     "failed, or ServiceNow has not yet committed the state change). Re-check "
@@ -282,6 +296,46 @@ KB_VERIFY_FIELDS = ("sys_id", "number", "workflow_state", "short_description")
 # Retired = explicitly killed; outdated = prior version after a newer publish (ServiceNow versioning artefact).
 # Draft / review / published remain blockers because they represent live or pending content.
 KB_DUPLICATE_IGNORED_STATES = {"retired", "outdated"}
+
+# Row cap on the duplicate-check query. The check LIKE-matches in ServiceNow and
+# then exact-matches in Python, so a page that hits this cap may have left the
+# real duplicate behind — a capped page is inconclusive, not clean. Without an
+# explicit limit the instance default applies silently and truncation is
+# indistinguishable from a complete answer.
+KB_DEDUP_QUERY_LIMIT = 200
+
+# Characters that cannot be carried inside an encoded-query value. The read path
+# percent-encodes sysparm_query but keeps the ServiceNow operator characters in
+# its safe-set (http_layer/url_builder.ensure_query_encoded), and it unquotes
+# before re-quoting, so pre-encoding these at the call site does not survive:
+#   "Cost^Center"  ->  short_descriptionLIKECost ^ Center   (two conditions)
+#   "A&B"          ->  short_descriptionLIKEA & B           (a second URL param)
+# Either way the query that runs is not the query that was asked for, and it
+# runs BROADER. A duplicate check cannot be trusted for such a value, so the
+# publish guard treats it as inconclusive rather than clean.
+KB_QUERY_UNSAFE_CHARS = ("^", "&")
+
+# The duplicate check could not produce a trustworthy answer, so the publish did
+# not happen. Fail-closed: "could not check" is not "nothing found".
+ERROR_KB_DUPLICATE_CHECK_INCONCLUSIVE = (
+    "Duplicate check for {number} could not be completed ({reason}), so it was not "
+    "published. Nothing was written. Re-run once the cause is resolved."
+)
+KB_DEDUP_REASON_UNSAFE_CHARS = (
+    "the title contains a character ({chars}) that ServiceNow's encoded-query syntax "
+    "cannot carry inside a value, which would silently widen the search"
+)
+KB_DEDUP_REASON_TRUNCATED = (
+    "the search hit its {limit}-row cap, so a duplicate may have been left off the page"
+)
+
+# The publish workflow fired but the confirming read failed. Distinct from a
+# publish that is known not to have happened: this one may well have committed.
+ERROR_KB_PUBLISH_VERIFY_UNREADABLE = (
+    "Publish for {number} was submitted but could not be confirmed: the verification "
+    "read failed ({message}). The article may or may not be published; check its state "
+    "before retrying, as retrying may publish a second version."
+)
 
 # KB publish workflow tuning — the SN /qonv/.../publish endpoint runs duplicate
 # check + state transition + reindex synchronously and routinely takes 60-90s.

--- a/http_layer/request_dispatcher.py
+++ b/http_layer/request_dispatcher.py
@@ -66,6 +66,7 @@ def _redact_url(url: str) -> str:
 _TYPED_CALLERS: frozenset[str] = frozenset({
     "Table_Tools.generic_table_tools",
     "Table_Tools.cmdb_tools",
+    "Table_Tools.kb_article_tools",
 })
 
 # This package's own name, used for the frame-walk boundary test below.

--- a/tests/test_http_layer_errors.py
+++ b/tests/test_http_layer_errors.py
@@ -161,6 +161,7 @@ class TestLegacyNoneShim:
         assert dispatcher._TYPED_CALLERS == frozenset({
             "Table_Tools.generic_table_tools",
             "Table_Tools.cmdb_tools",
+            "Table_Tools.kb_article_tools",
         })
 
     def test_typed_caller_names_are_real_module_names(self):

--- a/tests/test_kb_article_tools.py
+++ b/tests/test_kb_article_tools.py
@@ -9,7 +9,10 @@ import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 import httpx
 
+from constants import ERROR_KB_WRITE_UNCONFIRMED
+from http_layer.errors import ErrorCode, ServiceNowRequestError
 from Table_Tools.kb_article_tools import (
+    KbDuplicateCheckInconclusive,
     _handle_kb_error,
     _unwrap_kb_write_response,
     _write_kb_article,
@@ -31,6 +34,13 @@ def _make_http_status_error(status_code: int) -> httpx.HTTPStatusError:
     response = MagicMock()
     response.status_code = status_code
     return httpx.HTTPStatusError(str(status_code), request=MagicMock(), response=response)
+
+
+def _timeout() -> ServiceNowRequestError:
+    """The shape a failed GET now arrives in for this module (v4.4 Tier 0.3)."""
+    return ServiceNowRequestError(
+        ErrorCode.TIMEOUT, "ServiceNow request timed out", retryable=True
+    )
 
 
 class TestHandleKbError:
@@ -62,13 +72,16 @@ class TestUnwrapKbWriteResponse:
         result = _unwrap_kb_write_response({"result": {"number": "KB0001234"}}, "update")
         assert result == {"number": "KB0001234"}
 
-    def test_unwrap_empty_dict_returns_fallback(self):
+    def test_unwrap_empty_dict_is_unconfirmed_not_success(self):
+        """An empty write response cannot establish that the write landed."""
         result = _unwrap_kb_write_response({}, "publish")
-        assert "successful but no data returned" in result
+        assert result == ERROR_KB_WRITE_UNCONFIRMED.format(operation="publish")
+        assert "successful" not in result
 
-    def test_unwrap_none_returns_fallback(self):
+    def test_unwrap_none_is_unconfirmed_not_success(self):
         result = _unwrap_kb_write_response(None, "retire")
-        assert "successful but no data returned" in result
+        assert result == ERROR_KB_WRITE_UNCONFIRMED.format(operation="retire")
+        assert "successful" not in result
 
     def test_unwrap_dict_without_result_key_returns_as_is(self):
         result = _unwrap_kb_write_response({"some": "value"}, "update")
@@ -97,12 +110,13 @@ class TestWriteKbArticle:
             )
 
     @pytest.mark.asyncio
-    async def test_none_result_returns_fallback(self):
+    async def test_none_result_is_unconfirmed_not_success(self):
         with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
             mock_request.return_value = None
 
             result = await _write_kb_article("PATCH", "http://x", {}, "update")
-            assert "successful but no data returned" in result
+            assert result == ERROR_KB_WRITE_UNCONFIRMED.format(operation="update")
+            assert "successful" not in result
 
     @pytest.mark.asyncio
     async def test_http_status_error_mapped(self):
@@ -141,11 +155,17 @@ class TestGetKbArticleSysId:
             assert await _get_kb_article_sys_id("KB9999999") is None
 
     @pytest.mark.asyncio
-    async def test_none_response_returns_none(self):
-        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
-            mock_request.return_value = None
+    async def test_read_failure_propagates_instead_of_looking_absent(self):
+        """Decision (d): None means absent, so a failed read must NOT return None.
 
-            assert await _get_kb_article_sys_id("KB0001234") is None
+        The old test mocked None here and asserted None came back, which is now an
+        input the transport cannot produce -- a failed GET raises. Returning None
+        is what made update/retire report "article not found" for a timeout.
+        """
+        with patch('Table_Tools.kb_article_tools.make_nws_request',
+                   side_effect=_timeout()):
+            with pytest.raises(ServiceNowRequestError):
+                await _get_kb_article_sys_id("KB0001234")
 
     @pytest.mark.asyncio
     async def test_none_result_key_returns_none(self):
@@ -269,11 +289,11 @@ class TestGetKbArticleMeta:
             assert await _get_kb_article_meta("KB9999999") is None
 
     @pytest.mark.asyncio
-    async def test_none_response_returns_none(self):
-        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
-            mock_request.return_value = None
-
-            assert await _get_kb_article_meta("KB0001234") is None
+    async def test_read_failure_propagates_instead_of_looking_absent(self):
+        with patch('Table_Tools.kb_article_tools.make_nws_request',
+                   side_effect=_timeout()):
+            with pytest.raises(ServiceNowRequestError):
+                await _get_kb_article_meta("KB0001234")
 
     @pytest.mark.asyncio
     async def test_workflow_state_appended_to_query_when_provided(self):
@@ -338,11 +358,17 @@ class TestCheckKbDuplicates:
             assert await _check_kb_duplicates("Test", "KB0001234") == []
 
     @pytest.mark.asyncio
-    async def test_none_response_returns_empty_list(self):
-        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
-            mock_request.return_value = None
+    async def test_read_failure_is_not_an_empty_duplicate_list(self):
+        """The headline fix: [] means "checked, clear" and nothing else.
 
-            assert await _check_kb_duplicates("Test", "KB0001234") == []
+        The old test asserted [] for a failed read. Because the only reading of []
+        available to publish_knowledge_article is "clear to publish", that made a
+        timeout during the duplicate check publish the article unchecked.
+        """
+        with patch('Table_Tools.kb_article_tools.make_nws_request',
+                   side_effect=_timeout()):
+            with pytest.raises(ServiceNowRequestError):
+                await _check_kb_duplicates("Test", "KB0001234")
 
     @pytest.mark.asyncio
     async def test_retired_duplicate_skipped(self):
@@ -700,11 +726,16 @@ class TestVerifyKbPublished:
             assert row is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_request_fails(self):
-        with patch('Table_Tools.kb_article_tools.make_nws_request') as mock_request:
-            mock_request.return_value = None
-            row = await _verify_kb_published("KB0001234")
-            assert row is None
+    async def test_read_failure_propagates_instead_of_looking_unpublished(self):
+        """None means "no Published row yet"; a failed read is not that.
+
+        Conflating them made _publish_with_verify treat an unreadable verify as
+        evidence the publish had not committed, and fire it a second time.
+        """
+        with patch('Table_Tools.kb_article_tools.make_nws_request',
+                   side_effect=_timeout()):
+            with pytest.raises(ServiceNowRequestError):
+                await _verify_kb_published("KB0001234")
 
     @pytest.mark.asyncio
     async def test_query_filters_by_published_state(self):

--- a/tests/test_typed_read_kb_article_tools.py
+++ b/tests/test_typed_read_kb_article_tools.py
@@ -189,6 +189,52 @@ class TestDuplicateCheckOutcomes:
         with pytest.raises(KbDuplicateCheckInconclusive):
             await _check_kb_duplicates("Sales & Marketing", "KB0001234")
 
+    @pytest.mark.parametrize("title, becomes", [
+        ("Deal 20%2C off", "Deal 20, off"),
+        ("Reset %41dmin password", "Reset Admin password"),
+        ("Up 20%DB backups", None),  # invalid byte -> U+FFFD
+    ])
+    @pytest.mark.asyncio
+    async def test_percent_escape_in_the_title_is_inconclusive(self, title, becomes):
+        """The quiet one: ensure_query_encoded unquotes, so '%XY' is decoded.
+
+        ServiceNow would be searched for a different string than the title, and
+        `unquote` never raises, so nothing announces it. That silently returned
+        `[]` and published the article.
+        """
+        if becomes is not None:
+            from urllib.parse import unquote
+            assert unquote(title) == becomes, "premise of the test"
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            with pytest.raises(KbDuplicateCheckInconclusive) as excinfo:
+                await _check_kb_duplicates(title, "KB0001234")
+        request.assert_not_called()
+        assert "percent-escape" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_a_bare_percent_is_not_refused(self):
+        """No false positives: a '%' not followed by hex digits survives intact.
+
+        Blacklisting '%' outright would refuse an ordinary title, which is why the
+        check is a round trip on the value rather than a character list.
+        """
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            request.return_value = {"result": []}
+            assert await _check_kb_duplicates("Cut costs by 50% off", "KB0001234") == []
+        request.assert_called_once()
+
+    @pytest.mark.parametrize("char", list("=<>():@!"))
+    @pytest.mark.asyncio
+    async def test_the_rest_of_the_operator_safe_set_is_not_refused(self, char):
+        """Only ^ and & break structure; the others survive the round trip.
+
+        Pinned so a future widening of KB_QUERY_UNSAFE_CHARS has to be deliberate
+        rather than a precaution that quietly blocks publishes.
+        """
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            request.return_value = {"result": []}
+            assert await _check_kb_duplicates(f"Cost{char}Center guide", "KB0001234") == []
+
     @pytest.mark.asyncio
     async def test_truncated_page_is_inconclusive_not_clear(self):
         """A full page may have left the real duplicate off the end of it."""

--- a/tests/test_typed_read_kb_article_tools.py
+++ b/tests/test_typed_read_kb_article_tools.py
@@ -1,0 +1,603 @@
+"""Typed read failures in the KB article tools (v4.4 Tier 0.3, PR C).
+
+`Table_Tools.kb_article_tools` joins `_TYPED_CALLERS`, so a failed GET raises
+instead of returning None. Four things are locked here:
+
+1. **The publish guard is fail-closed.** `_check_kb_duplicates` has three
+   outcomes — clear, duplicates-found, inconclusive — and only *clear* permits a
+   publish. Before this, a failed duplicate-check read returned `[]`, the one
+   value `publish_knowledge_article` reads as "clear to publish", so a timeout
+   published the article with the guard silently skipped and reported success.
+
+2. **An unreadable verify does not re-fire the publish.** The write has already
+   gone out; retrying on the strength of a failed *read* published a second
+   version. Exactly one fire, status `unconfirmed`.
+
+3. **Pre-write reads distinguish absent from failed** (decision (d)), so a write
+   no longer reports "article not found" for a timeout.
+
+4. **A failure shape is never re-wrapped as success.** `_normalize_publish_result`
+   reports `published` by fall-through, so every non-success shape has to be
+   recognised ahead of it.
+
+The assertions to keep honest are the ones about what did NOT happen: no publish
+POST fired, exactly one fired, the batch did not lose its other rows. Those are
+the properties that would silently regress.
+"""
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from constants import (
+    ERROR_KB_ARTICLE_NOT_FOUND_OP,
+    KB_DEDUP_QUERY_LIMIT,
+)
+from http_layer.errors import ErrorCode, ServiceNowRequestError
+from Table_Tools.kb_article_tools import (
+    KbDuplicateCheckInconclusive,
+    _check_kb_duplicates,
+    _normalize_publish_result,
+    _publish_with_verify,
+    check_kb_duplicates,
+    publish_knowledge_article,
+    publish_knowledge_articles,
+    retire_knowledge_article,
+    update_knowledge_article,
+)
+
+TIMEOUT = ServiceNowRequestError(
+    ErrorCode.TIMEOUT, "ServiceNow request timed out", retryable=True
+)
+FORBIDDEN = ServiceNowRequestError(
+    ErrorCode.FORBIDDEN, "ServiceNow returned HTTP 403", status_code=403
+)
+
+META = {"sys_id": "a" * 32, "short_description": "How to reset a password"}
+PUBLISHED_ROW = {"number": "KB0001234", "workflow_state": "Published"}
+
+
+def _no_sleep():
+    return patch("Table_Tools.kb_article_tools.asyncio.sleep", new_callable=AsyncMock)
+
+
+def _assert_plain_failure(response, code):
+    assert isinstance(response, dict), response
+    assert set(response) == {"error"}, response
+    assert response["error"]["code"] == code
+
+
+class TestPublishGuardIsFailClosed:
+    """A publish requires a duplicate check that positively came back clear."""
+
+    @pytest.mark.asyncio
+    async def test_failed_duplicate_read_does_not_publish(self):
+        """The headline bug. A timeout in the guard must not become permission."""
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(return_value=META),
+        ), patch(
+            "Table_Tools.kb_article_tools._check_kb_duplicates",
+            new=AsyncMock(side_effect=TIMEOUT),
+        ), patch(
+            "Table_Tools.kb_article_tools._publish_with_verify", new=AsyncMock()
+        ) as publish:
+            result = await publish_knowledge_article("KB0001234")
+
+        publish.assert_not_called()
+        assert result["success"] is False
+        assert result["duplicate_check"] == "inconclusive"
+        assert "not published" in result["message"]
+        assert "Nothing was written" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_inconclusive_check_does_not_publish(self):
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(return_value=META),
+        ), patch(
+            "Table_Tools.kb_article_tools._check_kb_duplicates",
+            new=AsyncMock(side_effect=KbDuplicateCheckInconclusive("the reason")),
+        ), patch(
+            "Table_Tools.kb_article_tools._publish_with_verify", new=AsyncMock()
+        ) as publish:
+            result = await publish_knowledge_article("KB0001234")
+
+        publish.assert_not_called()
+        assert result["duplicate_check"] == "inconclusive"
+        assert "the reason" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_clear_check_still_publishes(self):
+        """The guard must not have become so strict that nothing can publish."""
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(return_value=META),
+        ), patch(
+            "Table_Tools.kb_article_tools._check_kb_duplicates",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "Table_Tools.kb_article_tools._publish_with_verify",
+            new=AsyncMock(return_value=PUBLISHED_ROW),
+        ) as publish:
+            result = await publish_knowledge_article("KB0001234")
+
+        publish.assert_called_once()
+        assert result == PUBLISHED_ROW
+
+    @pytest.mark.asyncio
+    async def test_found_duplicates_still_block_with_their_blockers(self):
+        dupes = [{"number": "KB0009999", "workflow_state": "published"}]
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(return_value=META),
+        ), patch(
+            "Table_Tools.kb_article_tools._check_kb_duplicates",
+            new=AsyncMock(return_value=dupes),
+        ), patch(
+            "Table_Tools.kb_article_tools._publish_with_verify", new=AsyncMock()
+        ) as publish:
+            result = await publish_knowledge_article("KB0001234")
+
+        publish.assert_not_called()
+        assert result["duplicates"] == dupes
+        assert "duplicate_check" not in result
+
+    @pytest.mark.asyncio
+    async def test_failed_meta_read_is_not_article_not_found(self):
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(side_effect=TIMEOUT),
+        ), patch(
+            "Table_Tools.kb_article_tools._publish_with_verify", new=AsyncMock()
+        ) as publish:
+            result = await publish_knowledge_article("KB0001234")
+
+        publish.assert_not_called()
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+        assert result != ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB0001234")
+
+    @pytest.mark.asyncio
+    async def test_absent_article_keeps_its_not_found_message(self):
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await publish_knowledge_article("KB9999999")
+        assert result == ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB9999999")
+
+
+class TestDuplicateCheckOutcomes:
+    """`[]` must mean "checked, clear" and nothing else."""
+
+    @pytest.mark.asyncio
+    async def test_unsafe_character_is_inconclusive_before_any_request(self):
+        """A '^' in the title splits the encoded query, silently widening it.
+
+        Percent-encoding at the call site does not help: ensure_query_encoded
+        unquotes before re-quoting and keeps '^' in its safe-set, so the operator
+        survives either way. The check therefore refuses to answer.
+        """
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            with pytest.raises(KbDuplicateCheckInconclusive) as excinfo:
+                await _check_kb_duplicates("Cost^Center report", "KB0001234")
+        request.assert_not_called()
+        assert "widen" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_ampersand_is_also_inconclusive(self):
+        with pytest.raises(KbDuplicateCheckInconclusive):
+            await _check_kb_duplicates("Sales & Marketing", "KB0001234")
+
+    @pytest.mark.asyncio
+    async def test_truncated_page_is_inconclusive_not_clear(self):
+        """A full page may have left the real duplicate off the end of it."""
+        rows = [
+            {"number": f"KB{i:07d}", "short_description": "other", "workflow_state": "published"}
+            for i in range(KB_DEDUP_QUERY_LIMIT)
+        ]
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            request.return_value = {"result": rows}
+            with pytest.raises(KbDuplicateCheckInconclusive) as excinfo:
+                await _check_kb_duplicates("How to reset a password", "KB0001234")
+        assert str(KB_DEDUP_QUERY_LIMIT) in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_a_definite_duplicate_beats_truncation(self):
+        """Both outcomes block, so report the specific one."""
+        rows = [
+            {"number": f"KB{i:07d}", "short_description": "other", "workflow_state": "published"}
+            for i in range(KB_DEDUP_QUERY_LIMIT - 1)
+        ] + [
+            {"number": "KB0009999", "short_description": "How to reset a password",
+             "workflow_state": "published"}
+        ]
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            request.return_value = {"result": rows}
+            matches = await _check_kb_duplicates("How to reset a password", "KB0001234")
+        assert [m["number"] for m in matches] == ["KB0009999"]
+
+    @pytest.mark.asyncio
+    async def test_short_page_with_no_match_is_clear(self):
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            request.return_value = {"result": [
+                {"number": "KB0002222", "short_description": "something else",
+                 "workflow_state": "published"},
+            ]}
+            assert await _check_kb_duplicates("How to reset a password", "KB0001234") == []
+
+    @pytest.mark.asyncio
+    async def test_query_carries_an_explicit_row_cap(self):
+        """Without a limit the instance default applies and truncation is invisible."""
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            request.return_value = {"result": []}
+            await _check_kb_duplicates("How to reset a password", "KB0001234")
+        url = request.call_args.args[0]
+        assert f"sysparm_limit={KB_DEDUP_QUERY_LIMIT}" in url
+
+
+class TestUnreadableVerifyDoesNotRefire:
+    @pytest.mark.asyncio
+    async def test_failed_verify_fires_the_publish_exactly_once(self):
+        with _no_sleep(), patch(
+            "Table_Tools.kb_article_tools._fire_publish",
+            new=AsyncMock(return_value=None),
+        ) as fire, patch(
+            "Table_Tools.kb_article_tools._verify_kb_published",
+            new=AsyncMock(side_effect=TIMEOUT),
+        ):
+            result = await _publish_with_verify("a" * 32, "KB0001234")
+
+        assert fire.call_count == 1, "an unreadable verify must not re-fire the write"
+        assert result["publish_confirmed"] is False
+        assert result["success"] is False
+        assert result["error"]["code"] == ErrorCode.TIMEOUT
+        assert "may or may not be published" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_still_draft_after_verify_does_retry(self):
+        """The retry path is for a verify that positively says "not published yet"."""
+        with _no_sleep(), patch(
+            "Table_Tools.kb_article_tools._fire_publish",
+            new=AsyncMock(return_value=None),
+        ) as fire, patch(
+            "Table_Tools.kb_article_tools._verify_kb_published",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "Table_Tools.kb_article_tools._get_kb_article_sys_id",
+            new=AsyncMock(return_value="b" * 32),
+        ):
+            await _publish_with_verify("a" * 32, "KB0001234")
+
+        assert fire.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_a_failed_sys_id_refresh_keeps_the_sys_id_in_hand(self):
+        """The refresh between attempts is best effort, not a reason to abort."""
+        seen = []
+
+        async def fire(sys_id):
+            seen.append(sys_id)
+            return None
+
+        with _no_sleep(), patch(
+            "Table_Tools.kb_article_tools._fire_publish", new=fire
+        ), patch(
+            "Table_Tools.kb_article_tools._verify_kb_published",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "Table_Tools.kb_article_tools._get_kb_article_sys_id",
+            new=AsyncMock(side_effect=TIMEOUT),
+        ):
+            await _publish_with_verify("a" * 32, "KB0001234")
+
+        assert seen == ["a" * 32, "a" * 32]
+
+
+class TestNormalizePublishResultNeverInventsSuccess:
+    """`published` is the fall-through, so every other shape must be caught first."""
+
+    def test_a_bare_failure_dict_is_not_reported_as_published(self):
+        row = _normalize_publish_result("KB0001234", TIMEOUT.to_error_dict())
+        assert row["status"] == "error"
+        assert row["code"] == ErrorCode.TIMEOUT
+        assert row["message"] == "ServiceNow request timed out"
+
+    def test_unconfirmed_is_its_own_status(self):
+        result = {
+            "success": False,
+            "publish_confirmed": False,
+            "message": "submitted but unconfirmed",
+            "error": {"code": ErrorCode.TIMEOUT, "message": "timed out"},
+        }
+        row = _normalize_publish_result("KB0001234", result)
+        assert row["status"] == "unconfirmed"
+        assert row["error"]["code"] == ErrorCode.TIMEOUT
+
+    def test_inconclusive_block_keeps_its_marker(self):
+        result = {
+            "success": False,
+            "duplicate_check": "inconclusive",
+            "message": "could not be completed",
+            "duplicates": [],
+        }
+        row = _normalize_publish_result("KB0001234", result)
+        assert row["status"] == "blocked"
+        assert row["duplicate_check"] == "inconclusive"
+
+    def test_duplicates_block_reports_its_blockers(self):
+        result = {
+            "success": False,
+            "message": "Duplicate KB article(s) found.",
+            "duplicates": [{"number": "KB0009999"}],
+        }
+        row = _normalize_publish_result("KB0001234", result)
+        assert row["status"] == "blocked"
+        assert row["blockers"] == [{"number": "KB0009999"}]
+
+    def test_a_published_row_is_still_published(self):
+        row = _normalize_publish_result("KB0001234", PUBLISHED_ROW)
+        assert row["status"] == "published"
+        assert row["workflow_state"] == "Published"
+
+    def test_a_non_dict_non_str_is_an_error_not_a_publish(self):
+        row = _normalize_publish_result("KB0001234", 42)
+        assert row["status"] == "error"
+
+
+class TestBatchesKeepTheirOtherRows:
+    @pytest.mark.asyncio
+    async def test_one_articles_raise_does_not_discard_the_batch(self):
+        """Some of these are already published by the time a later one fails."""
+        async def publish(number):
+            if number == "KB0002222":
+                raise TIMEOUT
+            return PUBLISHED_ROW
+
+        with patch("Table_Tools.kb_article_tools.publish_knowledge_article", new=publish):
+            result = await publish_knowledge_articles(
+                ["KB0001111", "KB0002222", "KB0003333"]
+            )
+
+        rows = {r["number"]: r for r in result["result"]}
+        assert len(rows) == 3
+        assert rows["KB0001111"]["status"] == "published"
+        assert rows["KB0003333"]["status"] == "published"
+        assert rows["KB0002222"]["status"] == "error"
+        assert rows["KB0002222"]["message"] == "ServiceNow request timed out"
+
+    @pytest.mark.asyncio
+    async def test_an_unexpected_bug_in_one_article_is_still_one_row(self):
+        async def publish(number):
+            if number == "KB0002222":
+                raise RuntimeError("boom")
+            return PUBLISHED_ROW
+
+        with patch("Table_Tools.kb_article_tools.publish_knowledge_article", new=publish):
+            result = await publish_knowledge_articles(["KB0001111", "KB0002222"])
+
+        rows = {r["number"]: r for r in result["result"]}
+        assert rows["KB0001111"]["status"] == "published"
+        assert rows["KB0002222"]["status"] == "error"
+        assert "RuntimeError" in rows["KB0002222"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_dup_check_row_for_a_failed_read_is_not_a_clean_bill_of_health(self):
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(return_value=META),
+        ), patch(
+            "Table_Tools.kb_article_tools._check_kb_duplicates",
+            new=AsyncMock(side_effect=FORBIDDEN),
+        ):
+            result = await check_kb_duplicates(["KB0001234"])
+
+        row = result["result"][0]
+        assert row["duplicate_check"] == "inconclusive"
+        assert row["error"] == "ServiceNow returned HTTP 403"
+        assert "has_duplicate" not in row, (
+            "a missing answer must not be readable as 'no duplicates'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_dup_check_row_for_a_failed_meta_read_is_also_inconclusive(self):
+        """The lookup half of the row can fail too, and reads the same way."""
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(side_effect=TIMEOUT),
+        ):
+            result = await check_kb_duplicates(["KB0001234"])
+
+        row = result["result"][0]
+        assert row["duplicate_check"] == "inconclusive"
+        assert "has_duplicate" not in row
+
+    @pytest.mark.asyncio
+    async def test_dup_check_row_for_an_untrustworthy_query_is_inconclusive(self):
+        """An unsafe title reaches the row as inconclusive, not as 'no duplicates'."""
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(return_value={"sys_id": "a" * 32,
+                                        "short_description": "Cost^Center report"}),
+        ):
+            result = await check_kb_duplicates(["KB0001234"])
+
+        row = result["result"][0]
+        assert row["duplicate_check"] == "inconclusive"
+        assert "widen" in row["error"]
+        assert "has_duplicate" not in row
+
+    @pytest.mark.asyncio
+    async def test_dup_check_row_for_a_real_answer_still_carries_has_duplicate(self):
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_meta",
+            new=AsyncMock(return_value=META),
+        ), patch(
+            "Table_Tools.kb_article_tools._check_kb_duplicates",
+            new=AsyncMock(return_value=[]),
+        ):
+            result = await check_kb_duplicates(["KB0001234"])
+
+        assert result["result"][0]["has_duplicate"] is False
+
+
+class TestOutcomeErrorMessage:
+    """Per-exception-type messages for anything that escapes a batch coroutine.
+
+    Both public batch entry points catch their own errors, so this is the net
+    under an unexpected escape. Tested directly rather than left uncovered: the
+    point of the net is that it produces a usable row, and that is cheap to
+    verify but invisible in the batch tests.
+    """
+
+    def test_typed_read_failure_uses_its_message(self):
+        from Table_Tools.kb_article_tools import _outcome_error_message
+        assert _outcome_error_message(TIMEOUT) == "ServiceNow request timed out"
+
+    def test_inconclusive_uses_its_reason(self):
+        from Table_Tools.kb_article_tools import _outcome_error_message
+        assert _outcome_error_message(
+            KbDuplicateCheckInconclusive("the page was capped")
+        ) == "the page was capped"
+
+    def test_anything_else_is_named_by_its_type(self):
+        from Table_Tools.kb_article_tools import _outcome_error_message
+        assert _outcome_error_message(RuntimeError("boom")) == "RuntimeError: boom"
+
+
+class TestPreWriteReadsDistinguishAbsentFromFailed:
+    """Decision (d): a write never reports "not found" because a lookup failed."""
+
+    @pytest.mark.asyncio
+    async def test_update_failed_lookup_is_not_not_found(self):
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_sys_id",
+            new=AsyncMock(side_effect=TIMEOUT),
+        ), patch(
+            "Table_Tools.kb_article_tools._write_kb_article", new=AsyncMock()
+        ) as write:
+            result = await update_knowledge_article("KB0001234", {"short_description": "x"})
+
+        write.assert_not_called()
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_update_absent_article_keeps_not_found(self):
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_sys_id",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await update_knowledge_article("KB9999999", {"short_description": "x"})
+        assert result == ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB9999999")
+
+    @pytest.mark.asyncio
+    async def test_retire_failed_lookup_is_not_not_found(self):
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_sys_id",
+            new=AsyncMock(side_effect=FORBIDDEN),
+        ), patch(
+            "Table_Tools.kb_article_tools._call_kb_workflow", new=AsyncMock()
+        ) as workflow:
+            result = await retire_knowledge_article("KB0001234")
+
+        workflow.assert_not_called()
+        _assert_plain_failure(result, ErrorCode.FORBIDDEN)
+
+    @pytest.mark.asyncio
+    async def test_retire_absent_article_keeps_not_found(self):
+        with patch(
+            "Table_Tools.kb_article_tools._get_kb_article_sys_id",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await retire_knowledge_article("KB9999999")
+        assert result == ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB9999999")
+
+
+class TestEndToEndThroughTheRealDispatcher:
+    """Proves the `_TYPED_CALLERS` entry resolves for this module.
+
+    Without the entry the shim returns None, `_check_kb_duplicates` answers `[]`,
+    and the article publishes — so these fail if the entry is reverted, which the
+    mock-at-the-module-seam tests above cannot detect on their own.
+    """
+
+    @pytest.fixture
+    def transport(self, monkeypatch):
+        """Fake the transport under the real dispatcher; record every write."""
+        import http_layer.request_dispatcher as dispatcher
+
+        writes = []
+
+        class FakeClient:
+            async def make_authenticated_request(self, method, url, raise_for_status=True, json=None):
+                writes.append((method, url))
+                return {"result": PUBLISHED_ROW}
+
+        def install(get_handler):
+            async def fake_get(url):
+                return get_handler(url)
+            monkeypatch.setattr(dispatcher, "make_oauth_request", fake_get)
+            monkeypatch.setattr(dispatcher, "get_oauth_client", lambda: FakeClient())
+            return writes
+
+        return install
+
+    @staticmethod
+    def _meta_ok_dedup(dedup):
+        """GET handler: meta resolves, the dedup query does whatever `dedup` says."""
+        def handler(url):
+            if "short_descriptionLIKE" in url:
+                return dedup() if callable(dedup) else dedup
+            if "sys_id" in url and "short_description" in url:
+                return {"result": [META]}
+            return {"result": []}
+        return handler
+
+    @pytest.mark.asyncio
+    async def test_dedup_timeout_blocks_the_publish(self, transport):
+        def boom():
+            raise TimeoutError()
+
+        writes = transport(self._meta_ok_dedup(boom))
+        with _no_sleep():
+            result = await publish_knowledge_article("KB0001234")
+
+        assert writes == [], "the publish workflow must not have been called"
+        assert result["duplicate_check"] == "inconclusive"
+
+    @pytest.mark.asyncio
+    async def test_clear_dedup_publishes(self, transport):
+        def handler(url):
+            if "short_descriptionLIKE" in url:
+                return {"result": []}
+            if "workflow_state=published" in url or "workflow_state%3Dpublished" in url:
+                return {"result": [PUBLISHED_ROW]}
+            if "sys_id" in url and "short_description" in url:
+                return {"result": [META]}
+            return {"result": []}
+
+        writes = transport(handler)
+        with _no_sleep():
+            result = await publish_knowledge_article("KB0001234")
+
+        assert len(writes) == 1
+        assert writes[0][0] == "POST"
+        assert result == PUBLISHED_ROW
+
+    @pytest.mark.asyncio
+    async def test_verify_timeout_leaves_exactly_one_write(self, transport):
+        def handler(url):
+            if "short_descriptionLIKE" in url:
+                return {"result": []}
+            if "workflow_state=published" in url or "workflow_state%3Dpublished" in url:
+                raise TimeoutError()
+            if "sys_id" in url and "short_description" in url:
+                return {"result": [META]}
+            return {"result": []}
+
+        writes = transport(handler)
+        with _no_sleep():
+            result = await publish_knowledge_article("KB0001234")
+
+        assert len(writes) == 1, "an unreadable verify must not re-fire the publish"
+        assert result["publish_confirmed"] is False

--- a/tests/test_vtb_task_tools.py
+++ b/tests/test_vtb_task_tools.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 import httpx
 
 # Import functions to test
+from constants import ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED
 from Table_Tools.vtb_task_tools import (
     _write_private_task,
     _unwrap_write_response,
@@ -61,7 +62,8 @@ class TestWritePrivateTask:
                 "creation",
             )
 
-            assert "successful but no data returned" in result
+            assert result == ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="creation")
+            assert "successful" not in result
 
     @pytest.mark.asyncio
     async def test_write_none_result_returns_fallback_string(self):
@@ -75,7 +77,8 @@ class TestWritePrivateTask:
                 "creation",
             )
 
-            assert "successful but no data returned" in result
+            assert result == ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="creation")
+            assert "successful" not in result
 
     @pytest.mark.asyncio
     async def test_write_401_returns_auth_failed(self):
@@ -169,13 +172,16 @@ class TestUnwrapWriteResponse:
         result = _unwrap_write_response({"result": {"number": "VTB0001"}}, "creation")
         assert result == {"number": "VTB0001"}
 
-    def test_unwrap_empty_dict_returns_fallback(self):
+    def test_unwrap_empty_dict_is_unconfirmed_not_success(self):
+        """An empty write response cannot establish that the write landed."""
         result = _unwrap_write_response({}, "creation")
-        assert "successful but no data returned" in result
+        assert result == ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="creation")
+        assert "successful" not in result
 
-    def test_unwrap_none(self):
+    def test_unwrap_none_is_unconfirmed_not_success(self):
         result = _unwrap_write_response(None, "update")
-        assert "successful but no data returned" in result
+        assert result == ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="update")
+        assert "successful" not in result
 
     def test_unwrap_dict_without_result_key(self):
         result = _unwrap_write_response({"some": "value"}, "creation")


### PR DESCRIPTION
PR C of the v4.4 Tier 0.3 typed-read chain (after #64, #65). Module: `Table_Tools/kb_article_tools.py`, plus the shared write helper.

**This one is not just a migration.** It closes a fail-open in the publish guard that is live on `main` today, found while scoping the PR and confirmed by running the real code with only the transport faked.

## The fail-open

`_check_kb_duplicates` returned `[]` when its read failed. The only reading of `[]` available to `publish_knowledge_article` is "clear to publish". So a timeout during the duplicate check published the article with the guard silently skipped — and reported success:

```
dedup GET raises TimeoutError
  -> returned : {'number': 'KB0001234', 'workflow_state': 'Published'}
  -> writes   : [('POST', '.../articles/{sys_id}/publish')]
```

`tests/test_kb_article_tools.py` asserted that behavior (`return_value = None` → `== []`), so it read as intended design rather than a defect.

Per the decision in this thread, the guard is now **fail-closed**. The check has three outcomes, not two — **clear**, **duplicates-found**, **inconclusive** — and only *clear* permits a publish. Inconclusive covers every way the check can fail to answer:

| cause | why it is not "clear" |
|---|---|
| read failed | the check never ran |
| title contains `^` or `&` | the encoded query cannot carry these inside a value, and the query that runs is **broader** than the one asked for |
| title contains a `%XY` percent-escape | the read path *decodes* it, so ServiceNow is searched for a **different string** |
| result page hit its row cap | the duplicate may be off the end of the page |

A definite duplicate still beats an inconclusive verdict — both block, so report the specific one.

### On the `^` / `&` case

Worth stating plainly because it defeats the obvious fix. `ensure_query_encoded` keeps the ServiceNow operators in its safe-set **and unquotes before re-quoting**, so percent-encoding at the call site does not survive:

```
value "Cost^Center"  ->  short_descriptionLIKECost ^ Center      (two conditions)
value "A&B"          ->  short_descriptionLIKEA & B              (a second URL param)
```

`quote(v, safe='')` at the call site is undone by the `unquote`. The encoder is **not** touched here: it is shared by every table and governed by the locked token-optimization invariant. Logging it as a separate item — it also affects `cmdb_tools`' attribute search and the generic text search, where the consequence is a silently widened query rather than a skipped guard.

### And the quieter `%` case (found in review)

The same `unquote` decodes any `%` followed by two hex digits, so the search string silently stops matching the title — and `unquote` never raises, so neither of the guard's raises fired. `[]` came back and the article published. Same fail-open, quieter route:

```
"Deal 20%2C off"         → searched as "Deal 20, off"
"Reset %41dmin password" → searched as "Reset Admin password"
"Up 20%DB backups"       → invalid byte, then U+FFFD
```

Detected by **round trip** (`unquote(value) == value`) rather than by blacklisting `%`, which was the review's suggestion: a bare `%` not followed by hex digits survives intact, so a blacklist would refuse an ordinary title like `"50% off"`. The round trip is also the condition that actually matters, so it keeps holding if the encoder's safe-set changes.

While there, I measured the entire safe-set instead of assuming `^`/`&` were the only structural offenders: they are. `= < > ( ) : @ !` all survive intact, and a parametrized test pins that so widening the list has to be deliberate rather than a precaution that quietly blocks publishes.

## Three more fixes in the same area

**An unreadable verify no longer re-fires the publish.** A failed `_verify_kb_published` read was indistinguishable from "not published yet", so `_publish_with_verify` retried — two publish workflows, potentially a second published version, because a *read* failed. Probed at **2 POSTs before, 1 after**. The result carries `publish_confirmed: False` and says the article may or may not be published, since the write did go out. (This was the second policy call in the thread.)

**`_normalize_publish_result` reported a failure as a success.** `published` is the fall-through, and no branch recognised the `{"error": ...}` shape — so the typed failure this tier introduces would have been reported as `status: "published", workflow_state: None`. Every non-success shape is now matched ahead of it. Statuses: `published` / `blocked` / `unconfirmed` / `error`.

**Both batch tools now `gather(..., return_exceptions=True)`.** This one was *prospective*, not live — I said otherwise earlier in the thread and was wrong. Today the shim's `None` becomes a per-article "not found" row and the batch completes. Once this module raises, one article's failure aborts the gather and discards the rows for articles that had **already been published**. Simulated at 2 published-and-unreported before the fix.

## Migration mechanics

- `_TYPED_CALLERS += "Table_Tools.kb_article_tools"`.
- **Decision (d)**: `_get_kb_article_sys_id` and `_get_kb_article_meta` return `None` only for a genuinely absent article; the raise propagates. `update` / `publish` / `retire` map it to `to_error_dict()` and keep their existing not-found message for a real absence. The `_get_*_sys_id → None` mocks at `:188,453,476` stay valid precisely because `None` still means "absent" at that boundary.
- **Decision (a)**: `to_error_dict()` only — no `retryable` in the payload, no prose translation.
- **Decision (b)**: empty result sets keep their existing messages.
- The standalone `check_kb_duplicates` tool stops answering `has_duplicate: False` **with no error field** when its read failed. An inconclusive row omits `has_duplicate` entirely rather than let a missing answer read as "no duplicates"; a consumer reaching for that key should fail loudly instead.

## Scope note: the shared write helper

`write_helpers.unwrap_write_response` is assigned to this PR by the handoff, and it is shared with `vtb_task_tools`, so this PR touches two VTB test assertions and one VTB call site. **VTB's typed-read migration is still PR D** — untouched here.

It returned `"<operation> successful but no data returned"` for a falsy response, asserting the write had landed on the strength of an empty response — the one thing an empty response cannot establish. #59 fixed the transport half; this stops treating falsy as success at all. Both subsystems now return an explicit "could not be confirmed" message.

## Behavior changes for the 4.4.0 CHANGELOG

- A KB publish is **refused** when the duplicate check cannot produce a trustworthy answer (read failure, unsafe character in the title, or a truncated result page). Previously it published. This is a deliberate availability-for-correctness trade: a ServiceNow blip now turns a publish into a retryable refusal instead of a silent duplicate.
- The duplicate-check query carries `sysparm_limit=200`. It previously had no explicit limit.
- A publish whose verification read fails reports `unconfirmed` and does **not** retry. Previously it re-fired the workflow once more.
- `publish_knowledge_articles` gained the `unconfirmed` status; a failure row carries the error `code`.
- `check_kb_duplicates` rows for an indeterminate check omit `has_duplicate` and carry `duplicate_check: "inconclusive"` plus `error`.
- KB and VTB writes that return no record now report "could not be confirmed" rather than "successful but no data returned".
- KB and VTB reads that fail during a pre-write lookup report the failure rather than "not found".

## Tests

`tests/test_typed_read_kb_article_tools.py` (new, 49 tests). Four `None`-returning read mocks inverted — they were mocking an input the transport can no longer produce.

**Mutation-checked rather than assumed.** Each of the three core changes was reverted in turn to confirm the suite catches it:

| reverted | caught by |
|---|---|
| `_TYPED_CALLERS` entry | the 2 end-to-end tests (30 module-seam tests stayed green) |
| normalizer's failure branch | `test_a_bare_failure_dict_is_not_reported_as_published` |
| verify guard | `test_failed_verify_fires_the_publish_exactly_once` + the e2e write-count test |
| percent-escape check | the 3 `test_percent_escape_in_the_title_is_inconclusive` cases |

That first row is the reason the end-to-end class exists: tests that patch `Table_Tools.kb_article_tools.make_nws_request` cannot detect the `_TYPED_CALLERS` entry at all, because they never reach the dispatcher.

Coverage on `Table_Tools/kb_article_tools.py`: **98.53% → 99.35%**, measured on the parent `b682b56`. The module was already well covered, so the number barely moves — what it means is that the 75 statements added here are covered, not that coverage improved. `write_helpers.py` stays at 100%.

Suite: **934 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
