### PR TITLE
fix(read): migrate the last two read-path consumers (vtb_task + auth tools)

### DIFF
--- a/Table_Tools/table_tools.py
+++ b/Table_Tools/table_tools.py
@@ -1,15 +1,34 @@
-from http_layer import make_nws_request, NWS_API_BASE
+"""Legacy auth/connectivity test tools.
+
+Read-failure contract (v4.4 Tier 0.3). This module is in
+`http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET raises
+`ServiceNowRequestError` instead of returning None.
+
+Both functions here are registered MCP tools, and both are diagnostics — which
+makes reporting the *specific* classified failure the point rather than a
+nicety. `nowtestauth` answered "Authentication test failed" for any failure
+including a timeout, and `nowtest_auth_input` guessed "table may not exist or no
+permissions" for a read that never completed: the same mislabelling this tier
+removes elsewhere, in the two tools people reach for when they are already
+trying to work out what is broken.
+"""
+from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
 from constants import TABLE_CONFIGS
 
 async def nowtestauth():
     """Test function to verify authentication with ServiceNow standard API."""
     # Use standard sys_user table as a simple auth test
     url = f"{NWS_API_BASE}/api/now/table/sys_user?sysparm_limit=1&sysparm_fields=sys_id,name"
-    data = await make_nws_request(url)
+    try:
+        data = await make_nws_request(url)
+    except ServiceNowRequestError as error:
+        # A diagnostic that says "auth failed" for a timeout sends the reader
+        # after the wrong problem. The code distinguishes AUTH from TIMEOUT.
+        return error.to_error_dict()
     if not data:
         return "Authentication test failed - unable to access ServiceNow API."
     return {
-        "status": "success", 
+        "status": "success",
         "message": "Authentication successful - ServiceNow API accessible",
         "test_endpoint": "/api/now/table/sys_user",
         "records_found": len(data.get('result', []))
@@ -21,10 +40,14 @@ async def nowtest_auth_input(table_name: str):
         return f"Invalid table '{table_name}'. Not in the supported allowlist."
     # Use standard table API to get basic table info
     url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_limit=1"
-    data = await make_nws_request(url)
+    try:
+        data = await make_nws_request(url)
+    except ServiceNowRequestError as error:
+        # Not "the table may not exist": the read did not complete.
+        return error.to_error_dict()
     if not data:
         return f"Unable to access table '{table_name}' - table may not exist or no permissions."
-    
+
     result = data.get('result', [])
     if not result:
         return f"Table '{table_name}' is accessible but contains no records."

--- a/Table_Tools/vtb_task_tools.py
+++ b/Table_Tools/vtb_task_tools.py
@@ -1,4 +1,16 @@
-from http_layer import make_nws_request, NWS_API_BASE
+"""Private task (vtb_task) CRUD.
+
+Read-failure contract (v4.4 Tier 0.3). This module is in
+`http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET raises
+`ServiceNowRequestError` instead of returning None. There is exactly one read
+here — the pre-write `sys_id` lookup — and it is the sensitive kind (decision
+(d)): `_get_task_sys_id` returns None ONLY for a task that genuinely does not
+exist, and a failed lookup propagates. `update_private_task` maps the raise to
+`error.to_error_dict()` and keeps `PRIVATE_TASK_NOT_FOUND_UPDATE` for a real
+absence, so an update no longer tells the user their task does not exist because
+the lookup timed out.
+"""
+from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
 from typing import Any, Dict
 import anyio
 import httpx
@@ -74,7 +86,13 @@ def _prepare_task_create_data(task_data: Dict[str, Any]) -> Dict[str, Any]:
     return create_data
 
 async def _get_task_sys_id(task_number: str) -> str | None:
-    """Get the sys_id for a task by its number."""
+    """Get the sys_id for a task by its number, or None if no such task exists.
+
+    None means "looked, absent" and nothing else (decision (d)). A failed read
+    raises `ServiceNowRequestError` for the caller to map — returning None for it
+    is what let a timeout report the task as missing, on the one code path where
+    that answer stops a write.
+    """
     sys_id_url = f"{NWS_API_BASE}/api/now/table/vtb_task?sysparm_fields=sys_id&sysparm_query=number={task_number}"
     sys_id_data = await make_nws_request(sys_id_url)
 
@@ -119,7 +137,12 @@ async def update_private_task(task_number: str, update_data: Dict[str, Any]) -> 
     if bad:
         return f"Rejected non-updatable field(s): {', '.join(bad)}"
 
-    sys_id = await _get_task_sys_id(task_number)
+    try:
+        sys_id = await _get_task_sys_id(task_number)
+    except ServiceNowRequestError as error:
+        # Not "task not found": the lookup never answered. Reporting absence here
+        # sends the user looking for a task that is probably sitting right there.
+        return error.to_error_dict()
     if not sys_id:
         return PRIVATE_TASK_NOT_FOUND_UPDATE
 

--- a/http_layer/errors.py
+++ b/http_layer/errors.py
@@ -14,8 +14,8 @@ correctly:
     retryable   whether retrying the identical request could plausibly succeed.
 
 Classification lives here rather than in the dispatcher so the mapping is
-unit-testable without an HTTP stack, and so every consumer migrated in PRs 2-7
-reads the same table.
+unit-testable without an HTTP stack, and so every migrated consumer reads the
+same table.
 """
 from __future__ import annotations
 

--- a/http_layer/request_dispatcher.py
+++ b/http_layer/request_dispatcher.py
@@ -67,6 +67,7 @@ _TYPED_CALLERS: frozenset[str] = frozenset({
     "Table_Tools.generic_table_tools",
     "Table_Tools.cmdb_tools",
     "Table_Tools.kb_article_tools",
+    "Table_Tools.vtb_task_tools",
 })
 
 # This package's own name, used for the frame-walk boundary test below.

--- a/http_layer/request_dispatcher.py
+++ b/http_layer/request_dispatcher.py
@@ -49,7 +49,7 @@ def _redact_url(url: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# TEMPORARY MIGRATION SCAFFOLD — v4.4 Tier 0.3, deleted in PR 8 of 8.
+# TEMPORARY MIGRATION SCAFFOLD — v4.4 Tier 0.3, deleted in the next PR.
 #
 # The GET path now raises ServiceNowRequestError instead of returning None.
 # Consumer modules that have not yet been taught to handle it would otherwise
@@ -59,15 +59,23 @@ def _redact_url(url: str) -> str:
 #
 # Opt-in, not opt-out: a caller that nobody has migrated (including tests and
 # any future module) keeps the old behavior, so no PR can accidentally expose a
-# half-migrated module. PRs 2-7 each add one module name; PR 8 deletes this
-# block, `_legacy_none_shim`, and `_calling_module` outright and lets the raise
-# propagate unconditionally.
+# half-migrated module. The set below is now COMPLETE — every module that calls
+# make_nws_request on the read path is listed — which is what makes the
+# unconditional raise safe.
+#
+# That completeness is the precondition for deleting this block, and it is not
+# self-evident: the migration inventory listed four consumer modules and missed
+# `table_tools`, whose two functions are registered MCP tools with no exception
+# handling at all. Before deleting the shim, re-derive the list from the code
+# (`grep -rl make_nws_request --include=*.py`, excluding tests, http_layer and
+# build artefacts under dist/) rather than from any planning document.
 # ---------------------------------------------------------------------------
 _TYPED_CALLERS: frozenset[str] = frozenset({
     "Table_Tools.generic_table_tools",
     "Table_Tools.cmdb_tools",
     "Table_Tools.kb_article_tools",
     "Table_Tools.vtb_task_tools",
+    "Table_Tools.table_tools",
 })
 
 # This package's own name, used for the frame-walk boundary test below.

--- a/tests/test_http_layer_errors.py
+++ b/tests/test_http_layer_errors.py
@@ -162,6 +162,7 @@ class TestLegacyNoneShim:
             "Table_Tools.generic_table_tools",
             "Table_Tools.cmdb_tools",
             "Table_Tools.kb_article_tools",
+            "Table_Tools.vtb_task_tools",
         })
 
     def test_typed_caller_names_are_real_module_names(self):

--- a/tests/test_http_layer_errors.py
+++ b/tests/test_http_layer_errors.py
@@ -163,7 +163,47 @@ class TestLegacyNoneShim:
             "Table_Tools.cmdb_tools",
             "Table_Tools.kb_article_tools",
             "Table_Tools.vtb_task_tools",
+            "Table_Tools.table_tools",
         })
+
+    def test_typed_callers_covers_every_read_path_consumer(self):
+        """The set must be derived from the CODE, not from a planning document.
+
+        The migration inventory listed four consumer modules. There were five —
+        `Table_Tools.table_tools`, whose two functions are registered MCP tools
+        with no exception handling at all. Nothing failed when it was left out,
+        because the shim quietly kept feeding it None; it would have surfaced as
+        an uncaught exception from a live tool the moment the shim was deleted.
+
+        This scan is what makes "the set is complete" checkable rather than
+        asserted. It is scaffold-lifetime: when the shim goes and the raise
+        becomes unconditional, completeness stops being the property that matters
+        and "every consumer HANDLES the raise" takes over — so replace this with
+        a handler check, do not simply delete it.
+        """
+        import pathlib
+
+        repo = pathlib.Path(__file__).resolve().parent.parent
+        # dist/ holds a packaging copy of the tree; http_layer defines the
+        # function; tests mock it. None of those are consumers.
+        skip = {".venv", "venv", "dist", "build", "tests", "http_layer",
+                ".git", "graphify-out", "__pycache__"}
+        consumers = set()
+        for path in repo.rglob("*.py"):
+            parts = path.relative_to(repo).parts
+            if any(p in skip for p in parts):
+                continue
+            if "make_nws_request(" not in path.read_text(encoding="utf-8"):
+                continue
+            consumers.add(".".join(path.relative_to(repo).with_suffix("").parts))
+
+        assert consumers, "scan found no consumers at all — the scan itself is broken"
+        missing = consumers - dispatcher._TYPED_CALLERS
+        assert not missing, (
+            f"unmigrated read-path consumer(s): {sorted(missing)}. Each still "
+            f"receives None for a failed read, and will raise uncaught once the "
+            f"shim is deleted."
+        )
 
     def test_typed_caller_names_are_real_module_names(self):
         """A typo'd dotted name silently leaves a module unmigrated, suite still green.

--- a/tests/test_typed_read_table_tools.py
+++ b/tests/test_typed_read_table_tools.py
@@ -1,0 +1,143 @@
+"""Typed read failures in the legacy auth-test tools (v4.4 Tier 0.3, PR D).
+
+`Table_Tools.table_tools` was missing from the migration inventory. Its two
+functions are registered MCP tools (`nowtestauth`, `nowtest_auth_input`) that
+called `make_nws_request` with a bare `if not data:` and no exception handling,
+so the shim was the only thing keeping them working — and deleting the shim
+would have turned any transient read failure into an uncaught exception from a
+live tool.
+
+These are diagnostics, which makes the mislabelling worse than usual rather than
+milder: `nowtestauth` reported "Authentication test failed" for a timeout, and
+`nowtest_auth_input` guessed "table may not exist or no permissions" for a read
+that never completed. Both are the tools someone reaches for when they are
+already trying to find out what is broken, and both were prepared to blame the
+wrong thing.
+
+Module was at 11.43% line coverage before this file.
+"""
+import pytest
+from unittest.mock import patch
+
+from constants import TABLE_CONFIGS
+from http_layer.errors import ErrorCode, ServiceNowRequestError
+from Table_Tools.table_tools import nowtest_auth_input, nowtestauth
+
+TIMEOUT = ServiceNowRequestError(
+    ErrorCode.TIMEOUT, "ServiceNow request timed out", retryable=True
+)
+AUTH = ServiceNowRequestError(
+    ErrorCode.AUTH, "ServiceNow authentication failed", status_code=401
+)
+
+
+def _assert_plain_failure(response, code):
+    assert isinstance(response, dict), response
+    assert set(response) == {"error"}, response
+    assert response["error"]["code"] == code
+
+
+class TestNowTestAuth:
+    @pytest.mark.asyncio
+    async def test_timeout_is_not_reported_as_an_auth_failure(self):
+        """The point of a diagnostic is to name the right failure."""
+        with patch("Table_Tools.table_tools.make_nws_request", side_effect=TIMEOUT):
+            result = await nowtestauth()
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+        assert "Authentication test failed" not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_a_real_auth_failure_says_auth(self):
+        with patch("Table_Tools.table_tools.make_nws_request", side_effect=AUTH):
+            result = await nowtestauth()
+        _assert_plain_failure(result, ErrorCode.AUTH)
+
+    @pytest.mark.asyncio
+    async def test_success_is_unchanged(self):
+        with patch("Table_Tools.table_tools.make_nws_request") as request:
+            request.return_value = {"result": [{"sys_id": "a" * 32, "name": "Someone"}]}
+            result = await nowtestauth()
+        assert result["status"] == "success"
+        assert result["records_found"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_falsy_body_keeps_the_legacy_string(self):
+        """Distinct from a failure now: a 2xx that carried no body at all.
+
+        Kept rather than deleted as unreachable — the dispatcher returns whatever
+        ServiceNow sent, and this arm is the only thing standing between an empty
+        body and a TypeError on `data.get`.
+        """
+        with patch("Table_Tools.table_tools.make_nws_request") as request:
+            request.return_value = None
+            result = await nowtestauth()
+        assert result == "Authentication test failed - unable to access ServiceNow API."
+
+
+class TestNowTestAuthInput:
+    @pytest.mark.asyncio
+    async def test_timeout_is_not_reported_as_a_missing_table(self):
+        with patch("Table_Tools.table_tools.make_nws_request", side_effect=TIMEOUT):
+            result = await nowtest_auth_input("incident")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+        assert "may not exist" not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_table_outside_the_allowlist_costs_no_request(self):
+        with patch("Table_Tools.table_tools.make_nws_request") as request:
+            result = await nowtest_auth_input("sys_user")
+        request.assert_not_called()
+        assert "not in the supported allowlist" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_table_keeps_its_own_message(self):
+        """Decision (b): a table that is readable but empty is a success."""
+        with patch("Table_Tools.table_tools.make_nws_request") as request:
+            request.return_value = {"result": []}
+            result = await nowtest_auth_input("incident")
+        assert "contains no records" in result
+
+    @pytest.mark.asyncio
+    async def test_success_reports_the_sample_fields(self):
+        with patch("Table_Tools.table_tools.make_nws_request") as request:
+            request.return_value = {"result": [{"number": "INC1", "state": "1"}]}
+            result = await nowtest_auth_input("incident")
+        assert result["status"] == "accessible"
+        assert result["total_fields"] == 2
+        assert set(result["sample_fields"]) == {"number", "state"}
+
+    @pytest.mark.asyncio
+    async def test_a_falsy_body_keeps_the_legacy_string(self):
+        with patch("Table_Tools.table_tools.make_nws_request") as request:
+            request.return_value = None
+            result = await nowtest_auth_input("incident")
+        assert "may not exist or no permissions" in result
+
+    def test_the_allowlist_used_by_the_test_is_the_real_one(self):
+        """Guards the premise of test_table_outside_the_allowlist_costs_no_request."""
+        assert "incident" in TABLE_CONFIGS
+        assert "sys_user" not in TABLE_CONFIGS
+
+
+class TestEndToEndThroughTheRealDispatcher:
+    """Without the `_TYPED_CALLERS` entry the shim returns None and both tools
+    fall back to their misleading strings. Module-seam mocks cannot see that."""
+
+    @pytest.fixture
+    def failing_transport(self, monkeypatch):
+        import http_layer.request_dispatcher as dispatcher
+
+        async def boom(url):
+            raise TimeoutError()
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", boom)
+
+    @pytest.mark.asyncio
+    async def test_nowtestauth_reports_the_timeout(self, failing_transport):
+        result = await nowtestauth()
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_nowtest_auth_input_reports_the_timeout(self, failing_transport):
+        result = await nowtest_auth_input("incident")
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)

--- a/tests/test_typed_read_vtb_task_tools.py
+++ b/tests/test_typed_read_vtb_task_tools.py
@@ -1,0 +1,171 @@
+"""Typed read failures in the private-task tools (v4.4 Tier 0.3, PR D).
+
+`Table_Tools.vtb_task_tools` joins `_TYPED_CALLERS`. The module has exactly one
+read, and it is the sensitive kind: the pre-write `sys_id` lookup in
+`update_private_task`. Its answer decides whether a write happens, so
+conflating "the task does not exist" with "the lookup failed" both mislabelled
+the failure AND withheld the write (decision (d)).
+
+`None` still means absent at `_get_task_sys_id`'s own boundary — that is what
+keeps the existing `_get_task_sys_id -> None` mocks meaningful. What changed is
+that a *failure* no longer arrives as None.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from constants import PRIVATE_TASK_NOT_FOUND_UPDATE
+from http_layer.errors import ErrorCode, ServiceNowRequestError
+from Table_Tools.vtb_task_tools import _get_task_sys_id, update_private_task
+
+TIMEOUT = ServiceNowRequestError(
+    ErrorCode.TIMEOUT, "ServiceNow request timed out", retryable=True
+)
+FORBIDDEN = ServiceNowRequestError(
+    ErrorCode.FORBIDDEN, "ServiceNow returned HTTP 403", status_code=403
+)
+SYS_ID = "a" * 32
+
+
+def _assert_plain_failure(response, code):
+    assert isinstance(response, dict), response
+    assert set(response) == {"error"}, response
+    assert set(response["error"]) == {"code", "message"}
+    assert response["error"]["code"] == code
+
+
+class TestPreWriteLookup:
+    @pytest.mark.asyncio
+    async def test_failed_lookup_is_not_task_not_found(self):
+        with patch(
+            "Table_Tools.vtb_task_tools._get_task_sys_id",
+            new=AsyncMock(side_effect=TIMEOUT),
+        ), patch(
+            "Table_Tools.vtb_task_tools._write_private_task", new=AsyncMock()
+        ) as write:
+            result = await update_private_task("VTB0001234", {"comments": "hi"})
+
+        write.assert_not_called()
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+        assert result != PRIVATE_TASK_NOT_FOUND_UPDATE
+
+    @pytest.mark.asyncio
+    async def test_forbidden_lookup_keeps_its_own_code(self):
+        with patch(
+            "Table_Tools.vtb_task_tools._get_task_sys_id",
+            new=AsyncMock(side_effect=FORBIDDEN),
+        ):
+            result = await update_private_task("VTB0001234", {"comments": "hi"})
+        _assert_plain_failure(result, ErrorCode.FORBIDDEN)
+
+    @pytest.mark.asyncio
+    async def test_absent_task_keeps_its_not_found_message(self):
+        """Decision (b): absent is still absent, and the message is unchanged."""
+        with patch(
+            "Table_Tools.vtb_task_tools._get_task_sys_id",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "Table_Tools.vtb_task_tools._write_private_task", new=AsyncMock()
+        ) as write:
+            result = await update_private_task("VTB9999999", {"comments": "hi"})
+
+        write.assert_not_called()
+        assert result == PRIVATE_TASK_NOT_FOUND_UPDATE
+
+    @pytest.mark.asyncio
+    async def test_found_task_still_writes(self):
+        with patch(
+            "Table_Tools.vtb_task_tools._get_task_sys_id",
+            new=AsyncMock(return_value=SYS_ID),
+        ), patch(
+            "Table_Tools.vtb_task_tools._write_private_task",
+            new=AsyncMock(return_value={"number": "VTB0001234"}),
+        ) as write:
+            result = await update_private_task("VTB0001234", {"comments": "hi"})
+
+        write.assert_called_once()
+        assert SYS_ID in write.call_args.args[1]
+        assert result == {"number": "VTB0001234"}
+
+    @pytest.mark.asyncio
+    async def test_validation_still_runs_before_the_lookup(self):
+        """A rejected field must not cost a round trip."""
+        with patch("Table_Tools.vtb_task_tools._get_task_sys_id") as lookup:
+            result = await update_private_task("VTB0001234", {"sys_id": "nope"})
+        lookup.assert_not_called()
+        assert "Rejected non-updatable field(s)" in result
+
+
+class TestEndToEndThroughTheRealDispatcher:
+    """Proves the `_TYPED_CALLERS` entry resolves for this module.
+
+    Without the entry the shim returns None, `_get_task_sys_id` answers None, and
+    the update reports the task as missing. Tests that patch
+    `Table_Tools.vtb_task_tools.make_nws_request` cannot detect that, because they
+    never reach the dispatcher.
+    """
+
+    @pytest.fixture
+    def transport(self, monkeypatch):
+        import http_layer.request_dispatcher as dispatcher
+
+        writes = []
+
+        class FakeClient:
+            async def make_authenticated_request(self, method, url, raise_for_status=True, json=None):
+                writes.append((method, url))
+                return {"result": {"number": "VTB0001234"}}
+
+        def install(get_handler):
+            async def fake_get(url):
+                return get_handler(url)
+            monkeypatch.setattr(dispatcher, "make_oauth_request", fake_get)
+            monkeypatch.setattr(dispatcher, "get_oauth_client", lambda: FakeClient())
+            return writes
+
+        return install
+
+    @pytest.mark.asyncio
+    async def test_lookup_timeout_does_not_report_the_task_missing(self, transport):
+        def boom(url):
+            raise TimeoutError()
+
+        writes = transport(boom)
+        result = await update_private_task("VTB0001234", {"comments": "hi"})
+
+        assert writes == [], "no write should be attempted on an unreadable lookup"
+        _assert_plain_failure(result, ErrorCode.TIMEOUT)
+        assert result != PRIVATE_TASK_NOT_FOUND_UPDATE
+
+    @pytest.mark.asyncio
+    async def test_genuinely_absent_task_still_says_not_found(self, transport):
+        writes = transport(lambda url: {"result": []})
+        result = await update_private_task("VTB9999999", {"comments": "hi"})
+
+        assert writes == []
+        assert result == PRIVATE_TASK_NOT_FOUND_UPDATE
+
+    @pytest.mark.asyncio
+    async def test_successful_lookup_writes_once(self, transport):
+        writes = transport(lambda url: {"result": [{"sys_id": SYS_ID}]})
+        result = await update_private_task("VTB0001234", {"comments": "hi"})
+
+        assert len(writes) == 1
+        assert writes[0][0] == "PATCH"
+        assert SYS_ID in writes[0][1]
+        assert result == {"number": "VTB0001234"}
+
+
+class TestReadFailureStillRaisesAtTheHelperBoundary:
+    @pytest.mark.asyncio
+    async def test_helper_propagates(self):
+        with patch(
+            "Table_Tools.vtb_task_tools.make_nws_request", side_effect=TIMEOUT
+        ):
+            with pytest.raises(ServiceNowRequestError):
+                await _get_task_sys_id("VTB0001234")
+
+    @pytest.mark.asyncio
+    async def test_helper_returns_none_for_a_genuinely_empty_result(self):
+        with patch("Table_Tools.vtb_task_tools.make_nws_request") as request:
+            request.return_value = {"result": []}
+            assert await _get_task_sys_id("VTB9999999") is None

--- a/tests/test_vtb_task_tools.py
+++ b/tests/test_vtb_task_tools.py
@@ -9,6 +9,7 @@ import httpx
 
 # Import functions to test
 from constants import ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED
+from http_layer.errors import ErrorCode, ServiceNowRequestError
 from Table_Tools.vtb_task_tools import (
     _write_private_task,
     _unwrap_write_response,
@@ -290,14 +291,18 @@ class TestTaskSysIdRetrieval:
             assert sys_id is None
 
     @pytest.mark.asyncio
-    async def test_get_task_sys_id_no_data(self):
-        """Test sys_id retrieval with no data."""
-        with patch('Table_Tools.vtb_task_tools.make_nws_request') as mock_request:
-            mock_request.return_value = None
+    async def test_get_task_sys_id_read_failure_propagates(self):
+        """Decision (d): None means absent, so a failed read must not return None.
 
-            sys_id = await _get_task_sys_id("VTB0001234")
-
-            assert sys_id is None
+        This mocked None and asserted None came back, which the transport can no
+        longer produce -- a failed GET raises for this module. None here is what
+        made update_private_task report the task as missing on a timeout.
+        """
+        with patch('Table_Tools.vtb_task_tools.make_nws_request',
+                   side_effect=ServiceNowRequestError(
+                       ErrorCode.TIMEOUT, "ServiceNow request timed out", retryable=True)):
+            with pytest.raises(ServiceNowRequestError):
+                await _get_task_sys_id("VTB0001234")
 
     @pytest.mark.asyncio
     async def test_get_task_sys_id_invalid_response(self):


### PR DESCRIPTION
PR D of the v4.4 Tier 0.3 typed-read chain (after #64, #65, #66). Migrates the **last two** read-path consumers: `Table_Tools/vtb_task_tools.py` and `Table_Tools/table_tools.py`. PR E then deletes the shim.

> Opened as a `vtb_task_tools`-only PR. Review found a fifth consumer that every planning document had missed, and it was a blocker for the shim deletion — so it is migrated here, which is what makes "last consumer PR" true rather than aspirational.

## 1. `vtb_task_tools` — the pre-write lookup

`_get_task_sys_id` returned `None` both for a task that does not exist and for a lookup that failed, and `update_private_task` turned `None` into `PRIVATE_TASK_NOT_FOUND_UPDATE`. So a timeout told the user their task did not exist — **and withheld the update** — for a task sitting right there. That is the plan's "a write no longer reports 'not found' for a timeout", on the one path in this module where the answer gates a write.

Per **decision (d)**: `None` now means absent and nothing else; a failed read propagates and the caller maps it to `error.to_error_dict()`. A genuinely absent task keeps its existing message (decision (b)).

Coverage: **96.88% → 100.00%**, measured on the parent `d6845ba`.

## 2. `Table_Tools/table_tools.py` — the consumer nobody counted

Found in review. It calls `make_nws_request` twice with a bare `if not data:` and **no exception handling**, and both of its functions — `nowtestauth`, `nowtest_auth_input` — are registered MCP tools. It was absent from `_TYPED_CALLERS` and from `0.3-MIGRATION-INVENTORY.md`, which stated *"that leaves 4 real modules, not 6"*.

Nothing failed, because the shim kept feeding it `None`. **PR E deletes the shim and makes the raise unconditional** — at which point any transient read failure inside either tool would have propagated uncaught to the MCP client. That is the exact failure mode this tier exists to prevent, arriving through the two modules nobody had taught to handle it.

These are diagnostics, which makes the mislabelling worse rather than milder:

| tool | said, for a timeout |
|---|---|
| `nowtestauth` | "Authentication test failed" |
| `nowtest_auth_input` | "table may not exist or no permissions" |

Both are what someone reaches for while trying to work out what is broken, and both were prepared to blame the wrong thing. They now return `error.to_error_dict()`, so `AUTH` and `TIMEOUT` are distinguishable. Empty results and falsy bodies keep their existing strings.

Coverage: **11.43% → 100.00%**. The module had no tests of its own.

### The guard that should have caught it

Added `test_typed_callers_covers_every_read_path_consumer`, which derives the consumer set from the **code** — scanning for `make_nws_request(` calls, excluding tests, `http_layer`, and the `dist/` packaging copy — and asserts every module found is in `_TYPED_CALLERS`. It fails naming this exact module when the entry is removed.

It is scaffold-lifetime, and PR E should **replace** it rather than delete it: once the raise is unconditional, completeness stops being the property that matters and "every consumer *handles* the raise" takes over.

The stale scaffold comments promising "PR 8 of 8" and "PRs 2-7 each add one module name" are corrected too. That drift is what let a dropped module look accounted for.

## What needed nothing, verified rather than assumed

**The write path.** Writes never raise `ServiceNowRequestError` — the dispatcher's write branch never touches `_get_typed` or `classify_read_failure` — so the bare `except Exception` in `_write_private_task` cannot swallow it. A write timeout raises builtin `TimeoutError` from its own independent `anyio.fail_after` scope. The "successful but no data returned" half was already fixed in #66 via the shared helper.

**`intelligent_query_tools`.** The handoff left its `except` narrowing to either PR A or PR D. PR A already did it: `intelligent_search` has the typed arm ahead of `except Exception`, plus `is_read_failure` and `carry_partial`. Its other wrappers are synchronous and call only pure computation.

## Tests

- `tests/test_typed_read_vtb_task_tools.py` (new, **10** tests — the first version of this description said 12, which was wrong)
- `tests/test_typed_read_table_tools.py` (new, 12 tests)
- One `make_nws_request → None` read mock inverted; it was mocking an input the transport can no longer produce
- The `_get_task_sys_id → None` mocks in the existing update tests **stay**, and stay meaningful, because `None` still means absent at that helper's own boundary — the condition the handoff attached to keeping them

**Mutation-checked.** Removing the `vtb_task_tools` entry fails exactly one test (its e2e); removing the `table_tools` entry fails four (both its e2e tests, the frozenset assertion, and the completeness scan).

The pattern across all four PRs in this chain is worth stating, because it is now the reason the e2e classes exist: **module-seam tests cannot detect a `_TYPED_CALLERS` entry at all.** A test that patches `Table_Tools.<module>.make_nws_request` never reaches the dispatcher. For `vtb_task_tools`, 9 of 10 tests stayed green under the mutation. Any future addition to that frozenset needs an end-to-end test or the wiring is untested by construction.

Suite: **957 passed, 5 skipped**.

## After this

PR E (`chore/v4.4_delete-none-shim`) deletes `_TYPED_CALLERS`, `_legacy_none_shim`, `_calling_module`, `_PACKAGE`, and makes the GET path propagate unconditionally. **Tier 0's exit criterion — "timeout is never reportable as not-found" — becomes true there and not before.** With this merge every read-path consumer is migrated and verified complete by a scan rather than by a document, which is the precondition that was quietly missing until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
