### PR TITLE
chore(http): delete the none-shim and make a failed GET raise for everyone

### DIFF
--- a/Table_Tools/cmdb_tools.py
+++ b/Table_Tools/cmdb_tools.py
@@ -49,8 +49,7 @@ DEFAULT_CI_PROBE_TABLES = [
 _CI_TYPE_PATTERN = re.compile(r'cmdb_ci[a-z0-9_]*')
 
 # ---------------------------------------------------------------------------
-# Read-failure contract (v4.4 Tier 0.3). This module is in
-# `http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET raises
+# Read-failure contract (v4.4 Tier 0.3). A failed GET raises
 # `ServiceNowRequestError` instead of returning None. Rules, as settled in the
 # generic_table_tools migration:
 #

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -36,10 +36,9 @@ from filter import (
 
 
 # ---------------------------------------------------------------------------
-# Read-failure contract (v4.4 Tier 0.3). This module is the first entry in
-# `http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET arrives here
-# as a raised `ServiceNowRequestError` instead of `None`. The rules below are
-# settled here and reused by every other consumer module migrated after it:
+# Read-failure contract (v4.4 Tier 0.3). A failed GET arrives here as a raised
+# `ServiceNowRequestError` instead of `None`. This module was migrated first, so
+# the rules below were settled here and are reused by every other consumer:
 #
 #   1. A raise returns `error.to_error_dict()` -> {"error": {code, message}}
 #      and nothing else. `retryable` is for our own retry logic, not the client,

--- a/Table_Tools/kb_article_tools.py
+++ b/Table_Tools/kb_article_tools.py
@@ -1,7 +1,6 @@
 """Knowledge-article reads and writes.
 
-Read-failure contract (v4.4 Tier 0.3). This module is in
-`http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET raises
+Read-failure contract (v4.4 Tier 0.3). A failed GET raises
 `ServiceNowRequestError` rather than returning None:
 
   * A raise surfaces as `error.to_error_dict()` -> {"error": {code, message}}.

--- a/Table_Tools/table_tools.py
+++ b/Table_Tools/table_tools.py
@@ -1,7 +1,6 @@
 """Legacy auth/connectivity test tools.
 
-Read-failure contract (v4.4 Tier 0.3). This module is in
-`http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET raises
+Read-failure contract (v4.4 Tier 0.3). A failed GET raises
 `ServiceNowRequestError` instead of returning None.
 
 Both functions here are registered MCP tools, and both are diagnostics — which

--- a/Table_Tools/vtb_task_tools.py
+++ b/Table_Tools/vtb_task_tools.py
@@ -1,7 +1,6 @@
 """Private task (vtb_task) CRUD.
 
-Read-failure contract (v4.4 Tier 0.3). This module is in
-`http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET raises
+Read-failure contract (v4.4 Tier 0.3). A failed GET raises
 `ServiceNowRequestError` instead of returning None. There is exactly one read
 here — the pre-write `sys_id` lookup — and it is the sensitive kind (decision
 (d)): `_get_task_sys_id` returns None ONLY for a task that genuinely does not

--- a/http_layer/request_dispatcher.py
+++ b/http_layer/request_dispatcher.py
@@ -18,11 +18,24 @@ The write path explicitly skips the read-only param injection and the
 display-value flattening — applying either to a write payload would
 break the request shape or the response shape (per the token-optimization
 invariant memory).
+
+Read-failure contract (v4.4 Tier 0.3, complete as of the shim deletion): a
+failed GET raises ``ServiceNowRequestError``, unconditionally, for every caller.
+It never returns ``None`` to mean failure. ``None``/falsy means ServiceNow
+answered with no body, and ``{"result": []}`` means it answered with no rows —
+both successes. Deciding whether an empty result means "not found" belongs to
+the consumer, which is the whole point: the transport reporting a 30-second
+timeout and an empty table with the same value is what let a failure be shown to
+users as a missing record.
+
+Every module calling this on the read path handles the raise. That set is
+enforced by ``tests/test_http_layer_errors.py`` scanning the tree rather than
+trusting a list — the migration's planning documents undercounted the consumers
+by one, and the module they missed had no exception handling at all.
 """
 from __future__ import annotations
 
 import hashlib
-import inspect
 import os
 import sys
 from typing import Any, Optional
@@ -48,71 +61,6 @@ def _redact_url(url: str) -> str:
     return f"{parts.path} q_hash={h}"
 
 
-# ---------------------------------------------------------------------------
-# TEMPORARY MIGRATION SCAFFOLD — v4.4 Tier 0.3, deleted in the next PR.
-#
-# The GET path now raises ServiceNowRequestError instead of returning None.
-# Consumer modules that have not yet been taught to handle it would otherwise
-# start propagating exceptions to MCP clients mid-migration, so the shim
-# converts the raise back into the legacy None for every caller EXCEPT the
-# modules listed here.
-#
-# Opt-in, not opt-out: a caller that nobody has migrated (including tests and
-# any future module) keeps the old behavior, so no PR can accidentally expose a
-# half-migrated module. The set below is now COMPLETE — every module that calls
-# make_nws_request on the read path is listed — which is what makes the
-# unconditional raise safe.
-#
-# That completeness is the precondition for deleting this block, and it is not
-# self-evident: the migration inventory listed four consumer modules and missed
-# `table_tools`, whose two functions are registered MCP tools with no exception
-# handling at all. Before deleting the shim, re-derive the list from the code
-# (`grep -rl make_nws_request --include=*.py`, excluding tests, http_layer and
-# build artefacts under dist/) rather than from any planning document.
-# ---------------------------------------------------------------------------
-_TYPED_CALLERS: frozenset[str] = frozenset({
-    "Table_Tools.generic_table_tools",
-    "Table_Tools.cmdb_tools",
-    "Table_Tools.kb_article_tools",
-    "Table_Tools.vtb_task_tools",
-    "Table_Tools.table_tools",
-})
-
-# This package's own name, used for the frame-walk boundary test below.
-_PACKAGE = __name__.split(".")[0]
-
-
-def _calling_module() -> str:
-    """Module name of the nearest frame outside the http_layer package.
-
-    Walks out of this package so intermediate http_layer frames never mask the
-    real consumer. Returns "" when the whole stack is internal (unreachable in
-    practice — something always calls in from outside).
-
-    The boundary test is exact-or-dotted, not a bare prefix: a module named
-    `http_layer_extras` is a different package and must be reportable as itself,
-    otherwise it could never be added to _TYPED_CALLERS.
-    """
-    frame = inspect.currentframe()
-    try:
-        while frame is not None:
-            name = frame.f_globals.get("__name__", "")
-            if not (name == _PACKAGE or name.startswith(_PACKAGE + ".")):
-                return name
-            frame = frame.f_back
-        return ""
-    finally:
-        # Break the reference cycle CPython warns about for held frame objects.
-        del frame
-
-
-def _legacy_none_shim(error: ServiceNowRequestError) -> None:
-    """Re-raise for migrated modules; swallow to None for everyone else."""
-    if _calling_module() in _TYPED_CALLERS:
-        raise error
-    return None
-
-
 async def make_nws_request(
     url: str,
     display_value: bool = True,
@@ -133,15 +81,14 @@ async def make_nws_request(
     Wrap calls in ``anyio.fail_after()`` at the call site to enforce
     per-operation deadlines (e.g. ``anyio.fail_after(180.0)`` for KB publish).
 
-    GET failures raise ``ServiceNowRequestError`` for modules listed in
-    ``_TYPED_CALLERS`` and return ``None`` for everyone else — see the
-    migration-scaffold note above.
+    A failed GET raises ``ServiceNowRequestError`` (``.code``, ``.status_code``,
+    ``.retryable``, ``.to_error_dict()``). It never returns ``None`` to mean
+    failure, which is what let a timeout be reported as a missing record. An
+    empty ``{"result": []}`` is still returned as-is: empty is success, and
+    deciding whether it means "not found" belongs to the consumer.
     """
     if method == "GET":
-        try:
-            return await _get_typed(url, display_value)
-        except ServiceNowRequestError as error:
-            return _legacy_none_shim(error)
+        return await _get_typed(url, display_value)
 
     # Write path: bypass read-only params + display flattening, raise
     # for status so callers can map HTTP errors to domain errors.

--- a/tests/test_http_layer_errors.py
+++ b/tests/test_http_layer_errors.py
@@ -1,14 +1,17 @@
-"""Tests for the typed read-path failure surface (v4.4 Tier 0.3, PR 1 of 8).
+"""Tests for the typed read-path failure surface (v4.4 Tier 0.3).
 
-Two contracts are locked here:
+Three contracts are locked here:
 
 1. `classify_read_failure` maps every failure the read path can produce onto
    the seven-code vocabulary, and never onto NOT_FOUND unless ServiceNow
    actually said 404. A timeout reported as not-found is the bug this tier
    exists to remove.
-2. The `_legacy_none_shim` keeps behavior identical on main for callers nobody
-   has migrated yet, while already raising for callers that opt in. Both
-   branches are exercised so PRs 2-7 cannot silently break either one.
+2. A failed GET raises for every caller, unconditionally, and an empty result
+   is still a success. The migration shim that used to convert the raise back
+   into `None` for unmigrated callers is gone.
+3. Every module that calls `make_nws_request` on the read path handles the
+   raise. That set is derived by scanning the tree, not from a list -- the
+   migration's own planning documents undercounted it by one.
 """
 import json
 
@@ -150,36 +153,26 @@ class TestClassifyOAuthFailures:
         assert via_oauth.code == via_http.code == ErrorCode.AUTH
 
 
-class TestLegacyNoneShim:
-    """PR 1 must not change behavior on main. PRs 2-7 flip modules one at a time."""
+class TestReadFailuresPropagate:
+    def test_every_read_path_consumer_handles_the_raise(self):
+        """Derived from the CODE, not from a list. The list was wrong once already.
 
-    def test_typed_callers_matches_the_migration_state(self):
-        """Updated deliberately, once per PR — the assertion IS the migration record.
-
-        PR E deletes this class along with the shim.
-        """
-        assert dispatcher._TYPED_CALLERS == frozenset({
-            "Table_Tools.generic_table_tools",
-            "Table_Tools.cmdb_tools",
-            "Table_Tools.kb_article_tools",
-            "Table_Tools.vtb_task_tools",
-            "Table_Tools.table_tools",
-        })
-
-    def test_typed_callers_covers_every_read_path_consumer(self):
-        """The set must be derived from the CODE, not from a planning document.
-
-        The migration inventory listed four consumer modules. There were five —
+        The migration inventory named four consumer modules. There were five:
         `Table_Tools.table_tools`, whose two functions are registered MCP tools
-        with no exception handling at all. Nothing failed when it was left out,
-        because the shim quietly kept feeding it None; it would have surfaced as
-        an uncaught exception from a live tool the moment the shim was deleted.
+        with no exception handling at all. Nothing failed while the shim was
+        feeding it None, and it would have started raising out of a live tool the
+        moment the shim went.
 
-        This scan is what makes "the set is complete" checkable rather than
-        asserted. It is scaffold-lifetime: when the shim goes and the raise
-        becomes unconditional, completeness stops being the property that matters
-        and "every consumer HANDLES the raise" takes over — so replace this with
-        a handler check, do not simply delete it.
+        This replaces the shim-era completeness check. Completeness of an opt-in
+        set stopped being the property that matters once the raise became
+        unconditional; what matters now is that every module reading through this
+        path is prepared to catch. A new consumer added without a handler fails
+        here, named.
+
+        A source scan, not a behavioural one -- it cannot prove the handler is
+        correct, only that the module has one. Correctness per module lives in the
+        five `test_typed_read_*.py` files, each of which drives a failure through
+        the real dispatcher.
         """
         import pathlib
 
@@ -188,51 +181,33 @@ class TestLegacyNoneShim:
         # function; tests mock it. None of those are consumers.
         skip = {".venv", "venv", "dist", "build", "tests", "http_layer",
                 ".git", "graphify-out", "__pycache__"}
-        consumers = set()
-        for path in repo.rglob("*.py"):
-            parts = path.relative_to(repo).parts
-            if any(p in skip for p in parts):
+        unhandled = []
+        consumers = 0
+        for path in sorted(repo.rglob("*.py")):
+            if any(part in skip for part in path.relative_to(repo).parts):
                 continue
-            if "make_nws_request(" not in path.read_text(encoding="utf-8"):
+            source = path.read_text(encoding="utf-8")
+            if "make_nws_request(" not in source:
                 continue
-            consumers.add(".".join(path.relative_to(repo).with_suffix("").parts))
+            consumers += 1
+            if "except ServiceNowRequestError" not in source:
+                unhandled.append(str(path.relative_to(repo)))
 
-        assert consumers, "scan found no consumers at all — the scan itself is broken"
-        missing = consumers - dispatcher._TYPED_CALLERS
-        assert not missing, (
-            f"unmigrated read-path consumer(s): {sorted(missing)}. Each still "
-            f"receives None for a failed read, and will raise uncaught once the "
-            f"shim is deleted."
+        assert consumers >= 5, (
+            f"scan found only {consumers} consumers; it is probably broken"
+        )
+        assert not unhandled, (
+            f"read-path consumer(s) with no `except ServiceNowRequestError`: "
+            f"{unhandled}. A failed GET raises unconditionally, so these would "
+            f"propagate an exception to MCP clients."
         )
 
-    def test_typed_caller_names_are_real_module_names(self):
-        """A typo'd dotted name silently leaves a module unmigrated, suite still green.
-
-        `_calling_module()` compares against `frame.f_globals["__name__"]`, so
-        "Table_Tools.generic_tables_tools" would never match anything and the
-        module would keep receiving None with nothing failing to say so.
-        """
-        import importlib
-
-        for name in dispatcher._TYPED_CALLERS:
-            assert importlib.import_module(name).__name__ == name
-
     @pytest.mark.asyncio
-    async def test_unmigrated_caller_still_gets_none(self, monkeypatch):
-        async def boom(url):
-            raise _status_error(500)
-
-        monkeypatch.setattr(dispatcher, "make_oauth_request", boom)
-        result = await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_migrated_caller_gets_typed_error(self, monkeypatch):
+    async def test_get_failure_raises_typed_error(self, monkeypatch):
         async def boom(url):
             raise _status_error(403)
 
         monkeypatch.setattr(dispatcher, "make_oauth_request", boom)
-        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
 
         with pytest.raises(ServiceNowRequestError) as excinfo:
             await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
@@ -241,13 +216,12 @@ class TestLegacyNoneShim:
         assert excinfo.value.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_timeout_reaches_migrated_caller_as_timeout_not_not_found(self, monkeypatch):
+    async def test_timeout_is_a_timeout_not_a_not_found(self, monkeypatch):
         """The headline bug: a 30s deadline must never look like a missing record."""
         async def slow(url):
             raise TimeoutError()
 
         monkeypatch.setattr(dispatcher, "make_oauth_request", slow)
-        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
 
         with pytest.raises(ServiceNowRequestError) as excinfo:
             await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
@@ -256,12 +230,11 @@ class TestLegacyNoneShim:
         assert excinfo.value.retryable is True
 
     @pytest.mark.asyncio
-    async def test_success_path_untouched_by_the_shim(self, monkeypatch):
+    async def test_success_path_unaffected(self, monkeypatch):
         async def ok(url):
             return {"result": [{"number": "INC0012345"}]}
 
         monkeypatch.setattr(dispatcher, "make_oauth_request", ok)
-        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
 
         result = await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
         assert result == {"result": [{"number": "INC0012345"}]}
@@ -273,7 +246,6 @@ class TestLegacyNoneShim:
             return {"result": []}
 
         monkeypatch.setattr(dispatcher, "make_oauth_request", empty)
-        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
 
         result = await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
         assert result == {"result": []}
@@ -283,7 +255,7 @@ class TestResponseParsingStaysGuarded:
     """The pre-v4.4 blanket except covered the flattener for every read caller."""
 
     @pytest.mark.asyncio
-    async def test_flattener_failure_is_classified_not_propagated(self, monkeypatch):
+    async def test_flattener_failure_is_classified_as_internal(self, monkeypatch):
         async def ok(url):
             return {"result": [{"number": "INC0001"}]}
 
@@ -292,55 +264,8 @@ class TestResponseParsingStaysGuarded:
 
         monkeypatch.setattr(dispatcher, "make_oauth_request", ok)
         monkeypatch.setattr(dispatcher, "extract_display_values", exploding_flattener)
-
-        # Un-migrated caller: must still get None, not a RuntimeError.
-        assert await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident") is None
-
-    @pytest.mark.asyncio
-    async def test_flattener_failure_reaches_migrated_caller_as_internal(self, monkeypatch):
-        async def ok(url):
-            return {"result": [{"number": "INC0001"}]}
-
-        def exploding_flattener(payload):
-            raise RuntimeError("parser blew up")
-
-        monkeypatch.setattr(dispatcher, "make_oauth_request", ok)
-        monkeypatch.setattr(dispatcher, "extract_display_values", exploding_flattener)
-        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
 
         with pytest.raises(ServiceNowRequestError) as excinfo:
             await dispatcher.make_nws_request("https://example.service-now.com/api/now/table/incident")
 
         assert excinfo.value.code == ErrorCode.INTERNAL
-
-
-class TestCallingModuleResolution:
-    def test_resolves_to_the_caller_outside_http_layer(self):
-        assert dispatcher._calling_module() == __name__
-
-    def test_boundary_is_the_package_not_a_bare_prefix(self):
-        """A module named http_layer_extras is a different package, not internal."""
-        import types
-
-        fake = types.ModuleType("http_layer_extras")
-        code = "def probe(walk):\n    return walk()\n"
-        exec(compile(code, "http_layer_extras.py", "exec"), fake.__dict__)
-
-        assert fake.probe(dispatcher._calling_module) == "http_layer_extras"
-
-    def test_skips_intermediate_http_layer_frames(self, monkeypatch):
-        """An http_layer frame between the consumer and the walk must not mask it.
-
-        `_legacy_none_shim` lives in http_layer and calls `_calling_module()`
-        one frame deeper, so reaching this module's name proves the walk climbs
-        out of the package instead of stopping at the nearest frame.
-        """
-        monkeypatch.setattr(dispatcher, "_TYPED_CALLERS", frozenset({__name__}))
-        error = ServiceNowRequestError(ErrorCode.AUTH, "denied", status_code=401)
-
-        with pytest.raises(ServiceNowRequestError):
-            dispatcher._legacy_none_shim(error)
-
-    def test_unlisted_caller_swallowed_by_shim(self):
-        error = ServiceNowRequestError(ErrorCode.AUTH, "denied", status_code=401)
-        assert dispatcher._legacy_none_shim(error) is None

--- a/tests/test_http_layer_errors.py
+++ b/tests/test_http_layer_errors.py
@@ -169,11 +169,23 @@ class TestReadFailuresPropagate:
         path is prepared to catch. A new consumer added without a handler fails
         here, named.
 
-        A source scan, not a behavioural one -- it cannot prove the handler is
-        correct, only that the module has one. Correctness per module lives in the
-        five `test_typed_read_*.py` files, each of which drives a failure through
-        the real dispatcher.
+        Two things this deliberately does NOT buy, so nobody over-trusts it:
+
+        * It cannot prove a handler is correct, only that the module has one.
+          Correctness per module lives in the five `test_typed_read_*.py` files,
+          each of which drives a real failure through the real dispatcher.
+        * It is per-module, not per-call-site. A module with a handler in one
+          function and none in another passes. Today none of the five has such a
+          gap (checked by hand); a scan that could prove it wouldn't be a scan.
+
+        Consumers are detected by IMPORT rather than by a `make_nws_request(`
+        text match, via the AST: an aliased import
+        (`from http_layer import make_nws_request as fetch`) binds the name and
+        then never spells it at the call site, so a text match would miss the
+        module entirely — silently, which is the failure mode that makes a guard
+        worse than no guard. Parsing also ignores mentions in comments.
         """
+        import ast
         import pathlib
 
         repo = pathlib.Path(__file__).resolve().parent.parent
@@ -181,20 +193,46 @@ class TestReadFailuresPropagate:
         # function; tests mock it. None of those are consumers.
         skip = {".venv", "venv", "dist", "build", "tests", "http_layer",
                 ".git", "graphify-out", "__pycache__"}
+
+        def imports_the_read_entry_point(tree):
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom):
+                    names = [a.name for a in node.names]
+                elif isinstance(node, ast.Import):
+                    names = [a.name.rsplit(".", 1)[-1] for a in node.names]
+                else:
+                    continue
+                if "make_nws_request" in names:
+                    return True
+            return False
+
+        def handles_the_typed_error(tree):
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ExceptHandler) or node.type is None:
+                    continue
+                caught = node.type.elts if isinstance(node.type, ast.Tuple) else [node.type]
+                for exc in caught:
+                    name = exc.attr if isinstance(exc, ast.Attribute) else getattr(exc, "id", None)
+                    if name == "ServiceNowRequestError":
+                        return True
+            return False
+
         unhandled = []
-        consumers = 0
+        consumers = []
         for path in sorted(repo.rglob("*.py")):
             if any(part in skip for part in path.relative_to(repo).parts):
                 continue
-            source = path.read_text(encoding="utf-8")
-            if "make_nws_request(" not in source:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            if not imports_the_read_entry_point(tree):
                 continue
-            consumers += 1
-            if "except ServiceNowRequestError" not in source:
-                unhandled.append(str(path.relative_to(repo)))
+            rel = str(path.relative_to(repo))
+            consumers.append(rel)
+            if not handles_the_typed_error(tree):
+                unhandled.append(rel)
 
-        assert consumers >= 5, (
-            f"scan found only {consumers} consumers; it is probably broken"
+        assert len(consumers) >= 5, (
+            f"scan found only {len(consumers)} consumers ({consumers}); it is "
+            f"probably broken rather than the codebase having shrunk"
         )
         assert not unhandled, (
             f"read-path consumer(s) with no `except ServiceNowRequestError`: "

--- a/tests/test_service_now_api.py
+++ b/tests/test_service_now_api.py
@@ -300,16 +300,22 @@ class TestServiceNowAPI(unittest.IsolatedAsyncioTestCase):
 
     @patch('http_layer.request_dispatcher.make_oauth_request')
     async def test_make_nws_request_http_error(self, mock_oauth_request):
-        """Test API request with error returns None."""
+        """A failed GET raises a classified error instead of returning None.
+
+        Inverted with the shim deletion (v4.4 Tier 0.3). This asserted
+        `result is None`, which is the conflation the tier removes: the caller
+        could not tell this from a table with no matching rows.
+        """
         if not self.api_available:
             self.skipTest(f"ServiceNow API not available: {self.import_error}")
+
+        from http_layer.errors import ServiceNowRequestError
 
         mock_oauth_request.side_effect = Exception("404 Not Found")
 
         url = "https://test.service-now.com/api/now/table/nonexistent"
-        result = await self.make_nws_request(url)
-
-        self.assertIsNone(result)
+        with self.assertRaises(ServiceNowRequestError):
+            await self.make_nws_request(url)
 
     @patch('http_layer.request_dispatcher.get_oauth_client')
     async def test_make_nws_request_write_delegates_to_oauth_client(self, mock_get_client):

--- a/tests/test_typed_read_cmdb_tools.py
+++ b/tests/test_typed_read_cmdb_tools.py
@@ -1,7 +1,6 @@
 """Typed read failures in the CMDB tools (v4.4 Tier 0.3, PR B).
 
-`Table_Tools.cmdb_tools` joins `_TYPED_CALLERS`, so a failed GET raises instead
-of returning None. Two things are locked here:
+A failed GET raises instead of returning None. Two things are locked here:
 
 1. Every public function returns `{"error": {"code", "message"}}` on a failure
    instead of one of its not-found strings (NO_CIS_FOUND_FOR_TYPE, CI_NOT_FOUND,
@@ -14,11 +13,9 @@ of returning None. Two things are locked here:
    gather in `get_ci_details`, a timeout on cmdb_ci_server made a server CI
    appear to live in the base cmdb_ci table.
 
-`TestEndToEndThroughTheRealDispatcher` checks the wiring against the real
-dispatcher instead of the module seam, since `_calling_module()` resolves the
-caller by walking the stack and a mocked `make_nws_request` would never exercise
-it. See that class's docstring for why the concurrent probes turned out not to
-threaten the walk.
+`TestEndToEndThroughTheRealDispatcher` drives failures through the real
+dispatcher rather than the module seam, so the handling is verified end to end
+rather than against a mock.
 """
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -292,19 +289,20 @@ class TestSimilarCis:
 
 
 class TestEndToEndThroughTheRealDispatcher:
-    """Proves the `_TYPED_CALLERS` entry actually resolves, gather included.
+    """Failures reach this module through the real dispatcher, gather included.
 
-    These exercise the real `make_nws_request`, not the module seam: without the
-    `"Table_Tools.cmdb_tools"` entry the shim hands back None and every
-    assertion here reverts to a not-found string.
+    These exercise the real `make_nws_request` rather than the module seam. That
+    was originally the only way to catch a typo in the `_TYPED_CALLERS` opt-in
+    list; with the shim gone the list is gone too, and what these now prove is
+    the property that outlived it — a real classified failure, produced by the
+    real dispatcher, is handled by this module rather than escaping it.
 
-    On the frame walk specifically — `_calling_module()` returns at the *first*
-    frame outside `http_layer`, which is `_probe_ci_table`, reached by an
-    ordinary direct await. The Task boundary that `asyncio.gather` introduces
-    sits several frames further out, past where the walk has already stopped, so
-    concurrency is not what puts the resolution at risk. Keep the gathered case
-    anyway: it costs nothing and pins the behavior against a future dispatcher
-    change that walks further.
+    Still not replaceable by the source scan in `test_http_layer_errors.py`: that
+    checks a handler EXISTS, these check it does the right thing.
+
+    The gathered case is kept deliberately: `get_ci_details` probes concurrently,
+    and a failure crossing a Task boundary is the case most likely to be handled
+    differently from a plain awaited one.
     """
 
     @pytest.mark.asyncio

--- a/tests/test_typed_read_generic_table_tools.py
+++ b/tests/test_typed_read_generic_table_tools.py
@@ -1,8 +1,8 @@
 """Typed read failures through the generic read path (v4.4 Tier 0.3, PR A).
 
-`Table_Tools.generic_table_tools` is the first module in
-`http_layer.request_dispatcher._TYPED_CALLERS`, so a failed GET arrives as a
-raised `ServiceNowRequestError` instead of `None`. What is locked here:
+`Table_Tools.generic_table_tools` was the first module migrated, so a failed
+GET arrives as a raised `ServiceNowRequestError` instead of `None`. What is
+locked here:
 
 * a failure returns `{"error": {"code", "message"}}` and nothing else — never a
   not-found message, never a bare error string;
@@ -12,8 +12,9 @@ raised `ServiceNowRequestError` instead of `None`. What is locked here:
 * the modules that re-wrap these responses (`consolidated_tools`,
   `intelligent_query_tools`) do not relabel a failure as "0 records found".
 
-The end-to-end test at the bottom goes through the real dispatcher, which is
-the only test that would catch a typo in the `_TYPED_CALLERS` module name.
+The end-to-end tests at the bottom go through the real dispatcher; everything
+above patches `make_nws_request` inside the consumer module and so cannot see
+whether the wiring below it actually works.
 """
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -466,11 +467,16 @@ class TestConsumersThatReWrap:
 
 
 class TestEndToEndThroughTheRealDispatcher:
-    """The only test that would catch a typo in the _TYPED_CALLERS module name.
+    """Failures reach the wrappers through the real dispatcher.
 
-    Everything above patches `make_nws_request` inside the consumer module, so
-    it would pass even if `_TYPED_CALLERS` never matched this module and the
-    shim kept returning None. These go through the real dispatcher.
+    These exercise the real `make_nws_request` rather than the module seam. That
+    was originally the only way to catch a typo in the `_TYPED_CALLERS` opt-in
+    list; with the shim gone the list is gone too, and what these now prove is
+    the property that outlived it — a real classified failure, produced by the
+    real dispatcher, is handled by this module rather than escaping it.
+
+    Still not replaceable by the source scan in `test_http_layer_errors.py`: that
+    checks a handler EXISTS, these check it does the right thing.
     """
 
     @pytest.mark.asyncio

--- a/tests/test_typed_read_kb_article_tools.py
+++ b/tests/test_typed_read_kb_article_tools.py
@@ -1,7 +1,6 @@
 """Typed read failures in the KB article tools (v4.4 Tier 0.3, PR C).
 
-`Table_Tools.kb_article_tools` joins `_TYPED_CALLERS`, so a failed GET raises
-instead of returning None. Four things are locked here:
+A failed GET raises instead of returning None. Four things are locked here:
 
 1. **The publish guard is fail-closed.** `_check_kb_duplicates` has three
    outcomes — clear, duplicates-found, inconclusive — and only *clear* permits a
@@ -560,11 +559,20 @@ class TestPreWriteReadsDistinguishAbsentFromFailed:
 
 
 class TestEndToEndThroughTheRealDispatcher:
-    """Proves the `_TYPED_CALLERS` entry resolves for this module.
+    """A failed read reaches the publish guard through the real dispatcher.
 
-    Without the entry the shim returns None, `_check_kb_duplicates` answers `[]`,
-    and the article publishes — so these fail if the entry is reverted, which the
-    mock-at-the-module-seam tests above cannot detect on their own.
+    These exercise the real `make_nws_request` rather than the module seam. That
+    was originally the only way to catch a typo in the `_TYPED_CALLERS` opt-in
+    list; with the shim gone the list is gone too, and what these now prove is
+    the property that outlived it — a real classified failure, produced by the
+    real dispatcher, is handled by this module rather than escaping it.
+
+    Still not replaceable by the source scan in `test_http_layer_errors.py`: that
+    checks a handler EXISTS, these check it does the right thing.
+
+    Concretely: if a failure ever again arrives here as `None`,
+    `_check_kb_duplicates` answers `[]` and the article publishes unchecked. That
+    is the regression these guard, and the module-seam tests above cannot see it.
     """
 
     @pytest.fixture

--- a/tests/test_typed_read_table_tools.py
+++ b/tests/test_typed_read_table_tools.py
@@ -120,8 +120,12 @@ class TestNowTestAuthInput:
 
 
 class TestEndToEndThroughTheRealDispatcher:
-    """Without the `_TYPED_CALLERS` entry the shim returns None and both tools
-    fall back to their misleading strings. Module-seam mocks cannot see that."""
+    """Both tools report the classified failure through the real dispatcher.
+
+    If a failed read ever arrives here as `None` again, both fall back to their
+    misleading strings — "Authentication test failed" for a timeout, "table may
+    not exist" for a read that never completed. Module-seam mocks cannot see it.
+    """
 
     @pytest.fixture
     def failing_transport(self, monkeypatch):

--- a/tests/test_typed_read_vtb_task_tools.py
+++ b/tests/test_typed_read_vtb_task_tools.py
@@ -1,7 +1,7 @@
 """Typed read failures in the private-task tools (v4.4 Tier 0.3, PR D).
 
-`Table_Tools.vtb_task_tools` joins `_TYPED_CALLERS`. The module has exactly one
-read, and it is the sensitive kind: the pre-write `sys_id` lookup in
+The module has exactly one read, and it is the sensitive kind: the pre-write
+`sys_id` lookup in
 `update_private_task`. Its answer decides whether a write happens, so
 conflating "the task does not exist" with "the lookup failed" both mislabelled
 the failure AND withheld the write (decision (d)).
@@ -96,12 +96,20 @@ class TestPreWriteLookup:
 
 
 class TestEndToEndThroughTheRealDispatcher:
-    """Proves the `_TYPED_CALLERS` entry resolves for this module.
+    """A failed lookup reaches `update_private_task` through the real dispatcher.
 
-    Without the entry the shim returns None, `_get_task_sys_id` answers None, and
-    the update reports the task as missing. Tests that patch
-    `Table_Tools.vtb_task_tools.make_nws_request` cannot detect that, because they
-    never reach the dispatcher.
+    These exercise the real `make_nws_request` rather than the module seam. That
+    was originally the only way to catch a typo in the `_TYPED_CALLERS` opt-in
+    list; with the shim gone the list is gone too, and what these now prove is
+    the property that outlived it — a real classified failure, produced by the
+    real dispatcher, is handled by this module rather than escaping it.
+
+    Still not replaceable by the source scan in `test_http_layer_errors.py`: that
+    checks a handler EXISTS, these check it does the right thing.
+
+    Concretely: if a failure arrives as `None` again, `_get_task_sys_id` answers
+    None and the update reports the task as missing while silently declining to
+    write it.
     """
 
     @pytest.fixture


### PR DESCRIPTION
Final PR of the v4.4 Tier 0.3 chain (after #64, #65, #66, #67). Deletes the migration scaffold.

## This is where Tier 0's exit criterion becomes true

Throughout the chain `_TYPED_CALLERS` was an **opt-in** set: any caller outside it still received `None` and still reported a timeout as a missing record. So *"a timeout is never reportable as not-found"* was **false for the entire migration**, and 4.4.0 could not honestly have claimed it before this commit. It is true now.

## Deleted

`_TYPED_CALLERS`, `_legacy_none_shim`, `_calling_module`, `_PACKAGE`, the scaffold comment block, and the now-unused `inspect` import. `make_nws_request`'s GET branch is one line:

```python
if method == "GET":
    return await _get_typed(url, display_value)
```

Net **-255 / +152** lines.

## Replaced, not deleted: the completeness check

The shim-era test asserted the opt-in set was *complete*. That property stops mattering once the raise is unconditional; what matters instead is that every read-path consumer **handles** the raise. So `test_typed_callers_covers_every_read_path_consumer` became `test_every_read_path_consumer_handles_the_raise`.

Both versions derive the consumer set by **scanning the tree** rather than trusting a list — which is the check that would have caught the module #67 found missing. A new consumer added without an `except ServiceNowRequestError` arm fails it, named.

Consumers are detected **by import, via the AST** — an aliased import (`from http_layer import make_nws_request as fetch`) binds the name and never spells it at the call site, so a text match would have missed the module *silently*, which is worse than not having the guard. The handler check is AST-based too, so it accepts a tuple arm or a qualified exception name.

Two limits, stated in the docstring so nobody over-reads a green run:
- it cannot prove a handler is *correct*, only that one exists — per-module correctness stays in the five `test_typed_read_*.py` files, each driving a real failure through the real dispatcher;
- it is per-module, not per-call-site: a module with a handler in one function and none in another passes. None of the five has such a gap today, checked by hand.

## Tests removed as meaningless rather than adjusted

| removed | why |
|---|---|
| `test_unmigrated_caller_still_gets_none` | there are no unmigrated callers |
| `test_flattener_failure_is_classified_not_propagated` | same; its migrated twin covers the behaviour |
| `TestCallingModuleResolution` (3 tests) | the frame walk it tested is gone |

Kept, with the `_TYPED_CALLERS` monkeypatch dropped and names corrected to stop describing callers as "migrated": the typed-error, timeout-is-not-not-found, success-path, empty-is-success, and flattener-classification cases.

## One straggler

`tests/test_service_now_api.py` asserted `result is None` for a failed GET — docstring and all (*"Test API request with error returns None"*). It was in no inventory, and **the checklist grep does not catch it**, because it mocks a `side_effect` rather than `return_value = None`. Now asserts the raise. Worth noting the checklist's grep has that blind spot; the suite caught this one, but only because the behaviour changed under it.

## Doc rot from the deletion

Five module docstrings and five test docstrings referenced the deleted symbols. The end-to-end classes needed more than find-and-replace: their stated purpose was *catching a typo in the opt-in list*, which no longer exists. Each now states what it actually proves — that a real classified failure, produced by the real dispatcher, is handled by that module. (One shared paragraph keeps a deliberate past-tense reference to `_TYPED_CALLERS` explaining the origin, and says in the same breath that the list is gone.)

## Enforced merge checklist (plan §4)

All three verified, not asserted:

1. **Zero `make_nws_request → None` mocks asserting not-found.** The three surviving `return_value = None` hits are write-path tests asserting `ERROR_*_WRITE_UNCONFIRMED`, plus the out-of-scope `test_connection` mock.
2. **Zero unhandled raises across the consumer modules** — now mechanically enforced by the handler scan rather than argued.
3. **`_legacy_none_shim` gone**, along with the rest of the scaffold.

### Review outcome

Reviewed. The critical question — can a `ServiceNowRequestError` now escape any of the 39 registered tools? — was traced per call site, including the three pass-through layers the scan structurally cannot see. **No such path.** One blind spot in the guard itself was found and fixed in `afa9b75` (see above). No blockers.

Suite: **949 passed, 5 skipped**. `http_layer/errors.py` at 100%; the 5 uncovered dispatcher lines are `test_oauth_connection`'s pre-existing except branch, untouched here.

## After this

`chore/v4.4_release`: 3-way version bump (`pyproject.toml:3`, `manifest.json:5`, `personal_mcp_servicenow_main.py:25`), CHANGELOG "Behavior changes" collecting all of #56 / #58 / #59 / #60 / #61 / #65 / #66 / #67 and this PR, refresh `graphify-out/`, tag `v4.4.0`.

Two items deliberately **not** in 4.4.0, both logged:
- **The encoder round trip.** `ensure_query_encoded` unquotes before re-quoting and keeps `= < > & ^ ( ) : @ !` in its safe-set, so `^`, `&` and `%XY` in a value produce a query that differs from the one requested, and runs broader. `kb_article_tools` refuses to answer in that case (#66); `cmdb_tools`' attribute search and the generic text search remain exposed. Shared by every table and under the locked token invariant, so it needs its own PR.
- **The planning docs are wrong about the module count** (four, not five). Worth correcting so the next reader doesn't inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
