### PR TITLE
chore(release): v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,176 @@ All notable changes to the Personal MCP ServiceNow project will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.0] - 2026-08-06
+
+Tier 0 of the v5 "Boron" redesign: correctness only, no tool-count changes. Still 39 tools.
+
+**The theme is that the server stops answering questions it does not know the answer to.**
+Before this release a failed read returned `None`, which every consumer turned into "no
+matching records" — so a 30-second timeout, an expired credential and an empty table all
+produced the same reply. Six months of "it says there are no results" could mean any of them.
+
+That one conflation is the root of most entries below, and it appeared in more places than
+expected once the reads were typed: a CMDB timeout attributed a server to the wrong table, a
+failed duplicate check let a KB article publish unchecked, a failed lookup told users their
+task did not exist and then declined to update it.
+
+**Upgrade note.** Read the "Behavior changes" section before upgrading. Result sets get larger
+(#58), some inputs that used to return rows now return errors (#60, #61), and a KB publish can
+now be refused where it previously went ahead (#66). All of those are deliberate.
+
+### Added
+
+- **Knowledge article SEO fields** — `meta` and `meta_description` are updatable via
+  `update_knowledge_article` and appear in detail reads. They were blocked by the write
+  allowlist. (#54)
+- **`Table_Tools/read_helpers.py`** — `is_read_failure`, `carry_partial`,
+  `carry_partial_after_filter`. The failure and partial-read shapes travel up through several
+  modules that re-wrap each other's responses; these keep both intact, because re-wrapping a
+  failure as an empty result is easy to reintroduce and reads as ordinary code.
+- **A test that derives its own subject matter.** `test_every_read_path_consumer_handles_the_raise`
+  walks the AST for every module importing `make_nws_request` and asserts each has an
+  `except ServiceNowRequestError` arm. Detection is by *import*, not by a text match on
+  `make_nws_request(` — an aliased import binds the name and never spells it at the call site,
+  so a text match would skip the module silently. A new consumer without a handler fails the
+  suite, named. (#67, #68)
+- Golden intent set for tool-selection baselining. (#57)
+
+### Behavior changes
+
+Each of these changes an answer a caller previously received.
+
+- **A failed read is never reported as a missing record.** A failed GET now raises
+  `ServiceNowRequestError`, and consumers return `{"error": {"code", "message"}}` with a code
+  from a fixed seven-value vocabulary (`VALIDATION`, `NOT_FOUND`, `AUTH`, `FORBIDDEN`,
+  `TIMEOUT`, `HTTP`, `INTERNAL`). `NOT_FOUND` is used only when ServiceNow actually returned
+  404. An empty result set keeps its existing not-found message — empty is still success, and
+  deciding what it means stays the consumer's job. (#59, #64-#68)
+- **A partial read keeps its rows.** A page failing mid-pagination returns the rows already
+  collected plus `partial: true` and the error, instead of discarding them; a first-page failure
+  is a plain error. If a filter empties a partial result, the response is the failure, not "no
+  matches" — a confident "nothing found" next to an error saying the read never finished is
+  self-contradicting, and the rows that would have matched may be in the pages that failed. (#64)
+- **KB publish is fail-closed.** The duplicate check now has three outcomes — clear,
+  duplicates-found, inconclusive — and only *clear* permits a publish. Previously a failed
+  check returned `[]`, the one value `publish_knowledge_article` reads as "clear to publish", so
+  a timeout published the article with the guard skipped and reported success. Inconclusive
+  covers: the read failed; the title contains `^` or `&`, which an encoded query cannot carry
+  inside a value; the title contains a `%XY` sequence, which the read path decodes so
+  ServiceNow would be searched for a different string; or the result page hit its new
+  `sysparm_limit=200` and a duplicate may be off the end of it. (#66)
+- **An unreadable publish verification no longer re-fires the workflow.** A failed verify read
+  was indistinguishable from "not published yet", so the publish was submitted a second time —
+  a write retried because a *read* failed. Now one submission, reported as `unconfirmed` with
+  the article's state unknown, because the write did go out and may have committed.
+  `publish_knowledge_articles` gains that status alongside `published`, `blocked` and `error`.
+  (#66)
+- **`check_kb_duplicates` no longer answers "no duplicates" from a check that did not run.**
+  Rows for an indeterminate check omit `has_duplicate` entirely and carry
+  `duplicate_check: "inconclusive"` plus `error`. Previously such a row read
+  `has_duplicate: False` with no error field — and this is the tool the publish-unconfirmed
+  message tells users to re-check with. (#66)
+- **KB and private-task writes that return no record report "could not be confirmed"** instead
+  of "<operation> successful but no data returned". The old wording asserted the write had
+  landed on the strength of an empty response, which is the one thing an empty response cannot
+  establish. (#66)
+- **Domain filtering deleted.** Incident queries no longer silently append
+  `category != Payroll / People Support / Workplace`, and `sc_*` queries no longer append a
+  `People_Pay` catalog exclusion plus 11 assignment-group exclusions. **Result sets get larger
+  and noisier** — this is the change most likely to be noticed. The exclusions were a legacy
+  policy from an earlier deployment; the server is authorized-personnel-only, so they bought
+  nothing while making every query wider, slower and harder to reason about. (#58)
+- **A CMDB probe failure fails the whole lookup** instead of counting as "the CI is not in this
+  table". Every CI also lives in the base `cmdb_ci` table, so a timeout on `cmdb_ci_server`
+  used to make a server CI appear to live in `cmdb_ci` — the wrong table, reported
+  confidently. An incomplete probe set supports neither "not found anywhere" nor attribution to
+  a less specific table. A failure *after* a hit is ignored: the higher-priority table already
+  decided. (#65)
+- **CMDB tools return an error object rather than a not-found string on failure.** Five guards
+  of the form `if data and data.get('result')` were collapsing a failed read into
+  `NO_CIS_FOUND_FOR_TYPE`, `CI_NOT_FOUND`, `NO_CI_TYPES_FOUND` and friends. The module's return
+  type is `dict | str` for now; the strings go in a later tier. (#65)
+- **`ci_type` is validated by shape.** A value that is not a `cmdb_ci*` table name returns an
+  error instead of rows from a different table, and cannot smuggle query parameters into the
+  URL path. `get_all_ci_types` renames `record_count` → `number_prefix_ref`: the underlying
+  `sys_db_object.number_ref` is a reference to the table's numbering configuration, never a row
+  count, and the old name invited callers to read it as a population figure. Use
+  `find_cis_by_type(ci_type)` and read `count` if you need one. (#60)
+- **`task_sla` is guarded on the identity tools.** `search_records`, `get_record_summary`,
+  `get_record` and `find_similar` return an error for `task_sla` instead of unrelated rows —
+  the table has no `number` prefix and uses `stage` rather than `state`, so those tools were
+  answering with whatever came back. `similar_slas_for_text` and natural-language search on
+  `task_sla` return actual matches instead of an arbitrary page, by resolving the text-search
+  field from the table rather than asking callers to pass it. (#61)
+- **An explicit `auth_type` other than `oauth` raises `ConfigError`** at validation instead of
+  being accepted and then failing at request time. (#56)
+- **A pre-write lookup failure is no longer reported as a missing record.**
+  `update_knowledge_article`, `publish_knowledge_article`, `retire_knowledge_article` and
+  `update_private_task` return the classified failure; a genuinely absent record keeps its
+  existing "not found" message. Previously a timeout during the `sys_id` lookup told the user
+  their article or task did not exist, and silently declined to write it. (#66, #67)
+- **The auth-test tools name the actual failure.** `nowtestauth` answered "Authentication test
+  failed" for any failure including a timeout, and `nowtest_auth_input` guessed "table may not
+  exist or no permissions" for a read that never completed. Both are what someone reaches for
+  while trying to find out what is broken, and both were prepared to blame the wrong thing.
+  (#67)
+
+### Fixed
+
+- **Read-failure classification.** `ValueError` was reported as "response is not valid JSON",
+  because `json.JSONDecodeError` subclasses it and the handler paired them — so a missing
+  `.env`, which raises `ValueError("Missing OAuth configuration")` *before any request*, was
+  reported as a JSON parse failure. Separately the OAuth exception hierarchy fell through to
+  `INTERNAL`, so a wrong client secret read as "unexpected internal error" while the identical
+  failure arriving as an httpx 401 mapped to `AUTH`. (#59)
+- **Response flattening is inside the error-handling boundary.** It had drifted outside, which
+  would have propagated a parser failure uncaught to MCP clients for every read caller. (#59)
+- **`ci_type` matched with `fullmatch`, not `match`.** Python's `$` also matches immediately
+  before a single trailing newline, so `"cmdb_ci_server\n"` passed the validation that was
+  meant to close a path-injection hole. (#60)
+- **`search_field` plumbing restored.** Merging #61 after #58 kept #61's docstrings and call
+  sites while taking the pre-#61 code, so the signature, an import and a format placeholder all
+  vanished while everything referencing them stayed. Docstrings surviving a conflict resolution
+  is not evidence the code did. (#63)
+- **Test coverage on the two least-tested modules.** `Table_Tools/cmdb_tools.py` went from
+  62.63% to 88.64% line coverage — its existing test file patched the module's own bound
+  attributes and so asserted nothing about the real functions. `table_tools.py` went from 11.43%
+  to 100%; it had no tests of its own at all, which is why it went unnoticed as an unmigrated
+  read-path consumer until the migration was nearly finished. (#65, #67)
+
+### Removed
+
+- The `_legacy_none_shim` / `_TYPED_CALLERS` / `_calling_module` migration scaffold. It let the
+  five consumer modules be migrated one PR at a time without exposing a half-migrated module,
+  and its deletion is what makes the read contract unconditional. (#68)
+- Domain category and catalog exclusion filtering. (#58)
+- The unusable basic-auth credential path. (#56)
+
+### Internal
+
+No runtime effect; listed so a merge log diffed against this file shows no silent gaps.
+`.gitignore` and stale-artifact cleanup (#53), SonarQube test-smell fixes (#55), doc rot plus
+the backfilled 4.3.0 changelog (#62). The `v4.3.0..HEAD` merge range also contains Bitbucket-
+numbered duplicates (#49-#52) of work already released in 4.3.0 — an artefact of the dual-remote
+history, not additional changes.
+
+### Known limitation
+
+**`^` and `&` inside an encoded-query *value* still produce a query that differs from the one
+requested — and it runs broader.** `ensure_query_encoded` unquotes before re-quoting and keeps
+the ServiceNow operator characters in its safe set, so percent-encoding a value at the call site
+does not survive. `^` is worse than a leak: it is genuinely unrepresentable inside a value,
+because ServiceNow's condition parser splits on it after URL-decoding and the syntax has no
+escape mechanism.
+
+Affected: `search_cis_by_attributes` / `quick_ci_search` (a `^` or `&` in a name or location),
+and caller-supplied filter values via `filter_records` / `query_table_with_filters`. Not
+affected: the text search tools, whose keyword tokenizer drops those characters before they
+reach a query, and the KB duplicate check, which refuses to answer rather than trust it (#66).
+
+The fix is a per-value encoding boundary plus refusing `^`, which touches every table and the
+token-optimization invariant — deliberately not bundled into a correctness release.
+
 ## [4.3.0] - 2026-07-14
 
 Backfilled 2026-08-03 from the 33 non-merge commits between the 4.1.0 work and the `v4.3.0` tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ Each of these changes an answer a caller previously received.
   is not evidence the code did. (#63)
 - **Test coverage on the two least-tested modules.** `Table_Tools/cmdb_tools.py` went from
   62.63% to 88.64% line coverage — its existing test file patched the module's own bound
-  attributes and so asserted nothing about the real functions. `table_tools.py` went from 11.43%
+  attributes and so asserted nothing about the real functions. `table_tools.py` went from 13.79%
   to 100%; it had no tests of its own at all, which is why it went unnoticed as an unmigrated
   read-path consumer until the migration was nearly finished. (#65, #67)
 
@@ -152,20 +152,33 @@ Each of these changes an answer a caller previously received.
 
 ### Internal
 
-No runtime effect; listed so a merge log diffed against this file shows no silent gaps.
+Listed so a merge log diffed against this file shows no silent gaps.
 `.gitignore` and stale-artifact cleanup (#53), SonarQube test-smell fixes (#55), doc rot plus
 the backfilled 4.3.0 changelog (#62). The `v4.3.0..HEAD` merge range also contains Bitbucket-
 numbered duplicates (#49-#52) of work already released in 4.3.0 — an artefact of the dual-remote
 history, not additional changes.
+
+One of these is visible at runtime, narrowly: #62 corrected the `how_to_use` hint returned by
+`get_servicenow_filter_templates`, which pointed at `getIncidentsByFilter`, a function that no
+longer exists. Copy in a tool's output, not behaviour.
 
 ### Known limitation
 
 **`^` and `&` inside an encoded-query *value* still produce a query that differs from the one
 requested — and it runs broader.** `ensure_query_encoded` unquotes before re-quoting and keeps
 the ServiceNow operator characters in its safe set, so percent-encoding a value at the call site
-does not survive. `^` is worse than a leak: it is genuinely unrepresentable inside a value,
-because ServiceNow's condition parser splits on it after URL-decoding and the syntax has no
-escape mechanism.
+does not survive.
+
+The two fail by different mechanisms, and `&` is the more severe:
+
+- `^` splits the value into two **conditions** inside ServiceNow's own encoded-query parser. It
+  is worse than a leak — it is genuinely *unrepresentable* inside a value, because the parser
+  splits on it after URL-decoding and the syntax has no escape mechanism. No encoder change can
+  carry it; the only options are refusing the value or restructuring the query.
+- `&` escapes `sysparm_query=` and becomes a **sibling URL parameter**, truncating the condition
+  at the `&` and appending a stray parameter — it breaks out of the query string itself rather
+  than being mis-parsed within it. Unlike `^` this one is representable, and survives correctly
+  if the encoding is preserved, so it is fixable.
 
 Affected: `search_cis_by_attributes` / `quick_ci_search` (a `^` or `&` in a name or location),
 and caller-supplied filter values via `filter_records` / `query_table_with_filters`. Not

--- a/Diagrams & Documentation/README.md
+++ b/Diagrams & Documentation/README.md
@@ -75,4 +75,4 @@ httpx → ServiceNow Table API
 
 ---
 
-*Last updated: 2026-07-19 · Project version: 4.3.0*
+*Last updated: 2026-08-06 · Project version: 4.4.0*

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ MCP server for ServiceNow integration. Uses FastMCP over stdio transport, OAuth 
 
 ## Release highlights
 
-Current version: **4.3.0** — 39 registered tools. Full history in [CHANGELOG.md](CHANGELOG.md).
+Current version: **4.4.0** — 39 registered tools. Full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Release | What changed |
 |---|---|
+| **4.4.0** | Correctness release. A failed read is no longer reported as a missing record — reads raise a classified error instead of returning `None`, so a timeout, an expired credential and an empty table stop producing the same answer. KB publishing is fail-closed on an unusable duplicate check. Legacy domain filtering deleted, so result sets get larger. See the CHANGELOG's "Behavior changes" before upgrading. |
 | **4.3.0** | Claude Desktop `.mcpb` packaging; Nuitka binary builds dropped from the release workflow. Absorbed the performance and token work planned as 4.2 (pooled httpx client, one OR-combined keyword query, concurrent CMDB probes). |
 | 4.1.0 † | v4.0 shims deleted; KB write tools; `get_kb_articles_by_state`; `get_query_syntax_help`; `filter_records` truncation metadata. |
 | **4.0.0** | SLA collapse, `filter/` + `http_layer/` + `oauth/` packages. Breaking — see below. |

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "personal-mcp-servicenow",
   "display_name": "ServiceNow for Claude",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Query and manage ServiceNow incidents, changes, knowledge articles, SLAs and CMDB directly from Claude.",
   "long_description": "39 tools for ServiceNow: incident/change/request search, intelligent query building, knowledge base management, SLA reporting, CMDB exploration and private task CRUD. Uses OAuth client credentials against your company's ServiceNow instance.",
   "author": {

--- a/personal_mcp_servicenow_main.py
+++ b/personal_mcp_servicenow_main.py
@@ -22,7 +22,7 @@ structlog.configure(
     logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
 )
 
-__version__ = "4.3.0"
+__version__ = "4.4.0"
 
 
 def parse_args():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "personal-mcp-servicenow"
-version = "4.3.0"
+version = "4.4.0"
 description = "MCP server for ServiceNow (incidents, changes, KB, SLA, CMDB)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Release branch for **v4.4.0** — Tier 0 of the v5 "Boron" redesign. Correctness only; tool count unchanged at 39.

Two commits: the 3-way version bump, and the CHANGELOG section.

## What's in the release

Tier 0 landed as #56, #57, #58, #59, #60, #61, #63, #64, #65, #66, #67, #68, plus the KB SEO-fields feature (#54).

**The theme:** the server stops answering questions it does not know the answer to. Before this, a failed read returned `None` and every consumer turned that into "no matching records" — so a 30-second timeout, an expired credential and an empty table all produced the same reply.

Once the reads were typed, that one conflation turned out to reach further than expected:
- a CMDB timeout attributed a server to the wrong table (every CI also lives in base `cmdb_ci`)
- a failed duplicate check let a KB article publish **unchecked**, and reported success
- a failed lookup told users their task did not exist, then declined to update it
- an unreadable publish verification re-fired the publish **write**

## Version

3-way sync, as the `.mcpb` packaging requires — `pyproject.toml:3`, `manifest.json:5`, `personal_mcp_servicenow_main.py:25` all at `4.4.0`. Verified no `4.3.0` remains in any version field.

## On the CHANGELOG

**Derived from `git log v4.3.0..HEAD`, not from the plan's behavior-change list.** That list omits #53, #54 and #55 — and #54 is user-facing (KB `meta` / `meta_description` became updatable). This is the third time this cycle a hand-maintained list turned out to be short; the same failure hid an unmigrated consumer module until #67.

Every PR number cited was cross-checked against the merge log programmatically. The seven merged-but-uncited PRs are recorded under **Internal** so that anyone diffing merges against the CHANGELOG finds no silent gap — #53/#55/#62 are housekeeping, and #49-#52 are Bitbucket-numbered duplicates of 4.3.0 work, an artefact of the dual-remote history.

Two numbers in my first draft were wrong and are corrected in the commit:
- `cmdb_tools` coverage is **62.63% → 88.64%**, not from the 10.86% the migration inventory quoted — that figure predates #60's test file
- `table_tools` had **no tests at all**, not bad ones

A later review caught a third: the `table_tools` baseline is **13.79%**, not the 11.43% I first wrote — I had measured after its own migration commit added statements to the file. Fixed in `840d155`, along with the README files, which were still advertising 4.3.0.

## Known limitation, documented rather than omitted

`^` and `&` inside an encoded-query **value** still produce a query that differs from the one requested — and it runs **broader**. `ensure_query_encoded` unquotes before re-quoting and keeps the SN operators in its safe set, so call-site percent-encoding does not survive.

They fail by **two different mechanisms**, and `&` is the more severe:

- `^` is mis-parsed *inside* ServiceNow's condition parser, splitting the value into two conditions. Genuinely **unrepresentable** in a value — no encoder change can carry it.
- `&` **escapes `sysparm_query=` entirely** and becomes a sibling URL parameter, truncating the condition and appending a stray one. Unlike `^` it is representable, so it is fixable.

Measured surface, not assumed:

| surface | exposed to |
|---|---|
| `search_cis_by_attributes` / `quick_ci_search` | `^`, `&` |
| caller-supplied values via `filter_records` / `query_table_with_filters` | `^`, `&` |
| text search tools (`search_records`, `find_similar`) | **nothing** — the keyword tokenizer drops those characters first |
| KB duplicate check | **nothing** — refuses to answer rather than trust it (#66) |

The text-search safety is *incidental* — it comes from tokenization, not design. Worth knowing before someone changes the tokenizer, which is why it is written down.

The fix (a per-value encoding boundary plus refusing `^`) touches every table and the locked token-optimization invariant, so it is deliberately not bundled into a correctness release.

### Review outcome

Fact-checked against the code, including independent probes of the exposure table and coverage measured across six commits in disposable worktrees. Four findings, all fixed in `840d155`: the `table_tools` coverage baseline, an incomplete version sync (two READMEs still said 4.3.0), an overstated "no runtime effect" claim, and the `^`-vs-`&` mechanisms, which are different and needed separating. No blockers.

## Not in this branch

**`graphify-out/` has not been refreshed** — being handled separately. Release branches are normally the only place it is committed, so either land that refresh before tagging or accept that the graph lags one release.

## After merge

Tag `v4.4.0` on `main`, then converge Bitbucket (`git reset --hard remote/main && git push origin main`) — merge on GitHub only, never the duplicate Bitbucket PR.

Suite: **949 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
