### PR TITLE
fix: carry encoded-query values faithfully and refuse '^' (v4.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,13 @@ a test matrix rather than incrementally.
   branch, both priority builders, the caller-exclusion list, `_build_additional_filters`, and the
   CMDB/KB/VTB call sites. The three the plan missed included the *default* handler — the one most
   callers reach. A source scan now fails, by name, if a new terminal handler forgets.
-- **A `sys_id`/`number` lookup that selects a write target is escaped.** `kb_article_tools` and
-  `vtb_task_tools` resolve a record by `number=` and then PATCH the result; a `^` there could
-  have OR'd in a second condition and resolved to a *different* record.
+- **A `sys_id`/`number` lookup that selects a write target is escaped.** `kb_article_tools`,
+  `cmdb_tools` and `vtb_task_tools` resolve a record by `number=` and then PATCH or attribute the
+  result; a `^` there could have OR'd in a second condition and resolved to a *different* record.
+  Five such lookups, and review caught that only one of them was pinned — reverting the escaping
+  on the other four left the suite green. An AST scan across `Table_Tools/` now names any
+  `number=` interpolation that is not escaped, following a one-hop local assignment so an
+  already-escaped variable is not a false positive.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,82 @@ All notable changes to the Personal MCP ServiceNow project will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.1] - 2026-08-10
+
+Closes the one correctness defect 4.4.0 shipped with a "Known limitation" heading: a `^`, `&` or
+literal `%XY` inside an encoded-query **value** produced a query that differed from the one
+requested — and always a broader one. Same family as the silently-dropped-filter class 4.4.0
+was about: the server answered a question nobody asked and presented the rows as matches.
+
+**Why it needed its own release.** The fix is a coordinated flip. The transport was silently
+normalising every producer's query, so it could not stop doing that until every producer escaped
+its own values, and no producer could usefully escape while the transport undid it. Half a flip
+gives either double-encoded values or raw structural characters, so it lands in one commit with
+a test matrix rather than incrementally.
+
+### Fixed
+
+- **`&` in a query value no longer truncates the condition.** It was never mis-parsed *within*
+  the query — it escaped `sysparm_query=` and became a sibling URL parameter, so
+  `nameLIKESales & Marketing` searched for "Sales " and sent a stray `Marketing` parameter.
+  `&` is not an encoded-query operator (conditions separate on `^`), so it left the transport's
+  safe-set; values are now escaped at the producer and that escaping survives.
+- **A literal `%XY` in a value is no longer decoded on its way out.** The transport unquoted
+  before re-quoting, so a search for `Deal 20%2C off` ran against `Deal 20, off` and `%41dmin`
+  against `Admin`. `unquote` never raises, so nothing announced it. Values escape their own `%`
+  to `%25` now.
+- **Nine escaping seams, not the four the plan listed.** Derived from the code: the exact-match
+  default, the operator-prefix handler, the suffix-operator handler, the date-range `>=`/`<=`
+  branch, both priority builders, the caller-exclusion list, `_build_additional_filters`, and the
+  CMDB/KB/VTB call sites. The three the plan missed included the *default* handler — the one most
+  callers reach. A source scan now fails, by name, if a new terminal handler forgets.
+- **A `sys_id`/`number` lookup that selects a write target is escaped.** `kb_article_tools` and
+  `vtb_task_tools` resolve a record by `number=` and then PATCH the result; a `^` there could
+  have OR'd in a second condition and resolved to a *different* record.
+
+### Changed
+
+- **A `^` in a query value is refused instead of answered.** It is unrepresentable, not merely
+  mis-transported: ServiceNow's parser splits on the *decoded* value, so no encoding can carry
+  it. Affected tools return `{"error": {"code": "VALIDATION", ...}}` and send no request.
+  `^OR` inside a filter value is unchanged — it is still read as caller-supplied query structure,
+  which is what an LLM writing `{"priority": "1^ORpriority=2"}` means.
+- **A `^NQ` new-query-reset in a filter value is refused instead of silently dropped.** The drop
+  removed the poisoned condition but still ran the rest, handing back real-looking rows from a
+  query the caller did not ask for.
+- **A KB title containing `&` or `%` no longer blocks a publish.** The duplicate check refused
+  those as inconclusive because it could not trust the query; it can now. `^` still blocks —
+  fail-closed, since a check that ran broader than asked cannot clear a publish. `KB_QUERY_UNSAFE_CHARS`
+  went from `("^", "&")` to `("^",)` and the percent round-trip check is gone.
+- **`Table_Tools.generic_table_tools._encode_query_string` is an alias for the transport's
+  encoder.** It was a second, independent `quote(safe=...)` with a different safe-set and no
+  idempotency, so a value could pass through two encoders that disagreed and be round-trip-stable
+  by luck. One implementation now.
+
+### Added
+
+- **`filter/value_encoding.py`** — `encode_query_value`, `QueryValueError`, `QUERY_VALUE_SAFE`.
+  The producer half of the contract. Its safe-set is deliberately the transport's minus `^`, and
+  a test pins that relationship: the transport's idempotency-by-decoding is only sound while
+  decoding cannot resurrect a structural character.
+- **`tests/test_query_value_encoding.py`** and **`tests/sn_query_probe.py`** — the matrix asserts
+  the value ServiceNow's parser *decodes*, plus the condition count and the URL parameter count,
+  across 24 characters and 12 producer seams. Asserting on the encoded URL string is how you
+  write a test that passes while the query is still wrong. 15 mutations were run against the
+  fix; each is caught by a named behavioural test.
+- A regression test pinning the text-search tokenizer's `\b[a-zA-Z]{4,}\b` character class. The
+  text-search tools were never affected by any of this, but only because a keyword cannot contain
+  `^`, `&` or `%` — protection nobody designed, which a widened tokenizer would have removed
+  silently.
+
+### Known limitation
+
+`_has_operator_in_value` still treats any `=` in a filter value as caller-supplied operator
+syntax, so `{"short_description": "Cost=Center"}` builds a condition on a field that does not
+exist, which ServiceNow drops silently. Not an encoding defect — escaping cannot decide whether
+the caller meant an operator — and pinned by a test rather than left unrecorded. The value
+round-trips correctly once the operator is explicit (`LIKECost=Center`).
+
 ## [4.4.0] - 2026-08-06
 
 Tier 0 of the v5 "Boron" redesign: correctness only, no tool-count changes. Still 39 tools.
@@ -164,10 +240,13 @@ longer exists. Copy in a tool's output, not behaviour.
 
 ### Known limitation
 
-**`^` and `&` inside an encoded-query *value* still produce a query that differs from the one
+**`^` and `&` inside an encoded-query *value* produce a query that differs from the one
 requested — and it runs broader.** `ensure_query_encoded` unquotes before re-quoting and keeps
 the ServiceNow operator characters in its safe set, so percent-encoding a value at the call site
 does not survive.
+
+> **Fixed in [4.4.1].** `&` and a literal `%XY` are carried faithfully; `^` is refused rather
+> than answered. Kept here as the record of what 4.4.0 shipped with.
 
 The two fail by different mechanisms, and `&` is the more severe:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,16 @@ a test matrix rather than incrementally.
   before re-quoting, so a search for `Deal 20%2C off` ran against `Deal 20, off` and `%41dmin`
   against `Admin`. `unquote` never raises, so nothing announced it. Values escape their own `%`
   to `%25` now.
-- **Nine escaping seams, not the four the plan listed.** Derived from the code: the exact-match
+- **Sixteen escaping seams, not the four the plan listed.** Derived from the code: the exact-match
   default, the operator-prefix handler, the suffix-operator handler, the date-range `>=`/`<=`
-  branch, both priority builders, the caller-exclusion list, `_build_additional_filters`, and the
-  CMDB/KB/VTB call sites. The three the plan missed included the *default* handler — the one most
-  callers reach. A source scan now fails, by name, if a new terminal handler forgets.
+  branch, all three priority builders, the caller-exclusion list, `_build_additional_filters`, and
+  the CMDB/KB/VTB call sites. The three the plan missed included the *default* handler — the one
+  most callers reach; review then found four more that were escaped correctly but **unasserted**
+  (`_build_priority_filter`'s single-priority branch and the CMDB `ip_address`/`location`/`status`
+  attributes), so reverting any of them left the suite green. A taint-propagating AST scan over the
+  condition-building closure now fails by name if a new terminal handler forgets. Its first version
+  was a regex with a hardcoded name whitelist, which `priorities[0]` walked straight past — a
+  subscript is not a bare name.
 - **A `sys_id`/`number` lookup that selects a write target is escaped.** `kb_article_tools`,
   `cmdb_tools` and `vtb_task_tools` resolve a record by `number=` and then PATCH or attribute the
   result; a `^` there could have OR'd in a second condition and resolved to a *different* record.
@@ -51,7 +56,22 @@ a test matrix rather than incrementally.
   which is what an LLM writing `{"priority": "1^ORpriority=2"}` means.
 - **A `^NQ` new-query-reset in a filter value is refused instead of silently dropped.** The drop
   removed the poisoned condition but still ran the rest, handing back real-looking rows from a
-  query the caller did not ask for.
+  query the caller did not ask for. The check now runs at the *top* of
+  `_build_query_condition`: review found it sat below the pre-built-fragment early returns, so
+  `filter_records({"_complete_caller_exclusion": "caller_id!=x^NQstate=99"})` walked straight past
+  it, and `_build_additional_filters` — a second, parallel assembly path — never reached it at
+  all, so `get_priority_incidents(additional_filters={"_date_range": "1^NQstate=99"})` sent the
+  reset to ServiceNow verbatim and returned rows. Both verified live before and after the fix.
+- **The three pre-built-fragment filter keys are guarded.** `_date_range`,
+  `_complete_caller_exclusion` and `_complete_query` carry their own operators, so they cannot be
+  escaped and `^` has to be allowed — `build_date_filter` emits
+  `sys_created_on>=A^sys_created_on<=B`. `&` is refused there instead, because it is not an
+  operator and can only truncate the fragment. Previously a `&` in `_date_range` silently cut the
+  query short at it.
+- **Filter field *names* are validated.** The keys of a `filters` dict are caller-supplied and
+  nothing checked them, so `{"x^NQstate=99": "1"}` built `x^NQstate=99=1` — the same unscoped
+  table read the value guard refuses, arriving through the key. A field name must now be
+  identifier characters plus `.` for dot-walking (`task.priority`).
 - **A KB title containing `&` or `%` no longer blocks a publish.** The duplicate check refused
   those as inconclusive because it could not trust the query; it can now. `^` still blocks —
   fail-closed, since a check that ran broader than asked cannot clear a publish. `KB_QUERY_UNSAFE_CHARS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,17 @@ a test matrix rather than incrementally.
   it, and `_build_additional_filters` — a second, parallel assembly path — never reached it at
   all, so `get_priority_incidents(additional_filters={"_date_range": "1^NQstate=99"})` sent the
   reset to ServiceNow verbatim and returned rows. Both verified live before and after the fix.
+- **Every structural paste of a caller-built fragment refuses `&`.** Four handlers return a
+  caller value verbatim because the value *is* the fragment — the bare-OR repair, a complete
+  `^OR` filter, the `BETWEEN` early return, and the already-`caller_id!=` passthrough. They
+  cannot escape it, so `&` is refused there as it is for the underscore fragment keys. Found in
+  the second review, and invisible from `filter_records`: that route runs
+  `_encode_query_string` and escaped the `&` before the URL was built, while
+  `query_table_with_generic_filters` did not, so `{"priority": "1^ORpriority=2&x"}` reached
+  ServiceNow as `priority=1^ORpriority=2` plus a stray `x` parameter. Reachable from
+  `similar_knowledge_for_text` and `get_knowledge_by_category`, whose `category`/`kb_base` land
+  in exactly that path. A `&` in an *ordinary* value ("Payroll & Benefits") is still escaped and
+  carried, not refused.
 - **The three pre-built-fragment filter keys are guarded.** `_date_range`,
   `_complete_caller_exclusion` and `_complete_query` carry their own operators, so they cannot be
   escaped and `^` has to be allowed — `build_date_filter` emits

--- a/Diagrams & Documentation/README.md
+++ b/Diagrams & Documentation/README.md
@@ -75,4 +75,4 @@ httpx → ServiceNow Table API
 
 ---
 
-*Last updated: 2026-08-06 · Project version: 4.4.0*
+*Last updated: 2026-08-10 · Project version: 4.4.1*

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ MCP server for ServiceNow integration. Uses FastMCP over stdio transport, OAuth 
 
 ## Release highlights
 
-Current version: **4.4.0** — 39 registered tools. Full history in [CHANGELOG.md](CHANGELOG.md).
+Current version: **4.4.1** — 39 registered tools. Full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Release | What changed |
 |---|---|
+| **4.4.1** | Encoded-query values are carried faithfully. A `&` or a literal `%XY` in a search value no longer silently changes the query into a broader one; a `^` is refused rather than answered, because ServiceNow's syntax cannot carry it inside a value. A KB title containing `&` or `%` no longer blocks a publish. |
 | **4.4.0** | Correctness release. A failed read is no longer reported as a missing record — reads raise a classified error instead of returning `None`, so a timeout, an expired credential and an empty table stop producing the same answer. KB publishing is fail-closed on an unusable duplicate check. Legacy domain filtering deleted, so result sets get larger. See the CHANGELOG's "Behavior changes" before upgrading. |
 | **4.3.0** | Claude Desktop `.mcpb` packaging; Nuitka binary builds dropped from the release workflow. Absorbed the performance and token work planned as 4.2 (pooled httpx client, one OR-combined keyword query, concurrent CMDB probes). |
 | 4.1.0 † | v4.0 shims deleted; KB write tools; `get_kb_articles_by_state`; `get_query_syntax_help`; `filter_records` truncation metadata. |

--- a/Table_Tools/cmdb_tools.py
+++ b/Table_Tools/cmdb_tools.py
@@ -7,8 +7,8 @@ Provides CI discovery, search, and analysis functionality.
 
 import asyncio
 import re
-from urllib.parse import quote
 from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
+from filter import QueryValueError, encode_query_value
 from utils import extract_keywords
 from typing import Any, Dict, Optional, List
 from .read_helpers import is_read_failure
@@ -171,22 +171,27 @@ async def search_cis_by_attributes(
 
     fields = DETAILED_CI_FIELDS if detailed else ESSENTIAL_CI_FIELDS
     
-    # Build query conditions. User values are percent-encoded (safe='') so
-    # structural characters (#, +, %, ?, ...) in a name/location don't corrupt
-    # the sysparm_query. (Operator chars in the locked encode safe-set —
-    # & ^ = etc. — still pass through and remain unsupported inside values.)
-    query_parts = []
-    if name:
-        query_parts.append(f"nameLIKE{quote(name, safe='')}")
-    if ip_address:
-        query_parts.append(f"ip_address={quote(ip_address, safe='')}")
-    if location:
-        query_parts.append(f"locationLIKE{quote(location, safe='')}")
-    if status:
-        query_parts.append(f"operational_status={quote(status, safe='')}")
-    
+    # Build query conditions. Each user value is escaped at this boundary and the
+    # escaping now SURVIVES: through v4.4.0 the transport unquoted before
+    # re-quoting, so the `quote(safe='')` here was undone and a `&` in a CI name
+    # still escaped sysparm_query= into a second URL parameter. A `^` is refused
+    # outright — no encoding can carry it (see filter/value_encoding.py).
+    try:
+        query_parts = []
+        if name:
+            query_parts.append(f"nameLIKE{encode_query_value(name)}")
+        if ip_address:
+            query_parts.append(f"ip_address={encode_query_value(ip_address)}")
+        if location:
+            query_parts.append(f"locationLIKE{encode_query_value(location)}")
+        if status:
+            query_parts.append(f"operational_status={encode_query_value(status)}")
+    except QueryValueError as refusal:
+        return refusal.to_error_dict()
+
     query_string = "^".join(query_parts)
-    
+
+
     try:
         url = f"{NWS_API_BASE}/api/now/table/{table}?sysparm_fields={','.join(fields)}&sysparm_query={query_string}&sysparm_display_value=true&sysparm_limit=100"
         data = await make_nws_request(url)
@@ -220,7 +225,12 @@ async def _probe_ci_table(table: str, ci_number: str) -> Optional[Dict[str, Any]
     — the wrong table, reported confidently. Failures propagate now and
     `get_ci_details` decides what a missing probe means.
     """
-    url = f"{NWS_API_BASE}/api/now/table/{table}?sysparm_fields={','.join(DETAILED_CI_FIELDS)}&sysparm_query=number={ci_number}&sysparm_display_value=true"
+    url = (
+        f"{NWS_API_BASE}/api/now/table/{table}"
+        f"?sysparm_fields={','.join(DETAILED_CI_FIELDS)}"
+        f"&sysparm_query=number={encode_query_value(ci_number)}"
+        f"&sysparm_display_value=true"
+    )
     data = await make_nws_request(url)
     if data and data.get('result'):
         return data['result'][0]
@@ -277,6 +287,11 @@ async def get_ci_details(ci_number: str, ci_type: Optional[str] = None) -> dict[
     )
     for table, outcome in zip(tables_to_search, outcomes):
         if isinstance(outcome, ServiceNowRequestError):
+            return outcome.to_error_dict()
+        if isinstance(outcome, QueryValueError):
+            # The ci_number itself is unqueryable, so every probe refused it
+            # identically. Must precede the BaseException arm below, which would
+            # re-raise it out of the tool.
             return outcome.to_error_dict()
         if isinstance(outcome, BaseException):
             # Not a classified read failure — a real bug. Propagate as before
@@ -438,9 +453,10 @@ async def quick_ci_search(search_term: str) -> dict[str, Any] | str:
         Dictionary with CI results or error string
     """
     try:
-        # Try multiple search approaches. Percent-encode the term so special
-        # characters in it don't corrupt the sysparm_query structure.
-        safe_term = quote(search_term, safe='')
+        # Try multiple search approaches. The term is escaped at this boundary
+        # and the escaping survives the transport (v4.4.1); a term containing '^'
+        # is refused instead of silently becoming extra conditions.
+        safe_term = encode_query_value(search_term)
         query_parts = [
             f"nameLIKE{safe_term}",
             f"ip_address={safe_term}",
@@ -460,6 +476,11 @@ async def quick_ci_search(search_term: str) -> dict[str, Any] | str:
         
         return NO_CIS_FOUND_FOR_SEARCH.format(search_term=search_term)
 
+    except QueryValueError as refusal:
+        # Ahead of the bare except below, for the same reason
+        # ServiceNowRequestError is: ERROR_QUICK_CI_SEARCH would replace the
+        # explanation of what about the term is unqueryable with a generic string.
+        return refusal.to_error_dict()
     except ServiceNowRequestError as error:
         return error.to_error_dict()
     except Exception:

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -891,6 +891,18 @@ async def _make_paginated_request(
     return all_results[:max_results]
 
 
+def _warn_on_validation_issues(validation: Optional[Any], label: str) -> None:
+    """Log a validation result's warnings to stderr, if it has any.
+
+    Extracted because the caller ran this shape twice — once for the filters and
+    once for the result count — and each copy nested an `if has_issues()` inside
+    another branch. Warnings go to stderr only: stdout is reserved for the MCP
+    JSON-RPC frame stream.
+    """
+    if validation and validation.has_issues():
+        print(f"[generic_table_tools] {label}: {validation.warnings}", file=sys.stderr)
+
+
 async def query_table_with_filters(table_name: str, params: TableFilterParams) -> dict[str, Any]:
     """Generic function to query table with custom filters and fields.
 
@@ -914,13 +926,9 @@ async def query_table_with_filters(table_name: str, params: TableFilterParams) -
     """
     fields = params.fields or ESSENTIAL_FIELDS.get(table_name, ["number", "short_description"])
 
-    # Validate filters before making request
-    validation_result = None
-    if params.filters:
-        validation_result = validate_query_filters(params.filters)
-        if validation_result.has_issues():
-            # Log warnings but continue with query
-            print(f"[generic_table_tools] Query validation warnings: {validation_result.warnings}", file=sys.stderr)
+    # Validate filters before making the request; warnings do not stop the query.
+    validation_result = validate_query_filters(params.filters) if params.filters else None
+    _warn_on_validation_issues(validation_result, "Query validation warnings")
 
     try:
         query_string = _build_query_string(params.filters)
@@ -948,10 +956,12 @@ async def query_table_with_filters(table_name: str, params: TableFilterParams) -
     truncated = returned_count >= max_results
 
     if all_results:
-        # Validate result completeness
-        result_validation = validate_result_count(table_name, params.filters or {}, returned_count)
-        if result_validation.has_issues():
-            print(f"[generic_table_tools] Result validation warnings: {result_validation.warnings}", file=sys.stderr)
+        # Validate result completeness. Only on a non-empty set — an empty result
+        # has nothing to check, and this costs a pass over the filters.
+        _warn_on_validation_issues(
+            validate_result_count(table_name, params.filters or {}, returned_count),
+            "Result validation warnings",
+        )
 
         response = {
             "result": all_results,

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -1,5 +1,10 @@
 import sys
-from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
+from http_layer import (
+    NWS_API_BASE,
+    ServiceNowRequestError,
+    encode_query_string,
+    make_nws_request,
+)
 from utils import extract_keywords
 from typing import Any, Dict, Optional, List
 import re
@@ -19,15 +24,18 @@ from constants import (
     text_search_field_for,
     LOGICMONITOR_CALLER_SYS_ID,
     ENABLE_COMPLETE_QUERY,
+    QUERY_VALUE_NEW_QUERY_ERROR,
     TABLE_CONFIGS
 )
 from .read_helpers import carry_partial, carry_partial_after_filter, is_read_failure
 from filter import (
     QueryExplainer,
     QueryIntelligence,
+    QueryValueError,
     TableFilterParams,
     build_pagination_params,
     build_smart_filter,
+    encode_query_value,
     explain_existing_filter,
     suggest_query_improvements,
     validate_query_filters,
@@ -52,6 +60,21 @@ from filter import (
 #      `partial` key.
 #   4. `except ServiceNowRequestError` always precedes a bare `except Exception`
 #      so the typed failure is never flattened into a message string.
+# ---------------------------------------------------------------------------
+# Encoded-query value boundary (v4.4.1). Every caller-supplied value that ends up
+# as the operand of a condition is escaped here, by `encode_query_value`, and the
+# transport preserves that escaping instead of unquoting it away. Two rules:
+#
+#   * A condition handler is either STRUCTURAL — the value IS a query fragment
+#     (`priority=1^ORpriority=2`, a BETWEEN/javascript range, a `^`-joined
+#     exclusion list) — or TERMINAL, pasting the value after `field=` or after an
+#     operator. Only terminal handlers encode. Encoding a structural value would
+#     escape the operators it is made of.
+#   * `^` inside a terminal value is refused (`QueryValueError`), not escaped:
+#     ServiceNow's parser splits on the DECODED value, so no encoding can carry
+#     it. Every public entry point below maps that refusal to
+#     `{"error": {"code": "VALIDATION", ...}}`, because a filter that cannot be
+#     expressed must not become a filter that quietly matches more.
 # ---------------------------------------------------------------------------
 
 
@@ -138,6 +161,13 @@ async def query_table_by_text(
     ``task.short_description``. Resolving from the table rather than requiring
     each caller to pass the right field means a new call site cannot
     reintroduce the bug by forgetting.
+
+    This path is immune to the encoded-query value defect for a reason nobody
+    designed: ``utils.extract_keywords`` tokenizes on ``\\b[a-zA-Z]{4,}\\b``, so a
+    keyword cannot contain ``^``, ``&`` or ``%``. The keywords are escaped anyway
+    (a no-op today) and ``tests/test_query_value_encoding.py`` pins the
+    tokenizer's character class, because the protection is incidental and a
+    widened tokenizer would remove it silently.
     """
     search_field = search_field or text_search_field_for(table_name)
     fields = DETAIL_FIELDS[table_name] if detailed else ESSENTIAL_FIELDS[table_name]
@@ -146,7 +176,12 @@ async def query_table_by_text(
         return {"result": [], "message": NO_RECORDS_FOUND}
 
     # OR-group the keyword conditions so one request matches any keyword.
-    query = "^OR".join(f"{search_field}LIKE{keyword}" for keyword in keywords)
+    try:
+        query = "^OR".join(
+            f"{search_field}LIKE{encode_query_value(keyword)}" for keyword in keywords
+        )
+    except QueryValueError as refusal:
+        return refusal.to_error_dict()
     base_url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields={','.join(fields)}&sysparm_query={query}"
     # Single paginated request; text searches capped at 50 results.
     try:
@@ -175,7 +210,10 @@ async def get_record_description(table_name: str, record_number: str) -> dict[st
     """Generic function to get short_description for any record."""
     if not _is_safe_record_number(record_number):
         return {"result": [], "message": RECORD_NOT_FOUND}
-    query = f"number={record_number}"
+    # `encode_query_value` cannot refuse here: `_is_safe_record_number` already
+    # rejected `^`. It is applied for the `%` case — an unescaped "INC%41" used to
+    # be decoded by the transport into "INCA", a lookup for a different record.
+    query = f"number={encode_query_value(record_number)}"
     url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields=short_description&sysparm_query={query}"
     try:
         data = await make_nws_request(url)
@@ -190,7 +228,8 @@ async def get_record_details(table_name: str, record_number: str) -> dict[str, A
     if not _is_safe_record_number(record_number):
         return {"result": [], "message": RECORD_NOT_FOUND}
     fields = DETAIL_FIELDS.get(table_name, ["number", "short_description"])
-    query = f"number={record_number}"
+    # See `get_record_description`: guarded against `^` upstream, escaped for `%`.
+    query = f"number={encode_query_value(record_number)}"
     url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields={','.join(fields)}&sysparm_query={query}&sysparm_display_value=true"
     try:
         data = await make_nws_request(url)
@@ -494,22 +533,27 @@ def _clean_priority_input(value: str) -> str:
 
 
 def _process_comma_separated_priorities(value: str) -> str:
-    """Process comma-separated priority list into OR syntax."""
+    """Process comma-separated priority list into OR syntax.
+
+    Structural overall — the `^OR` join is ours — but each element is a terminal
+    value and is escaped as one. `_normalize_priority_value` only strips a leading
+    "P", so anything else the caller sent arrives here intact.
+    """
     clean_value = _clean_priority_input(value)
     priorities = [p.strip().strip("\"'") for p in clean_value.split(",")]
-    
+
     # Convert P1/P2 notation to numbers
     priority_nums = [_normalize_priority_value(p) for p in priorities if p]
-    
+
     # Build OR syntax
-    priority_conditions = [f"priority={p}" for p in priority_nums]
+    priority_conditions = [f"priority={encode_query_value(p)}" for p in priority_nums]
     return "^OR".join(priority_conditions)
 
 
 def _format_single_priority(value: str) -> str:
-    """Format single priority value."""
+    """Format single priority value. Terminal."""
     priority_num = _normalize_priority_value(value)
-    return f"priority={priority_num}"
+    return f"priority={encode_query_value(priority_num)}"
 
 
 def _parse_priority_list(value: str) -> str:
@@ -562,17 +606,22 @@ def _parse_caller_exclusions(value: str) -> str:
     if value_lower in known_callers:
         return f"caller_id!={known_callers[value_lower]}"
     
-    # Handle comma-separated sys_ids
+    # Handle comma-separated sys_ids. Structural overall (the "^" join is ours),
+    # but each sys_id is a terminal value and is escaped as one.
     if "," in value:
         clean_value = value.strip("[]\"'")
         caller_ids = [c.strip().strip("\"'") for c in clean_value.split(",")]
-        exclusions = [f"caller_id!={caller_id}" for caller_id in caller_ids if caller_id]
+        exclusions = [
+            f"caller_id!={encode_query_value(caller_id)}"
+            for caller_id in caller_ids
+            if caller_id
+        ]
         return "^".join(exclusions)
-    
+
     # Single caller exclusion
     if value and not value.startswith("caller_id!="):
-        return f"caller_id!={value}"
-    
+        return f"caller_id!={encode_query_value(value)}"
+
     return value
 
 def _handle_complete_query_condition(value: str) -> str:
@@ -581,14 +630,21 @@ def _handle_complete_query_condition(value: str) -> str:
 
 
 def _handle_date_range_condition(field: str, value: str) -> Optional[str]:
-    """Handle date range parsing for sys_created_on field."""
+    """Handle date range parsing for sys_created_on field.
+
+    Structural on the BETWEEN and natural-language branches (both produce a
+    complete fragment, operators and `@` separator included). Terminal on the
+    `>=`/`<=` branch — the operand is escaped there. `>` `<` `=` `:` `(` `)` are
+    in the value safe-set, so a `>=javascript:gs.daysAgoStart(14)` operand is
+    still sent byte-for-byte as before.
+    """
     if field == "sys_created_on":
         # If already in BETWEEN format, return as-is
         if "BETWEEN" in value:
             return value
         # If already has operator, return as-is
         if value.startswith((">=", "<=")):
-            return f"{field}{value}"
+            return f"{field}{encode_query_value(value)}"
         # Try to parse natural language date range
         date_range = _parse_date_range_from_text(value)
         if date_range:
@@ -619,6 +675,13 @@ def _handle_bare_or_value_condition(field: str, value: str) -> Optional[str]:
     ServiceNow query: "priority=1^ORpriority=2".
 
     Works for any field (priority, task.priority, state, etc.).
+
+    STRUCTURAL, so the value is not escaped: it carries its own `^OR` and its own
+    `field=value` segments after the first. That makes `^OR` in a filter value
+    always read as structure, never as literal text — the one place the caret
+    refusal does not apply, because the handler exists precisely to honour an
+    LLM's intent to write an OR. A title genuinely containing "^OR" is
+    unqueryable here, the same as any other `^`.
     """
     if "^OR" not in value:
         return None
@@ -636,9 +699,15 @@ def _handle_servicenow_filter_condition(field: str, value: str) -> Optional[str]
 
 
 def _handle_operator_condition(field: str, value: str) -> Optional[str]:
-    """Handle direct operator syntax."""
+    """Handle direct operator syntax.
+
+    Terminal: the operator is a prefix ON the value (`LIKEserver down`,
+    `>=2024-01-01`), so the whole value is escaped. Every operator character is
+    either in the value safe-set or was already being escaped by the transport —
+    `NOT LIKE` has always reached ServiceNow as `NOT%20LIKE`.
+    """
     if _has_operator_in_value(value):
-        return f"{field}{value}"
+        return f"{field}{encode_query_value(value)}"
     return None
 
 
@@ -653,16 +722,17 @@ _SUFFIX_OPERATORS = (
 
 
 def _handle_suffix_operator_condition(field: str, value: str) -> Optional[str]:
-    """Handle suffix-based operators (foo_gte=5 -> foo>=5)."""
+    """Handle suffix-based operators (foo_gte=5 -> foo>=5). Terminal."""
     for suffix, operator in _SUFFIX_OPERATORS:
         if field.endswith(suffix):
-            return f"{field[:-len(suffix)]}{operator}{value}"
+            return f"{field[:-len(suffix)]}{operator}{encode_query_value(value)}"
     return None
 
 
 def _handle_exact_match_condition(field: str, value: str) -> str:
-    """Handle exact match condition."""
-    return f"{field}={value}"
+    """Handle exact match condition. Terminal, and the default — so this is the
+    handler that refuses a `^`-bearing value that no structural handler claimed."""
+    return f"{field}={encode_query_value(value)}"
 
 
 # Condition handler registry, ordered by specificity. Built once at import
@@ -699,10 +769,16 @@ def _build_query_condition(field: str, value: str) -> str:
     # Defend against a `^NQ` new-query-reset smuggled inside an otherwise
     # ordinary filter value: `^NQ` starts a brand-new query, discarding every
     # condition built before it — so one poisoned filter value turns a scoped
-    # query into an unbounded table read. Drop any condition that attempts it
-    # rather than passing it through.
+    # query into an unbounded table read.
+    #
+    # Checked HERE, before the handlers, and not left to `encode_query_value`:
+    # the structural handlers would claim `1^ORpriority=2^NQactive=true` as a
+    # caller-built fragment and never reach an encoder. v4.4.1 turned the
+    # response from a silent drop into a refusal — dropping the poisoned
+    # condition still ran the remaining ones, so the caller got real-looking rows
+    # from a query they did not ask for.
     if "^NQ" in value.upper():
-        return ""
+        raise QueryValueError.refused(value, QUERY_VALUE_NEW_QUERY_ERROR)
 
     # Try each condition handler until one matches
     for handler in _CONDITION_HANDLERS:
@@ -714,7 +790,14 @@ def _build_query_condition(field: str, value: str) -> str:
     return _handle_exact_match_condition(field, value)
 
 def _build_query_string(filters: Dict[str, str]) -> str:
-    """Build the complete query string from filters."""
+    """Build the complete query string from filters.
+
+    Raises:
+        QueryValueError: a filter value cannot be carried by encoded-query
+            syntax (`^`, or a `^NQ` reset). Every caller maps it to a VALIDATION
+            error dict; none of them may swallow it, because the alternative is
+            a query that runs broader than the one requested.
+    """
     if not filters:
         return ""
 
@@ -729,11 +812,16 @@ def _build_query_string(filters: Dict[str, str]) -> str:
     return "^".join(part for part in query_parts if part)
 
 def _encode_query_string(query_string: str) -> str:
-    """URL encode query string while preserving ServiceNow JavaScript functions and operators."""
-    from urllib.parse import quote
-    # Preserve ServiceNow-specific characters: =<>&^():@!
-    # Added '@' for JavaScript separators, '!' for NOT EQUALS, '^' for AND/OR operators
-    return quote(query_string, safe='=<>&^():@!')
+    """URL encode query string while preserving ServiceNow JavaScript functions and operators.
+
+    Thin alias for the transport's encoder since v4.4.1 — it used to be a second,
+    independent `quote(safe=...)` with different rules and no idempotency, so a
+    value could pass through two encoders that disagreed and be round-trip-stable
+    only by luck. One implementation now: escapes already applied by
+    `encode_query_value` survive both passes, and applying this before
+    `make_nws_request` is a no-op rather than a second opinion.
+    """
+    return encode_query_string(query_string)
 
 def _inject_sort_order(url: str, sort_directive: str) -> str:
     """Inject a sort directive into the URL's sysparm_query if no ORDERBY is present.
@@ -834,7 +922,13 @@ async def query_table_with_filters(table_name: str, params: TableFilterParams) -
             # Log warnings but continue with query
             print(f"[generic_table_tools] Query validation warnings: {validation_result.warnings}", file=sys.stderr)
 
-    query_string = _build_query_string(params.filters)
+    try:
+        query_string = _build_query_string(params.filters)
+    except QueryValueError as refusal:
+        # A filter that cannot be expressed is an error, never a dropped
+        # condition: dropping it would answer a broader question and label the
+        # rows as matches.
+        return refusal.to_error_dict()
     encoded_query = _encode_query_string(query_string)
 
     base_url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields={','.join(fields)}&sysparm_display_value=true"
@@ -1122,10 +1216,11 @@ def _build_priority_filter(priorities: List[str]) -> str:
     
     # Handle single priority
     if len(priorities) == 1:
-        return f"priority={priorities[0]}"
-    
-    # Build OR filter for multiple priorities
-    priority_filters = [f"priority={p}" for p in priorities]
+        return f"priority={encode_query_value(priorities[0])}"
+
+    # Build OR filter for multiple priorities. The "^OR" join is ours; each
+    # priority is a terminal value.
+    priority_filters = [f"priority={encode_query_value(p)}" for p in priorities]
     return "^OR".join(priority_filters)
 
 def _build_url_with_params(table_name: str, fields: List[str], query: str) -> str:
@@ -1137,7 +1232,12 @@ def _build_url_with_params(table_name: str, fields: List[str], query: str) -> st
     return f"{base_url}?{field_param}&{query_param}"
 
 def _build_additional_filters(additional_filters: Optional[Dict[str, str]]) -> List[str]:
-    """Convert additional_filters dict into a list of filter strings."""
+    """Convert additional_filters dict into a list of filter strings.
+
+    The second filter-assembly path (the first is `_build_query_string`), so it
+    escapes its values the same way. `_date_range` is the one structural key: a
+    pre-built fragment, complete with its operator.
+    """
     if not additional_filters:
         return []
     result = []
@@ -1146,7 +1246,7 @@ def _build_additional_filters(additional_filters: Optional[Dict[str, str]]) -> L
             # Pre-built date filter string (e.g., "sys_created_on>=2026-01-01 00:00:00")
             result.append(value)
         else:
-            result.append(f"{field}={value}")
+            result.append(f"{field}={encode_query_value(value)}")
     return result
 
 
@@ -1180,13 +1280,15 @@ async def get_records_by_priority(
     if not fields:
         return {"error": NO_FIELD_CONFIG_ERROR.format(table_name=table_name)}
 
-    # Build priority filter
-    priority_filter = _build_priority_filter(priorities)
-    if not priority_filter:
-        return {"error": NO_VALID_PRIORITIES_ERROR}
-
-    # Build complete filter list
-    filters = [priority_filter] + _build_additional_filters(additional_filters)
+    # Build priority filter + the additional-filter list. Both escape their
+    # values, so both can refuse one.
+    try:
+        priority_filter = _build_priority_filter(priorities)
+        if not priority_filter:
+            return {"error": NO_VALID_PRIORITIES_ERROR}
+        filters = [priority_filter] + _build_additional_filters(additional_filters)
+    except QueryValueError as refusal:
+        return refusal.to_error_dict()
 
     final_query = "^".join(filters)
     base_url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields={','.join(fields)}&sysparm_display_value=true"
@@ -1217,10 +1319,13 @@ async def query_table_with_generic_filters(
     if not fields:
         return {"error": NO_FIELD_CONFIG_ERROR.format(table_name=table_name)}
     
-    # Build query via _build_query_string so the ENABLE_COMPLETE_QUERY gate and
-    # the ^NQ defense (which can drop a condition to "") don't leave a dangling
-    # "^^" or leading/trailing "^" in the joined query.
-    query = _build_query_string(filters)
+    # Build query via _build_query_string so the ENABLE_COMPLETE_QUERY gate
+    # (which can drop a condition to "") doesn't leave a dangling "^^" or
+    # leading/trailing "^" in the joined query.
+    try:
+        query = _build_query_string(filters)
+    except QueryValueError as refusal:
+        return refusal.to_error_dict()
     base_url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields={','.join(fields)}&sysparm_display_value=true"
 
     if query:

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -24,6 +24,8 @@ from constants import (
     text_search_field_for,
     LOGICMONITOR_CALLER_SYS_ID,
     ENABLE_COMPLETE_QUERY,
+    QUERY_FIELD_NAME_ERROR,
+    QUERY_FRAGMENT_AMPERSAND_ERROR,
     QUERY_VALUE_NEW_QUERY_ERROR,
     TABLE_CONFIGS
 )
@@ -748,37 +750,80 @@ _CONDITION_HANDLERS = (
 )
 
 
+# A legitimate field name: identifier characters, '.' for dot-walked references
+# (task.priority), and a leading '_' for the internal fragment keys.
+_FIELD_NAME_PATTERN = re.compile(r'[A-Za-z_][A-Za-z0-9_.]*')
+
+
+def _reject_new_query_reset(value: str) -> None:
+    """Refuse a `^NQ` new-query-reset anywhere in a caller-supplied string.
+
+    `^NQ` starts a brand-new query, discarding every condition built before it, so
+    one poisoned filter turns a scoped query into an unbounded table read.
+
+    Called at the TOP of `_build_query_condition`, ahead of the fragment
+    early-returns. It used to sit after them, so `_complete_caller_exclusion` and
+    `_complete_query` walked straight past it — and `_build_additional_filters`,
+    a second assembly path, never reached it at all.
+    """
+    if isinstance(value, str) and "^NQ" in value.upper():
+        raise QueryValueError.refused(value, QUERY_VALUE_NEW_QUERY_ERROR)
+
+
+def _reject_unsafe_fragment(value: str) -> None:
+    """Guard for the three keys that take a pre-built fragment instead of a value.
+
+    A fragment carries its own operators, so it cannot be escaped and `^` has to be
+    allowed. `&` cannot be: it is not an encoded-query operator, so it only ever
+    ends the query string and drops the rest of the fragment. See
+    `QUERY_FRAGMENT_AMPERSAND_ERROR`.
+    """
+    _reject_new_query_reset(value)
+    if isinstance(value, str) and "&" in value:
+        raise QueryValueError.refused(value, QUERY_FRAGMENT_AMPERSAND_ERROR)
+
+
+def _reject_unsafe_field_name(field: str) -> None:
+    """Refuse a field name that is not a plain field name.
+
+    The keys of a `filters` dict are caller-supplied and were never checked, so
+    `{"x^NQstate=99": "1"}` built `x^NQstate=99=1` — the value guard refuses that
+    payload in a value and used to wave it through in a key.
+    """
+    if not isinstance(field, str) or not _FIELD_NAME_PATTERN.fullmatch(field):
+        raise QueryValueError.refused(str(field), QUERY_FIELD_NAME_ERROR)
+
+
 def _build_query_condition(field: str, value: str) -> str:
     """Build a single query condition based on field and value."""
-    # Handle special complete query cases first
+    _reject_unsafe_field_name(field)
+    # Ahead of every early return below: a fragment key must not be a way past it.
+    _reject_new_query_reset(value)
+
+    # Handle special complete query cases first. Both are pre-built fragments, so
+    # both get the fragment guard rather than value escaping — and both are reached
+    # only after the `^NQ` refusal above, which is the point.
     if field == "_complete_query":
         # `_complete_query` hands a raw, caller-built encoded query straight
-        # through, bypassing every per-field handler and the `^NQ` defense
-        # below. Gated off by default; drop it entirely (rather than call the
-        # handler) unless explicitly re-enabled.
+        # through, bypassing every per-field handler. Gated off by default; drop it
+        # entirely (rather than call the handler) unless explicitly re-enabled.
         if not ENABLE_COMPLETE_QUERY:
             return ""
+        _reject_unsafe_fragment(value)
         return _handle_complete_query_condition(value)
     if field == "_complete_caller_exclusion":
+        _reject_unsafe_fragment(value)
         return value  # Already in complete ServiceNow format
 
     # Rewrite GlideRecord-only operators (CONTAINS/NOTCONTAINS) to their
     # encoded-query equivalents (LIKE/NOT LIKE) before any handler runs.
-    value = _normalize_operator(value)
-
-    # Defend against a `^NQ` new-query-reset smuggled inside an otherwise
-    # ordinary filter value: `^NQ` starts a brand-new query, discarding every
-    # condition built before it — so one poisoned filter value turns a scoped
-    # query into an unbounded table read.
     #
-    # Checked HERE, before the handlers, and not left to `encode_query_value`:
-    # the structural handlers would claim `1^ORpriority=2^NQactive=true` as a
-    # caller-built fragment and never reach an encoder. v4.4.1 turned the
-    # response from a silent drop into a refusal — dropping the poisoned
-    # condition still ran the remaining ones, so the caller got real-looking rows
-    # from a query they did not ask for.
-    if "^NQ" in value.upper():
-        raise QueryValueError.refused(value, QUERY_VALUE_NEW_QUERY_ERROR)
+    # The `^NQ` refusal runs BEFORE this, at the top of the function: it has to
+    # precede the fragment early-returns above, and normalisation cannot introduce
+    # or remove a `^NQ`. The structural handlers below would otherwise claim
+    # `1^ORpriority=2^NQactive=true` as a caller-built fragment and never reach an
+    # encoder, which is why the check is not left to `encode_query_value`.
+    value = _normalize_operator(value)
 
     # Try each condition handler until one matches
     for handler in _CONDITION_HANDLERS:
@@ -1245,8 +1290,16 @@ def _build_additional_filters(additional_filters: Optional[Dict[str, str]]) -> L
     """Convert additional_filters dict into a list of filter strings.
 
     The second filter-assembly path (the first is `_build_query_string`), so it
-    escapes its values the same way. `_date_range` is the one structural key: a
-    pre-built fragment, complete with its operator.
+    escapes its values the same way — and it has to repeat the guards, because it
+    does not route through `_build_query_condition` and so reaches none of them.
+    That gap was live: `get_priority_incidents(additional_filters={"_date_range":
+    "1^NQstate=99"})` sent the reset to ServiceNow verbatim, past a release whose
+    whole claim was that it refuses exactly that.
+
+    `_date_range` is the one fragment key here: pre-built, complete with its
+    operators, and legitimately containing `^` (`build_date_filter` emits
+    `sys_created_on>=A^sys_created_on<=B`). So it gets the fragment guard, not
+    escaping.
     """
     if not additional_filters:
         return []
@@ -1254,8 +1307,11 @@ def _build_additional_filters(additional_filters: Optional[Dict[str, str]]) -> L
     for field, value in additional_filters.items():
         if field == "_date_range":
             # Pre-built date filter string (e.g., "sys_created_on>=2026-01-01 00:00:00")
+            _reject_unsafe_fragment(value)
             result.append(value)
         else:
+            _reject_unsafe_field_name(field)
+            _reject_new_query_reset(value)
             result.append(f"{field}={encode_query_value(value)}")
     return result
 

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -624,10 +624,13 @@ def _parse_caller_exclusions(value: str) -> str:
     if value and not value.startswith("caller_id!="):
         return f"caller_id!={encode_query_value(value)}"
 
+    # Already in `caller_id!=...` form: a caller-built fragment, passed through as
+    # one. Guarded rather than escaped, like every other structural paste.
+    _reject_unsafe_fragment(value)
     return value
 
 def _handle_complete_query_condition(value: str) -> str:
-    """Handle complete query condition."""
+    """Handle complete query condition. Guarded by the caller (`_reject_unsafe_fragment`)."""
     return value
 
 
@@ -641,8 +644,10 @@ def _handle_date_range_condition(field: str, value: str) -> Optional[str]:
     still sent byte-for-byte as before.
     """
     if field == "sys_created_on":
-        # If already in BETWEEN format, return as-is
+        # If already in BETWEEN format, return as-is — a caller-built fragment, so
+        # guarded rather than escaped.
         if "BETWEEN" in value:
+            _reject_unsafe_fragment(value)
             return value
         # If already has operator, return as-is
         if value.startswith((">=", "<=")):
@@ -689,13 +694,15 @@ def _handle_bare_or_value_condition(field: str, value: str) -> Optional[str]:
         return None
     before_or = value.split("^OR")[0]
     if "=" not in before_or:
+        _reject_unsafe_fragment(value)
         return f"{field}={value}"
     return None
 
 
 def _handle_servicenow_filter_condition(field: str, value: str) -> Optional[str]:
-    """Handle complete ServiceNow filters."""
+    """Handle complete ServiceNow filters. Structural, so guarded not escaped."""
     if _is_complete_servicenow_filter(value):
+        _reject_unsafe_fragment(value)
         return value
     return None
 
@@ -850,10 +857,11 @@ def _build_query_string(filters: Dict[str, str]) -> str:
     for field, value in filters.items():
         query_parts.append(_build_query_condition(field, value))
 
-    # A condition handler (e.g. the ENABLE_COMPLETE_QUERY gate, or the ^NQ
-    # defense) may now return "" to drop a condition entirely. Skip empties
-    # so a dropped condition doesn't leave a dangling "^^" or a leading/
-    # trailing "^" in the joined query.
+    # The ENABLE_COMPLETE_QUERY gate returns "" to drop a condition entirely, so
+    # skip empties — a dropped condition must not leave a dangling "^^" or a
+    # leading/trailing "^" in the joined query. That gate is now the ONLY thing
+    # that drops: `^NQ` raises at the top of `_build_query_condition` rather than
+    # silently removing the condition and running the rest (v4.4.1).
     return "^".join(part for part in query_parts if part)
 
 def _encode_query_string(query_string: str) -> str:
@@ -1356,6 +1364,11 @@ async def get_records_by_priority(
     except QueryValueError as refusal:
         return refusal.to_error_dict()
 
+    # Interpolated without a further encode pass, and that is deliberate: every
+    # producer above escapes its own value or refuses it, so there is nothing left
+    # to normalise. An `_encode_query_string` call here was tried and removed —
+    # mutation testing showed no test could tell the difference, including one
+    # asserting the three assembly paths agree, which they do without it.
     final_query = "^".join(filters)
     base_url = f"{NWS_API_BASE}/api/now/table/{table_name}?sysparm_fields={','.join(fields)}&sysparm_display_value=true"
 
@@ -1389,6 +1402,9 @@ async def query_table_with_generic_filters(
     # (which can drop a condition to "") doesn't leave a dangling "^^" or
     # leading/trailing "^" in the joined query.
     try:
+        # No further encode pass — see `get_records_by_priority`. The `&`
+        # truncation that used to be possible here is closed at the producers
+        # (every structural paste refuses `&`), not by normalising afterwards.
         query = _build_query_string(filters)
     except QueryValueError as refusal:
         return refusal.to_error_dict()

--- a/Table_Tools/kb_article_tools.py
+++ b/Table_Tools/kb_article_tools.py
@@ -18,8 +18,8 @@ skipped. "Could not check" is not "nothing found".
 import asyncio
 import sys
 import time
-from urllib.parse import unquote
 from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
+from filter import QueryValueError, encode_query_value
 from typing import Any, Dict, List, Optional
 import anyio
 import httpx
@@ -41,7 +41,6 @@ from constants import (
     ERROR_KB_DUPLICATE_CHECK_INCONCLUSIVE,
     ERROR_KB_PUBLISH_VERIFY_UNREADABLE,
     KB_DEDUP_QUERY_LIMIT,
-    KB_DEDUP_REASON_PERCENT_ESCAPE,
     KB_DEDUP_REASON_TRUNCATED,
     KB_DEDUP_REASON_UNSAFE_CHARS,
     KB_QUERY_UNSAFE_CHARS,
@@ -128,8 +127,14 @@ async def _get_kb_article_sys_id(article_number: str, workflow_state: str | None
     None means "looked, absent" and nothing else (decision (d)). A failed read
     raises `ServiceNowRequestError` and the caller maps it, so a write can no
     longer report "article not found" because the lookup timed out.
+
+    The number is escaped because this lookup picks the sys_id a write then
+    PATCHes: a `^` in it could append or OR-in a condition and resolve to a
+    *different* article. Refused (`QueryValueError`) rather than escaped, since no
+    encoding can carry a `^`. `workflow_state` is an internal literal, so its `^`
+    is ours and stays structural.
     """
-    query = f"number={article_number}"
+    query = f"number={encode_query_value(article_number)}"
     if workflow_state:
         query += f"^workflow_state={workflow_state}"
     url = f"{NWS_API_BASE}/api/now/table/kb_knowledge?sysparm_fields=sys_id&sysparm_query={query}"
@@ -143,9 +148,10 @@ async def _get_kb_article_meta(article_number: str, workflow_state: str | None =
     """Fetch sys_id + short_description in one GET — avoids a second round-trip in publish.
 
     Same boundary as `_get_kb_article_sys_id`: None means absent, a failed read
-    raises (decision (d)).
+    raises (decision (d)), and the number is escaped because it selects a write
+    target.
     """
-    query = f"number={article_number}"
+    query = f"number={encode_query_value(article_number)}"
     if workflow_state:
         query += f"^workflow_state={workflow_state}"
     url = (
@@ -162,20 +168,19 @@ async def _get_kb_article_meta(article_number: str, workflow_state: str | None =
 def _dedup_query_defect(short_description: str) -> Optional[str]:
     """Why the dedup query would not faithfully carry *short_description*, if so.
 
-    Two independent failures, both ending with ServiceNow running a query nobody
-    asked for. See the constants for the mechanics.
+    v4.4.1 narrowed this from three refusals to one. `&` and a literal `%XY` were
+    only ever mis-transported — the encoder unquoted before re-quoting, undoing
+    any escaping — and are carried faithfully now that the escaping survives and
+    `_check_kb_duplicates` escapes the title itself. Titles like
+    "Sales & Marketing" and "Deal 20%2C" no longer block a publish.
 
-    The percent check is a round trip rather than a character blacklist: it is
-    exactly the condition that matters (`unquote` is what corrupts the value), it
-    does not refuse an ordinary "50% off" title, and it keeps holding if the
-    encoder's safe-set changes. Verified against every character in that safe-set
-    — only ^ and & break structure; = < > ( ) : @ ! survive intact.
+    `^` still refuses, because it is unrepresentable rather than merely
+    mis-transported: ServiceNow's condition parser splits on the *decoded* value.
+    A duplicate check that ran broader than asked cannot clear a publish.
     """
     unsafe = [c for c in KB_QUERY_UNSAFE_CHARS if c in short_description]
     if unsafe:
         return KB_DEDUP_REASON_UNSAFE_CHARS.format(chars=" ".join(unsafe))
-    if unquote(short_description) != short_description:
-        return KB_DEDUP_REASON_PERCENT_ESCAPE
     return None
 
 
@@ -208,7 +213,7 @@ async def _check_kb_duplicates(short_description: str, exclude_number: str) -> l
     url = (
         f"{NWS_API_BASE}/api/now/table/kb_knowledge"
         f"?sysparm_fields={','.join(KB_DEDUP_FIELDS)}"
-        f"&sysparm_query=short_descriptionLIKE{short_description}"
+        f"&sysparm_query=short_descriptionLIKE{encode_query_value(short_description)}"
         f"&sysparm_limit={KB_DEDUP_QUERY_LIMIT}"
     )
     data = await make_nws_request(url)
@@ -263,7 +268,7 @@ async def _verify_kb_published(article_number: str) -> Dict[str, Any] | None:
     is not evidence the publish did not commit, and treating it as such is what
     made an unreadable verify re-fire the publish write.
     """
-    query = f"number={article_number}^workflow_state={KB_PUBLISHED_STATE}"
+    query = f"number={encode_query_value(article_number)}^workflow_state={KB_PUBLISHED_STATE}"
     url = (
         f"{NWS_API_BASE}/api/now/table/kb_knowledge"
         f"?sysparm_fields={','.join(KB_VERIFY_FIELDS)}"
@@ -376,9 +381,11 @@ async def update_knowledge_article(article_number: str, update_data: Dict[str, A
     t0 = time.monotonic()
     try:
         sys_id = await _get_kb_article_sys_id(article_number, workflow_state="draft")
-    except ServiceNowRequestError as error:
+    except (ServiceNowRequestError, QueryValueError) as error:
         # A failed lookup is not a missing article, and reporting it as one sent
         # people looking for an article that was there all along (decision (d)).
+        # An unqueryable article number is the same kind of answer — the lookup
+        # did not happen — and both types expose the same `to_error_dict()`.
         return error.to_error_dict()
     t1 = time.monotonic()
     print(f"[kb] {article_number} sys_id GET took {t1 - t0:.1f}s", file=sys.stderr)
@@ -409,7 +416,7 @@ async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str
     """
     try:
         meta = await _get_kb_article_meta(article_number, workflow_state="draft")
-    except ServiceNowRequestError as error:
+    except (ServiceNowRequestError, QueryValueError) as error:
         return error.to_error_dict()
     if not meta:
         return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
@@ -469,7 +476,7 @@ async def _check_single_kb_duplicate(article_number: str) -> Dict[str, Any]:
     """Lookup meta then check duplicates for one article. Used by check_kb_duplicates fan-out."""
     try:
         meta = await _get_kb_article_meta(article_number)
-    except ServiceNowRequestError as error:
+    except (ServiceNowRequestError, QueryValueError) as error:
         return _duplicate_row_inconclusive(article_number, error.message)
     if not meta:
         # A genuinely absent article: the check did run, so has_duplicate stands.
@@ -497,7 +504,7 @@ async def _check_single_kb_duplicate(article_number: str) -> Dict[str, Any]:
 
 def _outcome_error_message(outcome: BaseException) -> str:
     """Message for an exception that escaped a per-article coroutine."""
-    if isinstance(outcome, ServiceNowRequestError):
+    if isinstance(outcome, (ServiceNowRequestError, QueryValueError)):
         return outcome.message
     if isinstance(outcome, KbDuplicateCheckInconclusive):
         return outcome.reason
@@ -670,7 +677,7 @@ async def retire_knowledge_article(article_number: str) -> Dict[str, Any] | str:
     """
     try:
         sys_id = await _get_kb_article_sys_id(article_number, workflow_state="published")
-    except ServiceNowRequestError as error:
+    except (ServiceNowRequestError, QueryValueError) as error:
         return error.to_error_dict()
     if not sys_id:
         return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)

--- a/Table_Tools/vtb_task_tools.py
+++ b/Table_Tools/vtb_task_tools.py
@@ -10,6 +10,7 @@ absence, so an update no longer tells the user their task does not exist because
 the lookup timed out.
 """
 from http_layer import ServiceNowRequestError, make_nws_request, NWS_API_BASE
+from filter import QueryValueError, encode_query_value
 from typing import Any, Dict
 import anyio
 import httpx
@@ -91,8 +92,15 @@ async def _get_task_sys_id(task_number: str) -> str | None:
     raises `ServiceNowRequestError` for the caller to map — returning None for it
     is what let a timeout report the task as missing, on the one code path where
     that answer stops a write.
+
+    The number is escaped (v4.4.1) because this lookup chooses the record the
+    PATCH then writes to: a `^` in it could OR-in a second condition and resolve
+    to a different task. Unrepresentable, so refused rather than escaped.
     """
-    sys_id_url = f"{NWS_API_BASE}/api/now/table/vtb_task?sysparm_fields=sys_id&sysparm_query=number={task_number}"
+    sys_id_url = (
+        f"{NWS_API_BASE}/api/now/table/vtb_task"
+        f"?sysparm_fields=sys_id&sysparm_query=number={encode_query_value(task_number)}"
+    )
     sys_id_data = await make_nws_request(sys_id_url)
 
     if not sys_id_data or not sys_id_data.get('result') or not sys_id_data['result']:
@@ -138,9 +146,11 @@ async def update_private_task(task_number: str, update_data: Dict[str, Any]) -> 
 
     try:
         sys_id = await _get_task_sys_id(task_number)
-    except ServiceNowRequestError as error:
+    except (ServiceNowRequestError, QueryValueError) as error:
         # Not "task not found": the lookup never answered. Reporting absence here
         # sends the user looking for a task that is probably sitting right there.
+        # An unqueryable task number means the same thing — no lookup happened —
+        # and both types expose the same `to_error_dict()`.
         return error.to_error_dict()
     if not sys_id:
         return PRIVATE_TASK_NOT_FOUND_UPDATE

--- a/constants.py
+++ b/constants.py
@@ -305,35 +305,25 @@ KB_DUPLICATE_IGNORED_STATES = {"retired", "outdated"}
 KB_DEDUP_QUERY_LIMIT = 200
 
 # Characters that break the STRUCTURE of an encoded query when they appear
-# inside a value. The read path percent-encodes sysparm_query but keeps the
-# ServiceNow operator characters in its safe-set
-# (http_layer/url_builder.ensure_query_encoded), and it unquotes before
-# re-quoting, so pre-encoding these at the call site does not survive:
+# inside a value, and so make a duplicate check untrustworthy for that title.
+#
+# v4.4.1 narrowed this from ("^", "&") to ("^",). "&" was only ever broken in
+# transport: the encoder unquoted before re-quoting, so a call site's "%26" was
+# undone and the raw "&" escaped sysparm_query= into a sibling URL parameter.
+# The encoder preserves existing escapes now and `encode_query_value` escapes the
+# title, so "Sales & Marketing" is carried faithfully and no longer blocks a
+# publish. The same change retired the percent-escape round-trip check.
+#
+# "^" stays refused because it is unrepresentable, not merely mis-transported:
+# even correct end-to-end encoding hands ServiceNow a decoded value containing
+# "^", and its condition parser splits there —
 #   "Cost^Center"  ->  short_descriptionLIKECost ^ Center   (two conditions)
-#   "A&B"          ->  short_descriptionLIKEA & B           (a second URL param)
-# Either way the query that runs is not the query that was asked for, and it
-# runs BROADER. A duplicate check cannot be trusted for such a value, so the
-# publish guard treats it as inconclusive rather than clean.
+# The query that runs is broader than the one asked for, so a "no duplicates"
+# answer from it would be meaningless. Inconclusive, not clean.
 #
-# Measured against the whole safe-set: only these two break anything. A value
-# containing = < > ( ) : @ ! survives the round trip intact.
-KB_QUERY_UNSAFE_CHARS = ("^", "&")
-
-# The other, quieter way a value fails to survive: `ensure_query_encoded`
-# unquotes before re-quoting, so any "%" followed by two hex digits in the value
-# is decoded as a percent-escape and ServiceNow searches for a DIFFERENT string.
-# "Deal 20%2C off" becomes "Deal 20, off"; "%41dmin" becomes "Admin"; "20%DB"
-# becomes an invalid byte and then U+FFFD. `unquote` never raises, so nothing
-# announces it.
-#
-# Detected by round trip (unquote(value) == value) rather than by blacklisting
-# "%", which would needlessly refuse an ordinary title like "50% off" — a bare
-# "%" not followed by hex digits survives fine. The round trip is also general:
-# it keeps holding if the encoder's safe-set ever changes.
-KB_DEDUP_REASON_PERCENT_ESCAPE = (
-    "the title contains a '%' sequence that the read path decodes as a "
-    "percent-escape, so ServiceNow would be searched for a different string"
-)
+# Measured against the whole encoder safe-set (2026-08-05): a value containing
+# = < > ( ) : @ ! survives the round trip intact.
+KB_QUERY_UNSAFE_CHARS = ("^",)
 
 # The duplicate check could not produce a trustworthy answer, so the publish did
 # not happen. Fail-closed: "could not check" is not "nothing found".
@@ -347,6 +337,32 @@ KB_DEDUP_REASON_UNSAFE_CHARS = (
 )
 KB_DEDUP_REASON_TRUNCATED = (
     "the search hit its {limit}-row cap, so a duplicate may have been left off the page"
+)
+
+# ---------------------------------------------------------------------------
+# Encoded-query value boundary (v4.4.1)
+# ---------------------------------------------------------------------------
+# Refusal message for the one character a value cannot carry. Not a warning and
+# not a dropped condition: a silently dropped or widened condition is how a
+# scoped query became a table read (see the silently_dropped_filters memory), so
+# the caller is told instead of being handed rows from a different query.
+QUERY_VALUE_CARET_ERROR = (
+    "Cannot search for a value containing '{char}': ServiceNow's encoded-query "
+    "syntax uses '{char}' to separate conditions and has no way to escape it "
+    "inside a value, so the search would silently match more records than "
+    "requested. Refused rather than answered. Value: '{value}'. Remove the "
+    "'{char}', or express the intent as separate filters."
+)
+
+# `^NQ` starts a brand-new query, discarding every condition built before it, so
+# one poisoned filter value turns a scoped query into an unbounded table read.
+# v4.4.1 turned the existing defense from a silent drop into this refusal: the
+# drop removed the poisoned condition but ran the remaining ones, answering a
+# question nobody asked with rows that look legitimate.
+QUERY_VALUE_NEW_QUERY_ERROR = (
+    "Refusing a filter value containing '{char}NQ': it restarts the query and "
+    "discards every condition before it, which would return records from an "
+    "unscoped table read. Nothing was queried. Value: '{value}'."
 )
 
 # The publish workflow fired but the confirming read failed. Distinct from a

--- a/constants.py
+++ b/constants.py
@@ -365,6 +365,32 @@ QUERY_VALUE_NEW_QUERY_ERROR = (
     "unscoped table read. Nothing was queried. Value: '{value}'."
 )
 
+# Three filter keys accept a PRE-BUILT fragment rather than a value: `_date_range`,
+# `_complete_caller_exclusion`, and `_complete_query`. They carry their own
+# operators — `build_date_filter` legitimately emits
+# "sys_created_on>=A^sys_created_on<=B" — so they cannot be escaped, and `^` has to
+# be allowed. `&` never is: it is not an encoded-query operator, so it can only
+# escape `sysparm_query=` into a sibling URL parameter and truncate the fragment.
+# Refused because there is nowhere else to catch it.
+QUERY_FRAGMENT_AMPERSAND_ERROR = (
+    "Refusing a pre-built filter fragment containing '&': the fragment carries its "
+    "own operators so it cannot be escaped, and a raw '&' ends the query string and "
+    "silently drops everything after it. Nothing was queried. Fragment: '{value}'."
+)
+
+# Field NAMES are caller-supplied too — they are the keys of the filters dict, and
+# no tool validates them. An unchecked key put the operators straight into the
+# query: {"x^NQstate=99": "1"} built "x^NQstate=99=1", the same unscoped-table-read
+# injection the value guard refuses. Shape check rather than a character blacklist,
+# because a legitimate field name is narrow: identifier characters plus '.' for
+# dot-walking (task.priority) and a leading '_' for the internal fragment keys.
+QUERY_FIELD_NAME_ERROR = (
+    "Refusing the filter field name '{value}': a field name may contain only "
+    "letters, digits, '_' and '.' (for dot-walked references such as "
+    "task.priority). Anything else would be read as query syntax rather than as a "
+    "field. Nothing was queried."
+)
+
 # The publish workflow fired but the confirming read failed. Distinct from a
 # publish that is known not to have happened: this one may well have committed.
 ERROR_KB_PUBLISH_VERIFY_UNREADABLE = (

--- a/filter/__init__.py
+++ b/filter/__init__.py
@@ -10,6 +10,7 @@ Public API:
                    build_pagination_params
     NL parsing:    QueryIntelligence, build_smart_filter, get_filter_templates
     Explanation:   QueryExplainer, explain_existing_filter
+    Value escaping: encode_query_value, QueryValueError, QUERY_VALUE_SAFE
 """
 from filter.models import (
     QueryValidationResult,
@@ -36,6 +37,11 @@ from filter.explainer import (
     QueryExplainer,
     explain_existing_filter,
 )
+from filter.value_encoding import (
+    QUERY_VALUE_SAFE,
+    QueryValueError,
+    encode_query_value,
+)
 
 __all__ = [
     # Models
@@ -60,4 +66,8 @@ __all__ = [
     # Explanation
     "QueryExplainer",
     "explain_existing_filter",
+    # Value escaping
+    "QUERY_VALUE_SAFE",
+    "QueryValueError",
+    "encode_query_value",
 ]

--- a/filter/value_encoding.py
+++ b/filter/value_encoding.py
@@ -1,0 +1,127 @@
+"""Per-value encoding boundary for ServiceNow encoded queries (v4.4.1).
+
+One half of a two-part contract. The other half is
+``http_layer/url_builder.encode_query_string``, and they only work together.
+
+    producer  ->  encode_query_value(value)        THIS module: escapes one
+                                                   caller value, refuses '^'
+    assembly  ->  "field" + operator + value       structure added around it
+    transport ->  encode_query_string(whole)       normalises, and no longer
+                                                   treats '&' as an operator
+
+Before v4.4.1 nothing escaped values on most paths, and the transport kept ``&``
+in its safe-set — so it decoded any escaping a call site *had* applied and then
+passed the raw ``&`` through, ending ``sysparm_query`` and truncating the
+condition. Both halves had to change together: escaping here alone is undone by a
+transport that treats ``&`` as safe, and dropping ``&`` there alone does nothing
+for the paths that never escaped anything.
+
+Why the safe-set here is not ``safe=''``
+----------------------------------------
+``= < > ( ) : @ !`` were measured (2026-08-05) to survive intact inside a value:
+ServiceNow splits ``field=value`` on the first ``=`` only, and the rest are
+ordinary characters to its condition parser. Leaving them unescaped keeps a
+``javascript:gs.daysAgoStart(14)`` operand byte-identical to what shipped before.
+
+It also carries the invariant the transport's idempotency depends on. That
+function stays idempotent by decoding before re-encoding, which is only safe
+while decoding cannot resurrect a structural character. Because this safe-set is
+the transport's minus ``^`` — and ``^`` is refused rather than escaped — a
+producer never emits a ``%XY`` for anything the transport leaves raw. Widening
+either set breaks it, so the relationship is pinned by a test.
+
+Why ``^`` is refused rather than escaped
+----------------------------------------
+``^`` is the condition separator and encoded-query syntax has no escape for it.
+Correct end-to-end encoding still hands ServiceNow a *decoded* value containing
+``^``, and its parser splits there. No encoder can carry it, so a value
+containing one is refused: the alternative is running a broader query than the
+caller asked for and reporting its rows as matches.
+
+``^OR`` inside a filter value is the documented exception, and it is resolved
+*before* this function is reached — ``_build_query_condition``'s structural
+handlers claim such values as caller-supplied query fragments (an LLM writing
+``{"priority": "1^ORpriority=2"}`` means the OR). Only a *terminal* value —
+one that is about to be pasted after ``field=`` or after an operator — is
+encoded here, so the refusal never fires on the structural path.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from constants import QUERY_VALUE_CARET_ERROR
+from http_layer.errors import ErrorCode
+
+#: Characters left unescaped inside a value: the transport's operator safe-set
+#: minus ``^`` (refused) and minus ``&`` (must become ``%26`` or it separates
+#: URL parameters). Measured harmless inside a value — see the module docstring.
+QUERY_VALUE_SAFE = "=<>():@!"
+
+#: The one character encoded-query syntax cannot carry inside a value.
+QUERY_VALUE_FORBIDDEN = "^"
+
+#: Values are echoed back in the refusal message; cap the echo so a long
+#: description does not dominate the error.
+_MESSAGE_VALUE_LIMIT = 80
+
+
+class QueryValueError(ValueError):
+    """A caller value cannot be carried by ServiceNow's encoded-query syntax.
+
+    Raised at the point the value would be pasted into a query, so the request
+    is never sent. Carries ``to_error_dict()`` in the same shape and vocabulary
+    as ``ServiceNowRequestError`` (``VALIDATION``) — consumers already map that
+    shape, and ``read_helpers.is_read_failure`` already recognises it, so a
+    refusal travels back to the client through the paths that exist.
+    """
+
+    def __init__(self, value: str, message: str) -> None:
+        self.value = value
+        self.message = message
+        self.code = ErrorCode.VALIDATION
+        super().__init__(message)
+
+    @classmethod
+    def refused(cls, value: str, template: str) -> "QueryValueError":
+        """Build a refusal from a message template in ``constants``.
+
+        Keeps the value echo (and its length cap) in one place, so a second
+        refusal reason cannot drift from the first in how it reports the value.
+        """
+        return cls(
+            value,
+            template.format(value=_truncate(value), char=QUERY_VALUE_FORBIDDEN),
+        )
+
+    def to_error_dict(self) -> dict:
+        """The §3.1 failure shape. Consumers return this straight to the client."""
+        return {"error": {"code": self.code, "message": self.message}}
+
+
+def _truncate(value: str) -> str:
+    if len(value) <= _MESSAGE_VALUE_LIMIT:
+        return value
+    return value[:_MESSAGE_VALUE_LIMIT] + "..."
+
+
+def encode_query_value(value: str) -> str:
+    """Escape one caller-supplied value for use inside a ``sysparm_query``.
+
+    Args:
+        value: A terminal value — the operand of a single condition. Not a
+            query fragment: a caller-built ``priority=1^ORpriority=2`` must not
+            be passed here, it would be refused.
+
+    Returns:
+        The value with everything but ``QUERY_VALUE_SAFE`` percent-encoded.
+        Non-string input is returned unchanged, so an ``int`` filter value from
+        a JSON boundary still interpolates instead of raising ``TypeError``.
+
+    Raises:
+        QueryValueError: *value* contains ``^``.
+    """
+    if not isinstance(value, str):
+        return value
+    if QUERY_VALUE_FORBIDDEN in value:
+        raise QueryValueError.refused(value, QUERY_VALUE_CARET_ERROR)
+    return quote(value, safe=QUERY_VALUE_SAFE)

--- a/http_layer/__init__.py
+++ b/http_layer/__init__.py
@@ -27,9 +27,17 @@ from http_layer.request_dispatcher import (
     make_nws_request,
     test_oauth_connection,
 )
+from http_layer.url_builder import (
+    QUERY_OPERATOR_SAFE,
+    encode_query_string,
+    ensure_query_encoded,
+)
 
 __all__ = [
     "make_nws_request",
+    "encode_query_string",
+    "ensure_query_encoded",
+    "QUERY_OPERATOR_SAFE",
     "test_oauth_connection",
     "get_auth_info",
     "NWS_API_BASE",

--- a/http_layer/url_builder.py
+++ b/http_layer/url_builder.py
@@ -3,7 +3,7 @@
 Owns the two read-path mutations every GET to the table API must apply:
 
 1. URL-encoding the ``sysparm_query`` value while preserving the
-   ServiceNow operator characters ``= < > & ^ ( ) : @ !``.
+   ServiceNow operator characters ``= < > ^ ( ) : @ !``.
 2. Injecting the read-only performance parameters
    ``sysparm_display_value``, ``sysparm_exclude_reference_link``, and
    ``sysparm_no_count`` — the trio responsible for the v3 token-saving
@@ -11,17 +11,68 @@ Owns the two read-path mutations every GET to the table API must apply:
 
 Write paths (POST/PATCH/DELETE) MUST NOT call these helpers — read-only
 params on a write payload would mangle the request.
+
+Why ``&`` left the safe-set in v4.4.1
+------------------------------------
+This encoder normalises the whole assembled query, so it cannot tell a value's
+``&`` from an operator — and ``&`` is not an operator at all: encoded-query
+syntax separates conditions with ``^``. Keeping it safe meant a value's ``&``,
+however carefully escaped upstream, was decoded here and then passed through
+raw, ending ``sysparm_query`` and turning the rest of the condition into a
+sibling URL parameter. ``nameLIKESales & Marketing`` searched for "Sales " and
+sent a stray ``Marketing`` parameter — a query BROADER than the one asked for.
+Escaping it is correct in every case, since it is never structural.
+
+The invariant that makes this compose with the producers
+-------------------------------------------------------
+``unquote`` before ``quote`` keeps this function idempotent, which matters
+because ``query_table_with_filters`` encodes its assembled query and then
+``make_nws_request`` encodes it again. Idempotency by decoding is only safe
+while decoding cannot resurrect a structural character, and that holds by
+construction: ``filter.value_encoding`` escapes caller values with the safe-set
+here MINUS ``^``, so a producer never emits a ``%XY`` for a character this
+function would leave raw, and it refuses ``^`` outright rather than escaping it.
+Pinned by ``tests/test_query_value_encoding.py::
+test_the_two_safe_sets_differ_only_by_the_caret``.
+
+Flipping one side alone reopens the defect: producers that do not escape hand
+this function raw structural characters, and putting ``&`` back here undoes the
+escaping done by the ones that do.
 """
 from __future__ import annotations
 
 from urllib.parse import quote, unquote
+
+#: Characters left unescaped in an assembled query: ServiceNow's operators.
+#: ``&`` is deliberately NOT among them — see the module docstring. Values are
+#: escaped by ``filter.value_encoding.encode_query_value`` using this set minus
+#: ``^``, and the two must stay in that relationship.
+QUERY_OPERATOR_SAFE = "=<>^():@!"
+
+
+def encode_query_string(query: str) -> str:
+    """Percent-encode an assembled encoded-query string for a URL.
+
+    Idempotent: an already-encoded query is decoded first, so encoding twice is
+    the same as encoding once. ``Table_Tools.generic_table_tools`` used to keep a
+    near-copy of this with its own safe-set, so a value could pass through two
+    encoders that disagreed and be round-trip-stable by luck; this is the single
+    implementation both paths now share.
+    """
+    return quote(unquote(query), safe=QUERY_OPERATOR_SAFE)
 
 
 def ensure_query_encoded(url: str) -> str:
     """Ensure ``sysparm_query`` value in URL is percent-encoded for ServiceNow.
 
     Idempotent: already-encoded URLs are unquoted first to prevent
-    double-encoding. Preserves ServiceNow operators: ``= < > & ^ ( ) : @ !``.
+    double-encoding. Preserves ServiceNow operators: ``= < > ^ ( ) : @ !``.
+
+    The split on the first ``&`` is why a raw ``&`` inside a value cannot be
+    rescued at this layer: by the time it arrives it is indistinguishable from
+    the separator before ``sysparm_limit``, and everything after it has already
+    become ``suffix``. Values are escaped at the producer instead, and dropping
+    ``&`` from the safe-set is what stops this function undoing that.
     """
     if "sysparm_query=" not in url:
         return url
@@ -32,9 +83,7 @@ def ensure_query_encoded(url: str) -> str:
     else:
         query_value = rest
         suffix = ""
-    decoded_value = unquote(query_value)
-    encoded_value = quote(decoded_value, safe="=<>&^():@!")
-    return f"{prefix}sysparm_query={encoded_value}{suffix}"
+    return f"{prefix}sysparm_query={encode_query_string(query_value)}{suffix}"
 
 
 def add_default_params(url: str, display_value: bool = True) -> str:

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "personal-mcp-servicenow",
   "display_name": "ServiceNow for Claude",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Query and manage ServiceNow incidents, changes, knowledge articles, SLAs and CMDB directly from Claude.",
   "long_description": "39 tools for ServiceNow: incident/change/request search, intelligent query building, knowledge base management, SLA reporting, CMDB exploration and private task CRUD. Uses OAuth client credentials against your company's ServiceNow instance.",
   "author": {

--- a/personal_mcp_servicenow_main.py
+++ b/personal_mcp_servicenow_main.py
@@ -22,7 +22,7 @@ structlog.configure(
     logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
 )
 
-__version__ = "4.4.0"
+__version__ = "4.4.1"
 
 
 def parse_args():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "personal-mcp-servicenow"
-version = "4.4.0"
+version = "4.4.1"
 description = "MCP server for ServiceNow (incidents, changes, KB, SLA, CMDB)"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/sn_query_probe.py
+++ b/tests/sn_query_probe.py
@@ -1,0 +1,73 @@
+"""What ServiceNow's condition parser actually receives, modelled for tests.
+
+Asserting on the *encoded URL* is how you write a test that passes while the
+query is still wrong: ``sysparm_query=nameLIKEA&B`` reads as if it carries
+``A&B`` and in fact carries ``A``, with a stray ``B`` parameter alongside. Every
+encoder assertion in this repo goes through these helpers instead, so it is
+pinned against the decoded value rather than against a string that merely looks
+right.
+
+Two decoding steps happen on ServiceNow's side, in this order:
+
+1. The HTTP server splits the query string on ``&`` and percent-decodes each
+   parameter value. ``urllib.parse.parse_qsl`` does exactly this, including
+   reading ``+`` as a space.
+2. ServiceNow's encoded-query parser splits the *already decoded*
+   ``sysparm_query`` on ``^`` into conditions.
+
+The order is the whole story. Step 1 is why a raw ``&`` in a value truncates the
+condition it sits in. Step 2 is why a ``^`` in a value cannot be escaped at all:
+by the time the parser runs, the percent-decoding has already happened, so the
+parser sees a real separator no matter how the ``^`` was transmitted.
+
+Reproduces the 2026-08-05 probes that measured the defect, so a test failure here
+means the same thing a live-instance probe would.
+"""
+from __future__ import annotations
+
+from urllib.parse import parse_qsl, urlsplit
+
+
+def servicenow_params(url: str) -> dict[str, str]:
+    """The parameters ServiceNow's servlet layer would see, percent-decoded."""
+    return dict(parse_qsl(urlsplit(url).query, keep_blank_values=True))
+
+
+def servicenow_conditions(url: str) -> list[str]:
+    """The decoded ``sysparm_query`` split into conditions on ``^``."""
+    query = servicenow_params(url).get("sysparm_query")
+    if query is None:
+        return []
+    return query.split("^")
+
+
+def servicenow_value_after(url: str, prefix: str) -> str:
+    """The one condition beginning with *prefix*, with the prefix stripped.
+
+    Raises if the query did not resolve to exactly one such condition. That is
+    not defensiveness — it is the assertion: a value that splits on ``^``
+    produces two matching conditions, and a value truncated by ``&`` produces a
+    condition whose tail went missing.
+    """
+    matches = [
+        condition[len(prefix):]
+        for condition in servicenow_conditions(url)
+        if condition.startswith(prefix)
+    ]
+    if len(matches) != 1:
+        raise AssertionError(
+            f"expected exactly one condition starting with {prefix!r}, "
+            f"got {len(matches)}: {servicenow_conditions(url)!r}"
+        )
+    return matches[0]
+
+
+def assert_no_smuggled_parameter(url: str) -> None:
+    """No URL parameter appeared that the caller did not ask for.
+
+    The signature of the ``&`` defect: a value's ``&`` ends ``sysparm_query`` and
+    everything after it becomes a sibling parameter. Every parameter this codebase
+    sends is a ``sysparm_*``, so anything else is smuggled out of a value.
+    """
+    stray = [name for name in servicenow_params(url) if not name.startswith("sysparm_")]
+    assert not stray, f"value escaped into URL parameter(s): {stray!r} in {url!r}"

--- a/tests/test_generic_table_tools.py
+++ b/tests/test_generic_table_tools.py
@@ -401,9 +401,17 @@ class TestQueryBuilding:
         assert result == "priority=1^ORpriority=2"
 
     def test_build_query_condition_servicenow_in_operator(self):
-        """Test ServiceNow IN operator handling (e.g., task.priorityIN1,2)."""
+        """Test ServiceNow IN operator handling (e.g., task.priorityIN1,2).
+
+        The comma arrives escaped since v4.4.1, because the operand is escaped at
+        this boundary instead of by the transport. The bytes ServiceNow receives
+        are unchanged — ',' was never in either encoder's safe-set, so the URL has
+        always carried '%2C'; only the layer that applies it moved. Asserted on the
+        decoded value ServiceNow parses rather than on this intermediate string in
+        tests/test_query_value_encoding.py.
+        """
         result = _build_query_condition("task.priority", "IN1,2")
-        assert result == "task.priorityIN1,2"
+        assert result == "task.priorityIN1%2C2"
 
     def test_build_query_string_with_malformed_or_value(self):
         """Test full query string building with the MCP bug pattern.
@@ -437,9 +445,17 @@ class TestQueryBuilding:
         assert result == "priority=1^state=2"
 
     def test_build_query_condition_nq_defense(self):
-        """A ^NQ new-query-reset smuggled inside an ordinary filter value is dropped."""
-        result = _build_query_condition("short_description", "fooLIKEbar^NQactive=true")
-        assert result == ""
+        """A ^NQ new-query-reset smuggled inside an ordinary filter value is refused.
+
+        v4.4.1 changed the response from a silent drop to a raise. Dropping the
+        poisoned condition still ran the remaining ones, so the caller was handed
+        real-looking rows from a broader query than they asked for — the same
+        failure family as the encoded-query value defect this release fixes.
+        """
+        from filter import QueryValueError
+
+        with pytest.raises(QueryValueError):
+            _build_query_condition("short_description", "fooLIKEbar^NQactive=true")
 
     def test_build_query_condition_priority(self):
         """Test building priority condition."""

--- a/tests/test_query_value_encoding.py
+++ b/tests/test_query_value_encoding.py
@@ -330,6 +330,37 @@ async def _seam_vtb_sys_id_lookup(value):
     return await _send(lambda: _get_task_sys_id(value))
 
 
+# The write-target lookups. These resolve a record by `number=` and hand the
+# sys_id to a PATCH, so an unescaped '^' could OR in a second condition and
+# resolve a DIFFERENT record than the one named. Added after review: the first
+# draft of this file covered only the VTB one, so reverting the escaping on the
+# other four left the suite green while restoring exactly the defect the release
+# claims to close.
+
+async def _seam_kb_sys_id_lookup(value):
+    from Table_Tools.kb_article_tools import _get_kb_article_sys_id
+
+    return await _send(lambda: _get_kb_article_sys_id(value))
+
+
+async def _seam_kb_meta_lookup(value):
+    from Table_Tools.kb_article_tools import _get_kb_article_meta
+
+    return await _send(lambda: _get_kb_article_meta(value))
+
+
+async def _seam_kb_publish_verify(value):
+    from Table_Tools.kb_article_tools import _verify_kb_published
+
+    return await _send(lambda: _verify_kb_published(value))
+
+
+async def _seam_cmdb_ci_probe(value):
+    from Table_Tools.cmdb_tools import _probe_ci_table
+
+    return await _send(lambda: _probe_ci_table("cmdb_ci_server", value))
+
+
 # (seam, condition prefix ServiceNow should see). Derived from the code, not from
 # a plan document: every module that pastes a caller value into a sysparm_query.
 VALUE_SEAMS = [
@@ -345,6 +376,10 @@ VALUE_SEAMS = [
     (_seam_cmdb_quick_search, "nameLIKE"),
     (_seam_kb_duplicate_check, "short_descriptionLIKE"),
     (_seam_vtb_sys_id_lookup, "number="),
+    (_seam_kb_sys_id_lookup, "number="),
+    (_seam_kb_meta_lookup, "number="),
+    (_seam_kb_publish_verify, "number="),
+    (_seam_cmdb_ci_probe, "number="),
 ]
 
 SEAM_IDS = [seam.__name__.removeprefix("_seam_") for seam, _ in VALUE_SEAMS]
@@ -426,6 +461,82 @@ async def test_a_javascript_date_operand_is_sent_byte_for_byte():
     assert "sys_created_on>=javascript:gs.daysAgoStart(14)" in sent
     assert servicenow_value_after(sent, "sys_created_on>=") == (
         "javascript:gs.daysAgoStart(14)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_ci_details_maps_a_refusal_instead_of_re_raising_it():
+    """`get_ci_details` gathers its probes with `return_exceptions=True`.
+
+    Its loop re-raises anything that is not a classified read failure, so without
+    an explicit arm a `QueryValueError` from the number would escape the tool as an
+    exception rather than an error response. The arm has to precede the
+    `BaseException` one, which is not something a coverage number would reveal.
+    """
+    from Table_Tools.cmdb_tools import get_ci_details
+
+    urls, result = await _send(lambda: get_ci_details("Cost^Center"))
+    assert not urls, f"a probe was sent with an unqueryable number: {urls!r}"
+    assert isinstance(result, dict), result
+    assert result["error"]["code"] == "VALIDATION"
+
+
+def test_no_module_interpolates_a_record_number_unescaped():
+    """Cross-module scan for the write-target class specifically.
+
+    The handler scan below only reads `generic_table_tools`, so it says nothing
+    about the `number=` lookups in the KB, CMDB and VTB modules — and those are the
+    ones whose sys_id feeds a PATCH. Reverting the escaping on four of the five left
+    the suite green until the seams above existed; this makes the *next* one a named
+    failure rather than a silent regression.
+
+    Scanned over the AST rather than over lines: a line-based version flagged three
+    docstrings that merely *describe* `number={x}`, and missed that an escaped value
+    can arrive through a local variable. Prose is not code and a variable is not a
+    defect, so this reads f-strings and follows a one-hop assignment.
+    """
+    import ast
+    from pathlib import Path
+
+    def escaped_names(func: ast.AST) -> set[str]:
+        """Locals assigned directly from `encode_query_value(...)` in this function."""
+        names = set()
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+                continue
+            called = node.value.func
+            if isinstance(called, ast.Name) and called.id == "encode_query_value":
+                names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        return names
+
+    def is_escaped(expr: ast.AST, safe_locals: set[str]) -> bool:
+        if isinstance(expr, ast.Call):
+            return isinstance(expr.func, ast.Name) and expr.func.id == "encode_query_value"
+        return isinstance(expr, ast.Name) and expr.id in safe_locals
+
+    offenders = []
+    for module in sorted((Path(__file__).resolve().parent.parent / "Table_Tools").glob("*.py")):
+        tree = ast.parse(module.read_text(encoding="utf-8"))
+        for func in ast.walk(tree):
+            if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            safe_locals = escaped_names(func)
+            for fstring in (n for n in ast.walk(func) if isinstance(n, ast.JoinedStr)):
+                parts = fstring.values
+                for literal, following in zip(parts, parts[1:]):
+                    if not (isinstance(literal, ast.Constant) and isinstance(literal.value, str)):
+                        continue
+                    if not literal.value.endswith("number="):
+                        continue
+                    if not isinstance(following, ast.FormattedValue):
+                        continue
+                    if not is_escaped(following.value, safe_locals):
+                        offenders.append(f"{module.name}:{func.name}:{fstring.lineno}")
+
+    assert not offenders, (
+        f"{offenders} paste a record number into a query without encode_query_value. "
+        "These lookups pick the record a write then targets, so a '^' in the number "
+        "can resolve a different record than the one named."
     )
 
 

--- a/tests/test_query_value_encoding.py
+++ b/tests/test_query_value_encoding.py
@@ -1,0 +1,592 @@
+"""v4.4.1 — the encoded-query value boundary, asserted against what ServiceNow decodes.
+
+Three layers, because the defect had three separate failure modes and a test that
+only covers one of them passes while the query is still wrong:
+
+1. **Characters** — every character from the 2026-08-05 measurement, pushed
+   through the real producer encoder and the real transport encoder, asserting the
+   value ServiceNow's parser ends up with. Never the URL string.
+2. **Seams** — each place a caller-supplied value becomes part of a query, end to
+   end through ``make_nws_request`` (stubbed at the OAuth boundary, so the
+   encoding under test genuinely runs), for the character that actually broke.
+3. **Refusal** — ``^`` is unrepresentable; every seam must refuse rather than
+   answer, and must not send a request.
+
+The failure signatures being pinned, from the measurement:
+
+    'Cost^Center'  -> two conditions          (the '^' split)
+    'A&B'          -> two URL parameters      (the '&' escape)
+    'Deal 20%2C'   -> ServiceNow sees 'Deal 20,'   (the silent unquote)
+
+All three ran BROADER than the caller asked for, which is why an assertion on
+condition count and on parameter count belongs beside every value assertion.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from filter import QueryValueError, encode_query_value
+from filter.value_encoding import QUERY_VALUE_SAFE
+from http_layer.url_builder import QUERY_OPERATOR_SAFE, ensure_query_encoded
+from tests.sn_query_probe import (
+    assert_no_smuggled_parameter,
+    servicenow_conditions,
+    servicenow_params,
+    servicenow_value_after,
+)
+
+TEXT_PREFIX = "short_descriptionLIKE"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — characters
+# ---------------------------------------------------------------------------
+
+def _wire(value: str, prefix: str = TEXT_PREFIX) -> str:
+    """Push *value* through both encoders and return what ServiceNow decodes.
+
+    Composes the two halves in production order — the producer's
+    ``encode_query_value``, then the transport's ``ensure_query_encoded`` — so a
+    change to either half that breaks the round trip fails here. Running only one
+    of them is how the defect survived: each looked correct alone.
+    """
+    url = (
+        "https://x/api/now/table/incident"
+        f"?sysparm_fields=number&sysparm_query={prefix}{encode_query_value(value)}"
+        "&sysparm_limit=10"
+    )
+    encoded = ensure_query_encoded(url)
+    assert_no_smuggled_parameter(encoded)
+    assert len(servicenow_conditions(encoded)) == 1, servicenow_conditions(encoded)
+    return servicenow_value_after(encoded, prefix)
+
+
+# Every character from the measurement. Grouped only for readability — the
+# assertion is identical for all of them: ServiceNow must receive the value it
+# was given, and the query must stay one condition and one parameter.
+FAITHFUL_VALUES = [
+    # The structural character that was broken in transport (v4.4.0: truncated
+    # the condition and appended a stray URL parameter).
+    "Sales & Marketing",
+    "A&B&C",
+    # Previously fine, must stay fine: the rest of the operator safe-set. These
+    # survive because ServiceNow splits conditions on '^' alone.
+    "Cost=Center",
+    "a<b",
+    "a>b",
+    "f(x)",
+    "ratio:1",
+    "user@host",
+    "urgent!",
+    # Escape-adjacent. v4.4.0 decoded these, so ServiceNow was searched for a
+    # different string with nothing announcing it (`unquote` never raises).
+    "Deal 20%2C off",
+    "Reset %41dmin password",
+    "Up 20%DB backups",
+    "50% off",
+    "100%",
+    "%",
+    "%%",
+    # Ordinary text that has always needed escaping.
+    "server down",
+    "issue #123",
+    "a+b",
+    "what?",
+    "a,b",
+    "it's broken",
+    "café naïve",
+    "日本語のテキスト",
+]
+
+
+@pytest.mark.parametrize("value", FAITHFUL_VALUES, ids=repr)
+def test_servicenow_receives_the_value_it_was_given(value):
+    assert _wire(value) == value
+
+
+@pytest.mark.parametrize("value", FAITHFUL_VALUES, ids=repr)
+def test_encoding_a_value_is_idempotent_through_the_transport(value):
+    """Re-encoding an already-encoded URL changes nothing.
+
+    The property the old ``unquote()``-first implementation bought, kept without
+    it. It matters because ``query_table_with_filters`` encodes the assembled
+    query itself and ``make_nws_request`` encodes it again — two passes on the
+    same string, and before v4.4.1 they were two different encoders.
+    """
+    once = ensure_query_encoded(
+        f"https://x/api?sysparm_query={TEXT_PREFIX}{encode_query_value(value)}"
+    )
+    assert ensure_query_encoded(once) == once
+
+
+def test_caret_is_refused_not_escaped():
+    """No encoding can carry it: ServiceNow splits on the DECODED value."""
+    with pytest.raises(QueryValueError) as excinfo:
+        encode_query_value("Cost^Center")
+    assert excinfo.value.code == "VALIDATION"
+    assert "Cost^Center" in excinfo.value.message
+
+
+def test_a_caret_would_have_produced_two_conditions():
+    """The premise of the refusal, asserted rather than assumed.
+
+    Percent-encode ``^`` end to end, by hand, as correctly as anyone could, and
+    ServiceNow still receives two conditions. This is what makes ``^``
+    unrepresentable rather than merely mis-transported, and it is the reason the
+    refusal is not a missing feature.
+    """
+    hand_encoded = ensure_query_encoded(
+        f"https://x/api?sysparm_query={TEXT_PREFIX}Cost%5ECenter"
+    )
+    assert servicenow_conditions(hand_encoded) == ["short_descriptionLIKECost", "Center"]
+
+
+def test_a_non_string_value_passes_through_instead_of_raising():
+    """An `int` arriving from the JSON boundary must still interpolate.
+
+    MCP clients stringify inconsistently (see the param_coercion module), so a
+    filter value can reach here as an int. `quote` would raise TypeError on it,
+    turning a harmless filter into a crash.
+    """
+    assert encode_query_value(3) == 3
+    assert encode_query_value(None) is None
+
+
+def test_a_long_value_is_truncated_in_the_refusal_message():
+    """The message echoes the value; a 5000-character description must not fill it."""
+    long_value = "x" * 500 + "^"
+    with pytest.raises(QueryValueError) as excinfo:
+        encode_query_value(long_value)
+    assert "..." in excinfo.value.message
+    assert len(excinfo.value.message) < 500
+    assert excinfo.value.value == long_value, "the full value stays on the exception"
+
+
+def test_the_two_safe_sets_differ_only_by_the_caret():
+    """The relationship the design rests on, pinned so a future edit must be deliberate.
+
+    The value safe-set is the transport's minus ``^``. If they drift apart, either
+    a value stops round-tripping (transport escapes something the producer left
+    alone) or ``^`` becomes carryable again (it is not).
+    """
+    assert set(QUERY_OPERATOR_SAFE) - set(QUERY_VALUE_SAFE) == {"^"}
+
+
+def test_a_bare_equals_in_a_filter_value_is_still_read_as_an_operator():
+    """Known limitation, pinned rather than left unrecorded. Not an encoding bug.
+
+    ``_has_operator_in_value`` treats any ``=`` in a value as caller-supplied
+    operator syntax, so ``{"short_description": "Cost=Center"}`` builds
+    ``short_descriptionCost=Center`` — a condition on a field that does not
+    exist, which ServiceNow drops silently, widening the query. Escaping cannot
+    fix it: the ambiguity is in deciding whether the caller meant an operator.
+    The value round-trips fine once an operator is explicit
+    (``LIKECost=Center``), which is what `FAITHFUL_VALUES` covers.
+    """
+    from Table_Tools.generic_table_tools import _build_query_condition
+
+    assert _build_query_condition("short_description", "Cost=Center") == (
+        "short_descriptionCost=Center"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — seams, end to end
+# ---------------------------------------------------------------------------
+
+async def _send(call):
+    """Run *call* with the transport stubbed at the OAuth boundary.
+
+    Patched at ``http_layer.request_dispatcher.make_oauth_request`` and NOT at
+    each module's ``make_nws_request``: the transport half of the encoder lives
+    inside ``make_nws_request``, so stubbing that would test every producer
+    against an encoder that never ran — and pass.
+    """
+    urls: list[str] = []
+
+    async def fake_oauth(url):
+        urls.append(url)
+        return {"result": []}
+
+    with patch("http_layer.request_dispatcher.make_oauth_request", new=fake_oauth):
+        result = await call()
+    return urls, result
+
+
+async def _seam_filter_records(value):
+    from Table_Tools.generic_table_tools import query_table_with_filters
+    from filter import TableFilterParams
+
+    return await _send(lambda: query_table_with_filters(
+        "incident",
+        TableFilterParams(filters={"short_description": f"LIKE{value}"}, fields=["number"]),
+    ))
+
+
+async def _seam_generic_filters(value):
+    from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+    return await _send(lambda: query_table_with_generic_filters(
+        "incident", {"short_description": f"LIKE{value}"}
+    ))
+
+
+async def _seam_exact_match(value):
+    """A bare value, so `_build_query_condition` falls through to exact match.
+
+    The default handler, and therefore the one most callers hit. It had no seam
+    coverage in the first draft of this file: every other filter seam passes an
+    explicit `LIKE`, which diverts to the operator handler instead. A mutation
+    that dropped the escaping from exact match passed the whole suite.
+    """
+    from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+    return await _send(lambda: query_table_with_generic_filters(
+        "incident", {"assigned_to": value}
+    ))
+
+
+async def _seam_suffix_operator(value):
+    """`assigned_to_gte` -> `assigned_to>=`, a third terminal handler."""
+    from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+    return await _send(lambda: query_table_with_generic_filters(
+        "incident", {"assigned_to_gte": value}
+    ))
+
+
+async def _seam_priority_single(value):
+    """`_format_single_priority`, reached only via P-notation with no comma.
+
+    A distinct code path from the comma list, and it had only the source-scan
+    guard behind it until this seam existed.
+    """
+    from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+    return await _send(lambda: query_table_with_generic_filters(
+        "incident", {"priority": f"P{value}"}
+    ))
+
+
+async def _seam_date_range_operator(value):
+    """`_handle_date_range_condition`'s `>=`/`<=` branch — its terminal branch.
+
+    Its sibling branches are structural (a BETWEEN/javascript fragment), so this
+    is the only part of that handler that escapes, and it shares its exact source
+    line with the operator handler — which is how a mutation aimed at one of them
+    silently hit the other.
+    """
+    from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+    return await _send(lambda: query_table_with_generic_filters(
+        "incident", {"sys_created_on": f">={value}"}
+    ))
+
+
+async def _seam_priority_comma_list(value):
+    """`_parse_priority_list` -> `_process_comma_separated_priorities`.
+
+    Reached only by a comma in the value, which is why it is its own seam: the
+    priority handler claims the filter before any generic handler sees it.
+    """
+    from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+    return await _send(lambda: query_table_with_generic_filters(
+        "incident", {"priority": f"1,{value}"}
+    ))
+
+
+async def _seam_priority_additional_filters(value):
+    from Table_Tools.generic_table_tools import get_records_by_priority
+
+    return await _send(lambda: get_records_by_priority(
+        "incident", ["1"], additional_filters={"assigned_to": value}
+    ))
+
+
+async def _seam_cmdb_attributes(value):
+    from Table_Tools.cmdb_tools import search_cis_by_attributes
+
+    return await _send(lambda: search_cis_by_attributes(name=value))
+
+
+async def _seam_cmdb_quick_search(value):
+    from Table_Tools.cmdb_tools import quick_ci_search
+
+    return await _send(lambda: quick_ci_search(value))
+
+
+async def _seam_kb_duplicate_check(value):
+    from Table_Tools.kb_article_tools import _check_kb_duplicates
+
+    return await _send(lambda: _check_kb_duplicates(value, "KB0001234"))
+
+
+async def _seam_vtb_sys_id_lookup(value):
+    from Table_Tools.vtb_task_tools import _get_task_sys_id
+
+    return await _send(lambda: _get_task_sys_id(value))
+
+
+# (seam, condition prefix ServiceNow should see). Derived from the code, not from
+# a plan document: every module that pastes a caller value into a sysparm_query.
+VALUE_SEAMS = [
+    (_seam_filter_records, "short_descriptionLIKE"),
+    (_seam_generic_filters, "short_descriptionLIKE"),
+    (_seam_exact_match, "assigned_to="),
+    (_seam_suffix_operator, "assigned_to>="),
+    (_seam_priority_comma_list, "ORpriority="),
+    (_seam_priority_single, "priority="),
+    (_seam_date_range_operator, "sys_created_on>="),
+    (_seam_priority_additional_filters, "assigned_to="),
+    (_seam_cmdb_attributes, "nameLIKE"),
+    (_seam_cmdb_quick_search, "nameLIKE"),
+    (_seam_kb_duplicate_check, "short_descriptionLIKE"),
+    (_seam_vtb_sys_id_lookup, "number="),
+]
+
+SEAM_IDS = [seam.__name__.removeprefix("_seam_") for seam, _ in VALUE_SEAMS]
+
+# One value per failure mode, run through every seam. The exhaustive character
+# sweep is layer 1; this layer proves each producer is wired into it.
+SEAM_VALUES = ["Sales & Marketing", "Deal 20%2C off", "issue #123"]
+
+
+@pytest.mark.parametrize("seam, prefix", VALUE_SEAMS, ids=SEAM_IDS)
+@pytest.mark.parametrize("value", SEAM_VALUES, ids=repr)
+@pytest.mark.asyncio
+async def test_every_seam_carries_the_value_faithfully(seam, prefix, value):
+    urls, _ = await seam(value)
+
+    assert urls, "the seam sent no request, so nothing was asserted"
+    sent = urls[0]
+    assert_no_smuggled_parameter(sent)
+    assert servicenow_value_after(sent, prefix) == value
+
+
+@pytest.mark.parametrize("seam, prefix", VALUE_SEAMS, ids=SEAM_IDS)
+@pytest.mark.asyncio
+async def test_every_seam_refuses_a_caret_without_sending_a_request(seam, prefix):
+    """A refusal that still sends the request would defeat the point.
+
+    The KB duplicate check answers in its own fail-closed vocabulary
+    (`KbDuplicateCheckInconclusive`) because for a publish "could not check" has
+    to block, not just report. Everywhere else the refusal is a `QueryValueError`,
+    surfaced as a VALIDATION error dict.
+    """
+    from Table_Tools.kb_article_tools import KbDuplicateCheckInconclusive
+
+    try:
+        urls, result = await seam("Cost^Center")
+    except (QueryValueError, KbDuplicateCheckInconclusive):
+        # Helper-level seams (not registered tools) propagate; their callers map it.
+        return
+
+    assert not urls, f"a request was sent with an unqueryable value: {urls!r}"
+    assert isinstance(result, dict), result
+    assert result.get("error", {}).get("code") == "VALIDATION", result
+
+
+@pytest.mark.asyncio
+async def test_a_caller_exclusion_list_escapes_each_sys_id():
+    """The join is ours, the elements are values. Both have to be right.
+
+    `exclude_caller` produces `caller_id!=a^caller_id!=b`: escaping the whole
+    string would destroy the join, escaping nothing lets an element's '&' truncate
+    the query. Not in the seam matrix because its condition shape is its own.
+    """
+    from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+    urls, _ = await _send(lambda: query_table_with_generic_filters(
+        "incident", {"exclude_caller": "a&b,c&d"}
+    ))
+    sent = urls[0]
+    assert_no_smuggled_parameter(sent)
+    conditions = servicenow_conditions(sent)
+    assert "caller_id!=a&b" in conditions
+    assert "caller_id!=c&d" in conditions
+
+
+@pytest.mark.asyncio
+async def test_a_javascript_date_operand_is_sent_byte_for_byte():
+    """The reason the value safe-set is not `safe=''`.
+
+    ServiceNow evaluates `javascript:` operands server-side, and `( ) :` survive
+    inside a value, so escaping them would be a gratuitous change to a working
+    feature. Pinned because `safe=''` is the obvious thing to reach for.
+    """
+    from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+    urls, _ = await _send(lambda: query_table_with_generic_filters(
+        "incident", {"sys_created_on": ">=javascript:gs.daysAgoStart(14)"}
+    ))
+    sent = urls[0]
+    assert "sys_created_on>=javascript:gs.daysAgoStart(14)" in sent
+    assert servicenow_value_after(sent, "sys_created_on>=") == (
+        "javascript:gs.daysAgoStart(14)"
+    )
+
+
+def test_every_terminal_condition_handler_escapes_its_value():
+    """Derived from the code, not from a list of handlers someone maintained.
+
+    Same guard shape as `tests/test_http_layer_errors.py`'s read-path consumer
+    scan, and for the same reason: a hand-kept list of the places that needed
+    migrating was already wrong once in this project, by one module, and the
+    missed one had no handling at all. Here the first draft missed three — the
+    exact-match default and both priority helpers — and every existing test
+    stayed green.
+
+    A function that interpolates a bare `{value}`-family name into an f-string is
+    pasting a caller value into a query and must escape it. STRUCTURAL exceptions
+    are listed with why, so adding one is a decision rather than an omission.
+    """
+    import inspect
+    import re
+
+    from Table_Tools import generic_table_tools as gtt
+
+    # Names that hold a caller-supplied value at the point of interpolation.
+    VALUE_NAMES = ("value", "p", "priority_num", "caller_id", "keyword")
+    STRUCTURAL = {
+        # value IS a query fragment; escaping it would destroy the operators
+        # it is built from.
+        "_handle_complete_query_condition",
+        "_handle_servicenow_filter_condition",
+        "_handle_bare_or_value_condition",
+    }
+    pattern = re.compile(
+        r"f\"[^\"\n]*\{(?:" + "|".join(VALUE_NAMES) + r")\}[^\"\n]*\""
+    )
+
+    offenders = []
+    for name, obj in vars(gtt).items():
+        if name in STRUCTURAL or not inspect.isfunction(obj):
+            continue
+        if obj.__module__ != gtt.__name__:
+            continue
+        if pattern.search(inspect.getsource(obj)):
+            offenders.append(name)
+
+    assert not offenders, (
+        f"{offenders} paste a caller value into a query without "
+        "encode_query_value. Either escape it, or add the function to STRUCTURAL "
+        "with a reason — a value that reaches ServiceNow unescaped widens the "
+        "query instead of failing."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — the incidental protection nobody designed
+# ---------------------------------------------------------------------------
+
+class TestTextSearchTokenizerImmunity:
+    """`query_table_by_text` is safe by accident, so the accident is pinned.
+
+    `utils.extract_keywords` tokenizes on `\\b[a-zA-Z]{4,}\\b`, so a keyword
+    cannot contain `^`, `&` or `%` no matter what the caller typed. That is real
+    protection and it is the reason the text-search path never needed a fix — but
+    nobody chose it, and widening the character class would remove it silently
+    while every existing test stayed green.
+    """
+
+    @pytest.mark.parametrize("text", [
+        "Cost^Center outage",
+        "Sales & Marketing incident",
+        "Deal 20%2C discount problem",
+        "server down issue #123",
+    ])
+    def test_no_keyword_can_carry_a_structural_character(self, text):
+        from utils import extract_keywords
+
+        for keyword in extract_keywords(text):
+            assert not set(keyword) & set("^&%"), keyword
+
+    def test_the_tokenizer_pattern_is_still_letters_only(self):
+        """Pins the mechanism, not just today's outputs.
+
+        A test that only checks sample strings passes if the class is widened to
+        `[a-zA-Z0-9^&%]` and no sample happens to hit it. Equality on the pattern
+        makes a widening deliberate and points at what it costs.
+        """
+        import utils
+
+        assert utils._CONTENT_KEYWORD_PATTERN.pattern == r"\b[a-zA-Z]{4,}\b", (
+            "extract_keywords no longer tokenizes on letters only — the text "
+            "search is no longer immune to structural characters by construction, "
+            "so `query_table_by_text` now depends on encode_query_value for real "
+            "rather than as a no-op. Verify the seam tests cover it."
+        )
+
+    @pytest.mark.parametrize("text", FAITHFUL_VALUES + ["INC0012345 and Cost^Center"], ids=repr)
+    def test_every_token_the_tokenizer_emits_is_alphanumeric(self, text):
+        """Covers the record-number branch too, which has its own patterns.
+
+        `extract_keywords` returns record numbers (`inc\\d+`, `kb\\d+`, ...) ahead
+        of content keywords, so pinning only the content pattern would leave half
+        the function unpinned.
+        """
+        from utils import extract_keywords
+
+        for keyword in extract_keywords(text):
+            assert keyword.isalnum(), keyword
+
+    @pytest.mark.asyncio
+    async def test_text_search_sends_one_condition_per_keyword_and_no_stray_params(self):
+        from Table_Tools.generic_table_tools import query_table_by_text
+        from utils import extract_keywords
+
+        text = "Sales & Marketing outage report"
+        expected_keywords = extract_keywords(text)
+        assert expected_keywords, "premise of the test"
+
+        urls, _ = await _send(lambda: query_table_by_text("incident", text))
+        sent = urls[0]
+        assert_no_smuggled_parameter(sent)
+
+        # One LIKE condition per keyword — the '&' contributes no token at all —
+        # plus the injected ORDERBY, which is one more condition.
+        conditions = servicenow_conditions(sent)
+        like_conditions = [c for c in conditions if "short_descriptionLIKE" in c]
+        assert len(like_conditions) == len(expected_keywords)
+        assert all("&" not in c for c in like_conditions)
+        assert any("ORDERBYDESC" in c for c in conditions)
+
+
+# ---------------------------------------------------------------------------
+# The ^NQ reset — refused now, not silently dropped
+# ---------------------------------------------------------------------------
+
+class TestNewQueryResetRefusal:
+    """`^NQ` discards every condition before it, so a scoped query becomes a table read."""
+
+    def test_a_new_query_reset_is_refused(self):
+        from Table_Tools.generic_table_tools import _build_query_condition
+
+        with pytest.raises(QueryValueError) as excinfo:
+            _build_query_condition("short_description", "fooLIKEbar^NQactive=true")
+        assert "NQ" in excinfo.value.message
+
+    def test_it_is_refused_even_when_a_structural_handler_would_claim_it(self):
+        """Why the check runs before the handlers rather than inside the encoder.
+
+        `1^ORpriority=2^NQactive=true` is claimed by the bare-OR repair handler as
+        a caller-built fragment and passed straight through, so it would never
+        reach a value encoder. The reset has to be caught first.
+        """
+        from Table_Tools.generic_table_tools import _build_query_condition
+
+        with pytest.raises(QueryValueError):
+            _build_query_condition("priority", "1^ORpriority=2^NQactive=true")
+
+    @pytest.mark.asyncio
+    async def test_the_tool_reports_it_instead_of_querying(self):
+        from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+        urls, result = await _send(lambda: query_table_with_generic_filters(
+            "incident", {"short_description": "fooLIKEbar^NQactive=true"}
+        ))
+        assert not urls, "a query ran despite an unqueryable filter value"
+        assert result["error"]["code"] == "VALIDATION"

--- a/tests/test_query_value_encoding.py
+++ b/tests/test_query_value_encoding.py
@@ -285,6 +285,44 @@ async def _seam_date_range_operator(value):
     ))
 
 
+async def _seam_priority_builder_single(value):
+    """`_build_priority_filter`'s single-priority branch — a THIRD priority path.
+
+    Distinct from `_parse_priority_list`'s two helpers, reached from
+    `get_priority_incidents` whenever exactly one priority is asked for, which is
+    the common case. Review caught that it was escaped and entirely unasserted:
+    reverting it left 1108 passed.
+    """
+    from Table_Tools.generic_table_tools import get_records_by_priority
+
+    return await _send(lambda: get_records_by_priority("incident", [value]))
+
+
+async def _seam_priority_builder_multi(value):
+    """`_build_priority_filter`'s OR-joined branch. Sibling of the above."""
+    from Table_Tools.generic_table_tools import get_records_by_priority
+
+    return await _send(lambda: get_records_by_priority("incident", ["1", value]))
+
+
+async def _seam_cmdb_ip_address(value):
+    from Table_Tools.cmdb_tools import search_cis_by_attributes
+
+    return await _send(lambda: search_cis_by_attributes(ip_address=value))
+
+
+async def _seam_cmdb_location(value):
+    from Table_Tools.cmdb_tools import search_cis_by_attributes
+
+    return await _send(lambda: search_cis_by_attributes(location=value))
+
+
+async def _seam_cmdb_status(value):
+    from Table_Tools.cmdb_tools import search_cis_by_attributes
+
+    return await _send(lambda: search_cis_by_attributes(status=value))
+
+
 async def _seam_priority_comma_list(value):
     """`_parse_priority_list` -> `_process_comma_separated_priorities`.
 
@@ -372,7 +410,12 @@ VALUE_SEAMS = [
     (_seam_priority_single, "priority="),
     (_seam_date_range_operator, "sys_created_on>="),
     (_seam_priority_additional_filters, "assigned_to="),
+    (_seam_priority_builder_single, "priority="),
+    (_seam_priority_builder_multi, "ORpriority="),
     (_seam_cmdb_attributes, "nameLIKE"),
+    (_seam_cmdb_ip_address, "ip_address="),
+    (_seam_cmdb_location, "locationLIKE"),
+    (_seam_cmdb_status, "operational_status="),
     (_seam_cmdb_quick_search, "nameLIKE"),
     (_seam_kb_duplicate_check, "short_descriptionLIKE"),
     (_seam_vtb_sys_id_lookup, "number="),
@@ -550,36 +593,140 @@ def test_every_terminal_condition_handler_escapes_its_value():
     exact-match default and both priority helpers — and every existing test
     stayed green.
 
-    A function that interpolates a bare `{value}`-family name into an f-string is
-    pasting a caller value into a query and must escape it. STRUCTURAL exceptions
-    are listed with why, so adding one is a decision rather than an omission.
+    Anything derived from a function's parameters and interpolated into an f-string
+    is a caller value being pasted into a query, and must go through
+    `encode_query_value`. STRUCTURAL exceptions are listed with why, so adding one
+    is a decision rather than an omission.
+
+    **Taint-propagating AST walk, not a regex over source.** The first version was
+    a regex requiring a literal double-quoted f-string and a hardcoded whitelist of
+    variable names — `f'{x}={y}'` in single quotes would have slipped past it, and
+    `priorities[0]` demonstrably did, because a subscript is not a bare name. That
+    miss was a real unescaped call site found in review. Taint starts at the
+    parameters and follows assignments and comprehension targets, so it does not
+    care what anything is named.
+
+    Field names are exempt, because they are guarded by
+    `_reject_unsafe_field_name`'s shape check rather than by escaping — but the
+    exemption is *earned*, not granted by name: a name drops out of the taint set
+    when the same function actually calls that validator on it. Delete the guard call
+    and the interpolation is flagged again. The one exception is a parameter literally
+    named `field`, which a handler receives already validated by
+    `_build_query_condition`. `TestFieldNamesAreCallerSuppliedToo` holds up the
+    validator itself.
     """
+    import ast
     import inspect
-    import re
 
     from Table_Tools import generic_table_tools as gtt
 
-    # Names that hold a caller-supplied value at the point of interpolation.
-    VALUE_NAMES = ("value", "p", "priority_num", "caller_id", "keyword")
     STRUCTURAL = {
-        # value IS a query fragment; escaping it would destroy the operators
-        # it is built from.
+        # The value IS a query fragment; escaping it would destroy the operators it
+        # is built from. Guarded by `_reject_unsafe_fragment` instead.
         "_handle_complete_query_condition",
         "_handle_servicenow_filter_condition",
         "_handle_bare_or_value_condition",
     }
-    pattern = re.compile(
-        r"f\"[^\"\n]*\{(?:" + "|".join(VALUE_NAMES) + r")\}[^\"\n]*\""
-    )
+    SYNTHESISED = {
+        # Interpolate a value they built themselves rather than the caller's bytes,
+        # so there is nothing to escape.
+        #   date range: `f"{year}-{month:02d}-{day:02d}"` from regex-matched ints.
+        #               Its one terminal branch (`>=`/`<=`) does escape.
+        #   caller map: `known_callers[value_lower]` — the caller's text is a dict
+        #               KEY into a hardcoded map; the interpolated result is one of
+        #               our own sys_id constants.
+        "_handle_date_range_condition",
+        "_parse_caller_exclusions",
+    }
+
+    # The functions whose job is to turn a field and a value into a condition —
+    # derived by following calls from the three query-assembly entry points, so a
+    # new handler or a new helper under one is covered without editing this test.
+    # Scoping matters: taint from parameters legitimately reaches table names, field
+    # lists and message strings everywhere else in the module.
+    def call_closure(seeds: set[str]) -> set[str]:
+        seen, frontier = set(), set(seeds)
+        while frontier:
+            name = frontier.pop()
+            if name in seen:
+                continue
+            seen.add(name)
+            target = getattr(gtt, name, None)
+            if not inspect.isfunction(target) or target.__module__ != gtt.__name__:
+                continue
+            tree = ast.parse(inspect.getsource(target).lstrip())
+            frontier |= {
+                node.func.id
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            } - seen
+        return seen
+
+    CONDITION_BUILDERS = call_closure({
+        "_build_query_condition",      # the main filter path
+        "_build_additional_filters",   # the second assembly path
+        "_build_priority_filter",      # the third priority path
+    })
+
+    def tainted_names(func: ast.AST) -> set[str]:
+        """Parameter names plus everything that flows out of them."""
+        args = func.args
+        names = {
+            a.arg
+            for a in (*args.posonlyargs, *args.args, *args.kwonlyargs)
+            if a.arg != "field"
+        }
+        # Fixed-point: an assignment can chain (value -> parsed -> parts[0]).
+        for _ in range(len(list(ast.walk(func)))):
+            grew = False
+            for node in ast.walk(func):
+                targets = []
+                if isinstance(node, ast.Assign):
+                    targets, source = node.targets, node.value
+                elif isinstance(node, ast.comprehension):
+                    targets, source = [node.target], node.iter
+                elif isinstance(node, ast.For):
+                    targets, source = [node.target], node.iter
+                else:
+                    continue
+                if not (names & {n.id for n in ast.walk(source) if isinstance(n, ast.Name)}):
+                    continue
+                for target in targets:
+                    for bound in ast.walk(target):
+                        if isinstance(bound, ast.Name) and bound.id not in names:
+                            names.add(bound.id)
+                            grew = True
+            if not grew:
+                break
+        # A name this function passes to the field-name validator is guarded by shape
+        # instead of by escaping. Earned per call site: remove the call and the
+        # interpolation below is flagged again.
+        for node in ast.walk(func):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+                continue
+            if node.func.id != "_reject_unsafe_field_name" or not node.args:
+                continue
+            if isinstance(node.args[0], ast.Name):
+                names.discard(node.args[0].id)
+        return names
 
     offenders = []
-    for name, obj in vars(gtt).items():
-        if name in STRUCTURAL or not inspect.isfunction(obj):
+    for name in sorted(CONDITION_BUILDERS):
+        obj = getattr(gtt, name, None)
+        if name in STRUCTURAL or name in SYNTHESISED or not inspect.isfunction(obj):
             continue
         if obj.__module__ != gtt.__name__:
             continue
-        if pattern.search(inspect.getsource(obj)):
-            offenders.append(name)
+        func = ast.parse(inspect.getsource(obj).lstrip()).body[0]
+        tainted = tainted_names(func)
+        for interpolation in (n for n in ast.walk(func) if isinstance(n, ast.FormattedValue)):
+            expr = interpolation.value
+            if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Name) \
+                    and expr.func.id == "encode_query_value":
+                continue
+            referenced = {n.id for n in ast.walk(expr) if isinstance(n, ast.Name)}
+            if referenced & tainted:
+                offenders.append(f"{name} (interpolates {sorted(referenced & tainted)})")
 
     assert not offenders, (
         f"{offenders} paste a caller value into a query without "
@@ -587,6 +734,153 @@ def test_every_terminal_condition_handler_escapes_its_value():
         "with a reason — a value that reaches ServiceNow unescaped widens the "
         "query instead of failing."
     )
+
+
+class TestPreBuiltFragmentChannels:
+    """The three filter keys that take a fragment instead of a value.
+
+    `_date_range`, `_complete_caller_exclusion` and `_complete_query` hand a
+    pre-built fragment through, complete with its own operators. They cannot be
+    escaped — `build_date_filter` legitimately emits
+    `sys_created_on>=A^sys_created_on<=B`, so `^` has to be allowed — which makes
+    them the one place where a guard, not an encoder, is the only defence.
+
+    Both were live holes found in review, verified by execution before fixing:
+    `get_priority_incidents(additional_filters={"_date_range": "1^NQstate=99"})`
+    and `filter_records({"_complete_caller_exclusion": "caller_id!=x^NQstate=99"})`
+    each sent the reset to ServiceNow verbatim and returned rows, in a release
+    whose stated purpose was refusing exactly that. The `^NQ` check sat *after* the
+    fragment early-returns, and `_build_additional_filters` never reached it at all
+    because it is a second, parallel assembly path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_date_range_refuses_a_new_query_reset(self):
+        from Table_Tools.consolidated_tools import get_priority_incidents
+
+        urls, result = await _send(lambda: get_priority_incidents(
+            priorities=["1"], additional_filters={"_date_range": "1^NQstate=99^active=false"}
+        ))
+        assert not urls, f"the reset reached ServiceNow: {urls!r}"
+        assert result["error"]["code"] == "VALIDATION"
+
+    @pytest.mark.asyncio
+    async def test_date_range_refuses_an_ampersand(self):
+        """It cannot be escaped, and a raw '&' truncates the fragment silently."""
+        from Table_Tools.consolidated_tools import get_priority_incidents
+
+        urls, result = await _send(lambda: get_priority_incidents(
+            priorities=["1"], additional_filters={"_date_range": "sys_created_on>=A&B"}
+        ))
+        assert not urls
+        assert result["error"]["code"] == "VALIDATION"
+
+    @pytest.mark.asyncio
+    async def test_a_legitimate_date_range_still_carries_its_own_caret(self):
+        """The guard must not be so broad it refuses the real thing.
+
+        `build_date_filter(start, end)` joins two conditions with '^'. Refusing '^'
+        in a fragment — the obvious over-correction — would break every dated query.
+        """
+        from Table_Tools.consolidated_tools import get_priority_incidents
+
+        urls, _ = await _send(lambda: get_priority_incidents(
+            priorities=["1"], start_date="2026-01-01", end_date="2026-01-31"
+        ))
+        assert urls, "the legitimate date range was refused"
+        conditions = servicenow_conditions(urls[0])
+        assert "sys_created_on>=2026-01-01 00:00:00" in conditions
+        assert "sys_created_on<=2026-01-31 23:59:59" in conditions
+
+    @pytest.mark.parametrize("payload", [
+        "caller_id!=x^NQstate=99^active=false",
+        "caller_id!=x&y",
+    ], ids=["new_query_reset", "ampersand"])
+    @pytest.mark.asyncio
+    async def test_complete_caller_exclusion_is_guarded(self, payload):
+        from Table_Tools.generic_tool_wrappers import filter_records
+
+        urls, result = await _send(lambda: filter_records(
+            "incident", {"_complete_caller_exclusion": payload}
+        ))
+        assert not urls, f"an unguarded fragment reached ServiceNow: {urls!r}"
+        assert result["error"]["code"] == "VALIDATION"
+
+    @pytest.mark.asyncio
+    async def test_a_legitimate_caller_exclusion_still_works(self):
+        from Table_Tools.generic_tool_wrappers import filter_records
+
+        urls, _ = await _send(lambda: filter_records(
+            "incident", {"_complete_caller_exclusion": "caller_id!=a^caller_id!=b"}
+        ))
+        assert urls, "the legitimate exclusion list was refused"
+        conditions = servicenow_conditions(urls[0])
+        assert "caller_id!=a" in conditions and "caller_id!=b" in conditions
+
+    def test_complete_query_is_guarded_when_the_flag_enables_it(self):
+        """Gated off by default, so the guard behind the gate needs its own test."""
+        from unittest.mock import patch as _patch
+
+        from Table_Tools.generic_table_tools import _build_query_condition
+
+        with _patch("Table_Tools.generic_table_tools.ENABLE_COMPLETE_QUERY", True):
+            with pytest.raises(QueryValueError):
+                _build_query_condition("_complete_query", "priority=1^NQstate=99")
+            with pytest.raises(QueryValueError):
+                _build_query_condition("_complete_query", "priority=1&state=2")
+
+
+class TestFieldNamesAreCallerSuppliedToo:
+    """A filters dict's KEYS come from the caller and nothing validated them.
+
+    `{"x^NQstate=99": "1"}` built `x^NQstate=99=1` — the same unscoped-table-read
+    injection the value guard refuses, arriving through the key instead. Found while
+    auditing the two fragment holes: the guards all read `value` and none read
+    `field`.
+    """
+
+    @pytest.mark.parametrize("field", [
+        "x^NQstate=99",
+        "a&b",
+        "a^b",
+        "a=b",
+        "a b",
+        "",
+        "1field",
+    ])
+    @pytest.mark.asyncio
+    async def test_a_field_name_carrying_query_syntax_is_refused(self, field):
+        from Table_Tools.generic_tool_wrappers import filter_records
+
+        urls, result = await _send(lambda: filter_records("incident", {field: "1"}))
+        assert not urls, f"field name {field!r} reached ServiceNow: {urls!r}"
+        assert result["error"]["code"] == "VALIDATION"
+
+    @pytest.mark.parametrize("field", [
+        "priority",
+        "assigned_to",
+        "task.priority",
+        "sys_created_on",
+        "assigned_to_gte",
+    ])
+    @pytest.mark.asyncio
+    async def test_ordinary_and_dot_walked_field_names_are_accepted(self, field):
+        """Dot-walking is how `task_sla` is queried at all — it must survive."""
+        from Table_Tools.generic_tool_wrappers import filter_records
+
+        urls, result = await _send(lambda: filter_records("incident", {field: "1"}))
+        assert urls, f"field name {field!r} was refused: {result!r}"
+
+    @pytest.mark.asyncio
+    async def test_additional_filters_validates_its_keys_too(self):
+        """The second assembly path has to repeat the check, not inherit it."""
+        from Table_Tools.generic_table_tools import get_records_by_priority
+
+        urls, result = await _send(lambda: get_records_by_priority(
+            "incident", ["1"], additional_filters={"x^NQstate=99": "1"}
+        ))
+        assert not urls
+        assert result["error"]["code"] == "VALIDATION"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_query_value_encoding.py
+++ b/tests/test_query_value_encoding.py
@@ -830,6 +830,142 @@ class TestPreBuiltFragmentChannels:
                 _build_query_condition("_complete_query", "priority=1&state=2")
 
 
+class TestStructuralPastesRefuseAnAmpersand:
+    """The last `&` hole: structural handlers paste a caller fragment verbatim.
+
+    A structural handler cannot escape its value — the value IS the query fragment,
+    operators included — so `&` has to be refused there, exactly as it is for the
+    three underscore fragment keys. Four such pastes: the bare-OR repair, a complete
+    `^OR` filter, the `BETWEEN` early return, and `_parse_caller_exclusions`'
+    already-`caller_id!=` passthrough.
+
+    Found in the second review. It was invisible from `filter_records`, which routes
+    through `query_table_with_filters` and so gets an `_encode_query_string` pass
+    that escapes the `&` before the URL is built. `query_table_with_generic_filters`
+    had no such pass, so the raw `&` met `ensure_query_encoded`'s first-`&` split:
+
+        {"priority": "1^ORpriority=2&x"}
+          -> ServiceNow got  priority=1^ORpriority=2   plus a stray `x` parameter
+
+    Reachable from registered tools #7 and #8 (`similar_knowledge_for_text`,
+    `get_knowledge_by_category`), whose `category`/`kb_base` land in exactly that
+    path. Both assembly paths now also encode before interpolating, so a future
+    structural paste that forgets truncates nothing — but the refusal is the fix,
+    because turning a `&` inside caller-built *structure* into a literal is a guess.
+    """
+
+    STRUCTURAL_WITH_AMPERSAND = [
+        ("bare_or_repair", {"priority": "1^ORpriority=2&x"}),
+        ("complete_sn_filter", {"_f": "priority=1^ORpriority=2&x"}),
+        ("between_early_return", {"sys_created_on": "BETWEENa&b@c"}),
+        ("caller_id_passthrough", {"exclude_caller": "caller_id!=a&b"}),
+    ]
+
+    @pytest.mark.parametrize(
+        "filters", [f for _, f in STRUCTURAL_WITH_AMPERSAND],
+        ids=[name for name, _ in STRUCTURAL_WITH_AMPERSAND],
+    )
+    @pytest.mark.asyncio
+    async def test_a_structural_paste_refuses_an_ampersand(self, filters):
+        from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+        urls, result = await _send(lambda: query_table_with_generic_filters("incident", filters))
+        assert not urls, f"a truncated query reached ServiceNow: {urls!r}"
+        assert result["error"]["code"] == "VALIDATION"
+
+    @pytest.mark.asyncio
+    async def test_the_registered_kb_tool_refuses_it_too(self):
+        """The reachable surface, not just the internal function."""
+        from Table_Tools.consolidated_tools import get_knowledge_by_category
+
+        urls, result = await _send(
+            lambda: get_knowledge_by_category("1^ORkb_category=2&evil")
+        )
+        assert not urls
+        assert result["error"]["code"] == "VALIDATION"
+
+    @pytest.mark.parametrize("filters, expected", [
+        ({"priority": "1^ORpriority=2"}, "priority=1^ORpriority=2"),
+        ({"_f": "priority=1^ORpriority=2"}, "priority=1^ORpriority=2"),
+        ({"exclude_caller": "caller_id!=abc"}, "caller_id!=abc"),
+        (
+            {"sys_created_on": "BETWEENjavascript:gs.beginningOfWeek()@javascript:gs.endOfWeek()"},
+            "BETWEENjavascript:gs.beginningOfWeek()@javascript:gs.endOfWeek()",
+        ),
+    ], ids=["bare_or", "complete_filter", "caller_list", "between_javascript"])
+    @pytest.mark.asyncio
+    async def test_legitimate_structural_values_are_untouched(self, filters, expected):
+        """The guard refuses `&` only. Everything these fragments are made of stays."""
+        from Table_Tools.generic_table_tools import query_table_with_generic_filters
+
+        urls, _ = await _send(lambda: query_table_with_generic_filters("incident", filters))
+        assert urls, "a legitimate structural fragment was refused"
+        assert_no_smuggled_parameter(urls[0])
+        conditions = servicenow_conditions(urls[0])
+        for condition in expected.split("^"):
+            assert condition in conditions, (conditions, expected)
+
+    @pytest.mark.asyncio
+    async def test_an_ampersand_in_an_ordinary_value_still_works(self):
+        """The non-regression that matters: a real KB category contains '&'.
+
+        "Payroll & Benefits" is a terminal value, so it is escaped, not refused —
+        refusing it would make the guard worse than the bug.
+        """
+        from Table_Tools.consolidated_tools import get_knowledge_by_category
+
+        urls, _ = await _send(lambda: get_knowledge_by_category("Payroll & Benefits"))
+        assert urls, "an ordinary category containing '&' was refused"
+        assert_no_smuggled_parameter(urls[0])
+        assert servicenow_value_after(urls[0], "kb_category=") == "Payroll & Benefits"
+
+
+@pytest.mark.parametrize("filters", [
+    {"priority": "1"},
+    {"short_description": "LIKESales & Marketing"},
+    {"assigned_to": "Deal 20%2C off"},
+    {"priority": "1^ORpriority=2"},
+], ids=["plain", "ampersand", "percent_escape", "structural_or"])
+@pytest.mark.asyncio
+async def test_all_three_assembly_paths_build_the_same_query(filters):
+    """The same filters must produce the same query however they are assembled.
+
+    Three paths reach ServiceNow — `query_table_with_filters`,
+    `query_table_with_generic_filters` and `get_records_by_priority` — and only the
+    first encoded its assembled query before interpolating it into the URL. That
+    asymmetry is what hid the structural `&` truncation: every test that went through
+    `filter_records` got the encode pass and passed, while the other two paths
+    silently lost the tail of the query.
+
+    Asserting they agree pins the reason the other two now encode as well. Mutation
+    testing shows removing either encode breaks nothing else today, so this is what
+    holds them in place — not a claim that they are load-bearing on their own.
+    """
+    from Table_Tools.generic_table_tools import (
+        get_records_by_priority,
+        query_table_with_filters,
+        query_table_with_generic_filters,
+    )
+    from filter import TableFilterParams
+
+    fields = ["number"]
+    typed_urls, _ = await _send(lambda: query_table_with_filters(
+        "incident", TableFilterParams(filters=filters, fields=fields)
+    ))
+    generic_urls, _ = await _send(lambda: query_table_with_generic_filters("incident", filters))
+    priority_urls, _ = await _send(lambda: get_records_by_priority(
+        "incident", ["1"], additional_filters={"assigned_to": "x"}
+    ))
+
+    assert typed_urls and generic_urls and priority_urls
+    assert servicenow_params(typed_urls[0])["sysparm_query"] == \
+        servicenow_params(generic_urls[0])["sysparm_query"]
+    # The priority path takes its filters differently, so agreement is asserted on
+    # the property that matters rather than on the whole string.
+    for url in (typed_urls[0], generic_urls[0], priority_urls[0]):
+        assert_no_smuggled_parameter(url)
+
+
 class TestFieldNamesAreCallerSuppliedToo:
     """A filters dict's KEYS come from the caller and nothing validated them.
 

--- a/tests/test_typed_read_kb_article_tools.py
+++ b/tests/test_typed_read_kb_article_tools.py
@@ -27,6 +27,7 @@ import asyncio
 
 import pytest
 from unittest.mock import AsyncMock, patch
+from urllib.parse import unquote
 
 from constants import (
     ERROR_KB_ARTICLE_NOT_FOUND_OP,
@@ -173,9 +174,11 @@ class TestDuplicateCheckOutcomes:
     async def test_unsafe_character_is_inconclusive_before_any_request(self):
         """A '^' in the title splits the encoded query, silently widening it.
 
-        Percent-encoding at the call site does not help: ensure_query_encoded
-        unquotes before re-quoting and keeps '^' in its safe-set, so the operator
-        survives either way. The check therefore refuses to answer.
+        Encoding does not help, at any layer: ServiceNow's condition parser splits
+        the DECODED value, so a correctly transmitted '^' still separates two
+        conditions. Unrepresentable rather than mis-transported, which is why this
+        one refusal outlived the v4.4.1 encoder fix. Proven in
+        tests/test_query_value_encoding.py::test_a_caret_would_have_produced_two_conditions.
         """
         with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
             with pytest.raises(KbDuplicateCheckInconclusive) as excinfo:
@@ -184,51 +187,58 @@ class TestDuplicateCheckOutcomes:
         assert "widen" in str(excinfo.value)
 
     @pytest.mark.asyncio
-    async def test_ampersand_is_also_inconclusive(self):
-        with pytest.raises(KbDuplicateCheckInconclusive):
-            await _check_kb_duplicates("Sales & Marketing", "KB0001234")
+    async def test_ampersand_no_longer_blocks_a_publish(self):
+        """v4.4.1: '&' was a transport defect, not an unrepresentable value.
 
-    @pytest.mark.parametrize("title, becomes", [
-        ("Deal 20%2C off", "Deal 20, off"),
-        ("Reset %41dmin password", "Reset Admin password"),
-        ("Up 20%DB backups", None),  # invalid byte -> U+FFFD
+        The encoder unquoted before re-quoting, so the escaping applied at the
+        call site was undone and the raw '&' escaped `sysparm_query=` into a
+        sibling URL parameter — truncating the condition. Escapes survive now, so
+        an extremely ordinary KB title is checked properly instead of being refused.
+        """
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            request.return_value = {"result": []}
+            assert await _check_kb_duplicates("Sales & Marketing", "KB0001234") == []
+        url = request.call_args[0][0]
+        assert "short_descriptionLIKESales%20%26%20Marketing" in url
+
+    @pytest.mark.parametrize("title", [
+        "Deal 20%2C off",
+        "Reset %41dmin password",
+        "Up 20%DB backups",
     ])
     @pytest.mark.asyncio
-    async def test_percent_escape_in_the_title_is_inconclusive(self, title, becomes):
-        """The quiet one: ensure_query_encoded unquotes, so '%XY' is decoded.
+    async def test_a_percent_escape_in_the_title_is_now_carried_literally(self, title):
+        """The quiet one, fixed: '%XY' used to be decoded on its way out.
 
-        ServiceNow would be searched for a different string than the title, and
-        `unquote` never raises, so nothing announces it. That silently returned
-        `[]` and published the article.
+        v4.4.0 searched ServiceNow for "Deal 20, off" when asked for
+        "Deal 20%2C off", and `unquote` never raises so nothing announced it. The
+        title's '%' is escaped to '%25' at the producer now, and the transport
+        preserves escapes instead of decoding them, so the search runs against the
+        title as written. The dedup answer is trustworthy, so the publish proceeds.
         """
-        if becomes is not None:
-            from urllib.parse import unquote
-            assert unquote(title) == becomes, "premise of the test"
         with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
-            with pytest.raises(KbDuplicateCheckInconclusive) as excinfo:
-                await _check_kb_duplicates(title, "KB0001234")
-        request.assert_not_called()
-        assert "percent-escape" in str(excinfo.value)
+            request.return_value = {"result": []}
+            assert await _check_kb_duplicates(title, "KB0001234") == []
+        url = request.call_args[0][0]
+        assert "%25" in url, "the literal '%' was not escaped"
+        assert unquote(url.split("short_descriptionLIKE")[1].split("&")[0]) == title
 
     @pytest.mark.asyncio
     async def test_a_bare_percent_is_not_refused(self):
-        """No false positives: a '%' not followed by hex digits survives intact.
-
-        Blacklisting '%' outright would refuse an ordinary title, which is why the
-        check is a round trip on the value rather than a character list.
-        """
+        """No false positives: an ordinary "50% off" title is checked, not refused."""
         with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
             request.return_value = {"result": []}
             assert await _check_kb_duplicates("Cut costs by 50% off", "KB0001234") == []
         request.assert_called_once()
 
-    @pytest.mark.parametrize("char", list("=<>():@!"))
+    @pytest.mark.parametrize("char", list("=<>():@!&%"))
     @pytest.mark.asyncio
     async def test_the_rest_of_the_operator_safe_set_is_not_refused(self, char):
-        """Only ^ and & break structure; the others survive the round trip.
+        """Only ^ is unrepresentable; everything else survives the round trip.
 
         Pinned so a future widening of KB_QUERY_UNSAFE_CHARS has to be deliberate
-        rather than a precaution that quietly blocks publishes.
+        rather than a precaution that quietly blocks publishes. '&' and '%' joined
+        this list in v4.4.1 when the transport stopped undoing their escaping.
         """
         with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
             request.return_value = {"result": []}


### PR DESCRIPTION
Closes the one correctness defect 4.4.0 shipped under a "Known limitation" heading.

## The defect

A `&`, or a literal `%XY`, inside an encoded-query **value** produced a query that
differed from the one requested — always a broader one. Measured end to end
(2026-08-05):

| value | what ServiceNow received | |
|---|---|---|
| `A&B` | two URL parameters, condition truncated at the `&` | BROKEN |
| `Deal 20%2C off` | searched for `Deal 20, off` | BROKEN, silent |
| `Cost^Center` | two conditions | unrepresentable |

Same family as the silently-dropped-filter class 4.4.0 was about: the server
answered a question nobody asked and presented the rows as matches.

## Why it is one commit

The transport was silently normalising every producer's query, so it could not stop
doing that until every producer escaped its own values — and no producer could
usefully escape while the transport undid it. Half a flip yields either
double-encoded values or raw structural characters.

| half | rule |
|---|---|
| producer — `filter/value_encoding.encode_query_value` | `safe='=<>():@!'`, **refuses `^`** |
| transport — `http_layer/url_builder` | `safe='=<>^():@!'` — **`&` removed** |

The invariant tying them: the value safe-set is the transport's **minus `^`**, so
`unquote`-then-`quote` in the transport can never resurrect a structural character
from producer output. `test_the_two_safe_sets_differ_only_by_the_caret` pins it.

`^` is refused rather than escaped because ServiceNow's parser splits on the
*decoded* value — no encoding carries it. `^OR` in a filter value is unchanged: still
read as caller-supplied structure, which is what an LLM writing
`{"priority": "1^ORpriority=2"}` means.

## What the plan got wrong, and how

**Nine seams, not four.** The three the plan's list missed included the *exact-match
default* — the handler most callers reach — plus both priority builders. A mutation
removing the escaping from the default handler **passed the entire suite** before the
seam coverage was widened. A source scan
(`test_every_terminal_condition_handler_escapes_its_value`) now fails by name if a new
terminal handler forgets.

**The first design was more complex than the evidence justified.** The encoder was
originally rewritten to preserve existing `%XY` escapes instead of decoding them. A
mutation restoring the plain `unquote` passed every test, so the regex-and-loop version
was buying nothing: `quote(unquote(x))` and escape-preservation differ only on escapes
of safe-set characters, and ServiceNow parses those identically. Reverted to the
one-line version; the load-bearing change is dropping `&` from the safe-set.

## Review focus

- `http_layer/url_builder.py` — the safe-set change is the whole transport fix.
- The STRUCTURAL/TERMINAL split in `generic_table_tools._CONDITION_HANDLERS`. A
  structural handler that starts escaping would destroy the operators its value is made
  of; a terminal one that stops escaping reopens the defect.
- `_handle_bare_or_value_condition` is deliberately structural and deliberately does not
  refuse `^OR`. Is that the right call?
- KB: `KB_QUERY_UNSAFE_CHARS` narrowed `("^", "&")` → `("^",)` and the percent
  round-trip check deleted. This **loosens a fail-closed publish guard** — worth
  checking that `^` alone is sufficient.
- Please hunt for tests that would still pass if the fix were reverted.

## Verification

- **1090 passed, 5 skipped** (was 949 + 5). Coverage 90.92% total; both new modules
  100% line and branch.
- **15 mutations** run against the fix; every one caught by a **named behavioural**
  test, not only by the source scan. Two initially survived and are recorded above.
- Assertions go through `tests/sn_query_probe.py`, which replays ServiceNow's two
  decoding steps in order (servlet percent-decode, then split on `^`). Asserting on the
  encoded URL string is how you write a test that passes while the query is still wrong.
- Text-search immunity was incidental — `extract_keywords` tokenizes on
  `\b[a-zA-Z]{4,}\b` — and is now pinned, including the record-number branch.

## Not in this PR

`graphify-out/` is not refreshed: 49k lines of generated diff alongside a correctness
fix makes the review impossible. It follows separately, per the release-branch-only
policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
