### PR TITLE
feat(v5.0)!: §3.1 response contract across the tool surface (Tier 3.1-rest)

### DIFF
--- a/Table_Tools/consolidated_tools.py
+++ b/Table_Tools/consolidated_tools.py
@@ -16,6 +16,7 @@ from .generic_table_tools import (
     TableFilterParams
 )
 from .read_helpers import carry_partial, carry_partial_after_filter, is_read_failure
+from .response import error_response, list_response
 from .date_utils import (
     validate_date_format,
     build_date_filter,
@@ -45,7 +46,7 @@ def _validate_date_param(date_string: Optional[str], param_name: str) -> Optiona
     is_valid, error = validate_date_format(date_string)
     if not is_valid:
         logger.error("Invalid %s format: %s - %s", param_name, date_string, error)
-        return {"error": f"Invalid {param_name}: {error}"}
+        return error_response("VALIDATION", f"Invalid {param_name}: {error}")
     return None
 
 
@@ -88,9 +89,12 @@ def _build_metadata(
     record_count = len(records)
     date_range = {"start": start_date, "end": end_date} if start_date or end_date else None
 
-    return {
-        "result": records,
-        "metadata": {
+    # List-contract shape (result + returned_count + truncated); the descriptive
+    # block stays under `metadata` (nested, not a top-level message dialect).
+    return list_response(
+        records,
+        truncated=bool(result.get("truncated", False)),
+        metadata={
             "count": record_count,
             "priorities_queried": priorities,
             "date_range": date_range,
@@ -98,9 +102,9 @@ def _build_metadata(
             "query_timestamp": query_timestamp,
             "message": _build_priority_result_message(
                 record_count, priorities, start_date, end_date
-            )
-        }
-    }
+            ),
+        },
+    )
 
 
 async def get_priority_incidents(
@@ -329,18 +333,13 @@ async def get_kb_articles_by_state(
     # "No matching KB articles." from pages that never arrived would be the same
     # confident-wrong answer this tier removes, so that case reports the failure.
     if not deduped:
-        return carry_partial_after_filter({
-            "result": [],
-            "message": "No matching KB articles.",
-            "returned_count": 0,
-            "truncated": raw.get("truncated", False),
-        }, raw)
+        return carry_partial_after_filter(
+            list_response([], truncated=bool(raw.get("truncated", False))), raw
+        )
 
-    return carry_partial({
-        "result": deduped,
-        "returned_count": len(deduped),
-        "truncated": raw.get("truncated", False),
-    }, raw)
+    return carry_partial(
+        list_response(deduped, truncated=bool(raw.get("truncated", False))), raw
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -11,11 +11,8 @@ import re
 from constants import (
     ESSENTIAL_FIELDS,
     DETAIL_FIELDS,
-    NO_RECORDS_FOUND,
     RECORD_NOT_FOUND,
-    NO_SIMILAR_RECORDS_FOUND,
     CONNECTION_ERROR,
-    NO_DESCRIPTION_FOUND,
     REQUEST_FAILED_ERROR,
     NO_FIELD_CONFIG_ERROR,
     NO_VALID_PRIORITIES_ERROR,
@@ -30,6 +27,7 @@ from constants import (
     TABLE_CONFIGS
 )
 from .read_helpers import carry_partial_after_filter, is_read_failure
+from .response import error_response, list_response, record_response
 from filter import (
     QueryValueError,
     TableFilterParams,
@@ -169,7 +167,7 @@ async def query_table_by_text(
     fields = DETAIL_FIELDS[table_name] if detailed else ESSENTIAL_FIELDS[table_name]
     keywords = extract_keywords(input_text)
     if not keywords:
-        return {"result": [], "message": NO_RECORDS_FOUND}
+        return list_response([])
 
     # OR-group the keyword conditions so one request matches any keyword.
     try:
@@ -183,23 +181,17 @@ async def query_table_by_text(
     try:
         all_results = await _make_paginated_request(base_url, max_results=50)
     except PartialPageReadError as partial:
-        return _partial_envelope(_text_search_envelope(partial.rows, input_text), partial)
+        return _partial_envelope(_text_search_envelope(partial.rows), partial)
     except ServiceNowRequestError as error:
         return error.to_error_dict()
 
-    return _text_search_envelope(all_results, input_text)
+    return _text_search_envelope(all_results)
 
 
-def _text_search_envelope(rows: List[Dict[str, Any]], input_text: str) -> dict[str, Any]:
-    """Response shape for a text search. No rows is not-found, never a failure."""
-    if not rows:
-        return {"result": [], "message": NO_RECORDS_FOUND}
-    result_count = len(rows)
-    limit_note = " (limited to 50)" if result_count == 50 else ""
-    return {
-        "result": rows,
-        "message": f"Found {result_count} records matching '{input_text}'{limit_note}",
-    }
+def _text_search_envelope(rows: List[Dict[str, Any]]) -> dict[str, Any]:
+    """List-contract response for a text search. No rows is success (empty list),
+    never a failure. Text searches cap at 50 rows, so `truncated` fires at 50."""
+    return list_response(rows, truncated=len(rows) >= 50)
 
 
 async def get_record_description(table_name: str, record_number: str) -> dict[str, Any]:
@@ -220,9 +212,14 @@ async def get_record_description(table_name: str, record_number: str) -> dict[st
     return _record_envelope(data)
 
 async def get_record_details(table_name: str, record_number: str) -> dict[str, Any]:
-    """Generic function to get detailed information for any record."""
+    """Get one record's DETAIL_FIELDS, in the single-record contract shape.
+
+    Returns `{"record": {...}}` on a hit and `{"record": None}` on a miss
+    (§3.1) — never a 1-row `result` list, which is the arity ambiguity the
+    contract removes. An unqueryable record number is a miss, not a failure.
+    """
     if not _is_safe_record_number(record_number):
-        return {"result": [], "message": RECORD_NOT_FOUND}
+        return record_response(None)
     fields = DETAIL_FIELDS.get(table_name, ["number", "short_description"])
     # See `get_record_description`: guarded against `^` upstream, escaped for `%`.
     query = f"number={encode_query_value(record_number)}"
@@ -231,7 +228,8 @@ async def get_record_details(table_name: str, record_number: str) -> dict[str, A
         data = await make_nws_request(url)
     except ServiceNowRequestError as error:
         return error.to_error_dict()
-    return _record_envelope(data)
+    rows = data.get("result") if data else None
+    return record_response(rows[0] if rows else None)
 
 
 def _record_envelope(data: Optional[dict[str, Any]]) -> dict[str, Any]:
@@ -266,13 +264,7 @@ def _exclude_original_record(similar_data: dict[str, Any], record_number: str) -
     if not rows:
         return similar_data  # nothing to filter — pass the inner response through
     filtered_results = [record for record in rows if record.get('number') != record_number]
-    if filtered_results:
-        response = {
-            "result": filtered_results,
-            "message": f"Found {len(filtered_results)} similar records (excluding original record)",
-        }
-    else:
-        response = {"result": [], "message": NO_SIMILAR_RECORDS_FOUND}
+    response = list_response(filtered_results, truncated=bool(similar_data.get("truncated")))
     return carry_partial_after_filter(response, similar_data)
 
 
@@ -290,7 +282,9 @@ async def find_similar_records(table_name: str, record_number: str) -> dict[str,
 
         desc_text = _first_short_description(desc_data)
         if not desc_text:
-            return {"result": [], "message": NO_DESCRIPTION_FOUND}
+            # No seed description → nothing to match on. Empty is success (§3.1),
+            # not an error.
+            return list_response([])
 
         similar_data = await query_table_by_text(table_name, desc_text)
         if is_read_failure(similar_data):
@@ -302,7 +296,7 @@ async def find_similar_records(table_name: str, record_number: str) -> dict[str,
         # rather than letting CONNECTION_ERROR become a fourth error dialect.
         return error.to_error_dict()
     except Exception:
-        return {"result": [], "message": CONNECTION_ERROR}
+        return error_response("INTERNAL", CONNECTION_ERROR)
 
 # TableFilterParams moved to filter/models.py in v4.0 Sprint 1.
 # Re-exported above via `from filter import ...` so existing imports of
@@ -1010,21 +1004,10 @@ async def query_table_with_filters(table_name: str, params: TableFilterParams) -
             "Result validation warnings",
         )
 
-        response = {
-            "result": all_results,
-            "returned_count": returned_count,
-            "truncated": truncated,
-            "max_results": max_results,
-        }
+        response = list_response(all_results, truncated=truncated, max_results=max_results)
         return _partial_envelope(response, partial_read) if partial_read else response
 
-    empty_response = {
-        "result": [],
-        "message": NO_RECORDS_FOUND,
-        "returned_count": 0,
-        "truncated": False,
-        "max_results": max_results,
-    }
+    empty_response = list_response([], truncated=False, max_results=max_results)
     # Surface validation suggestions (e.g. reference-field dot-walk hint) on an
     # empty result so the caller can tell a genuine no-match from a silent
     # query-syntax mistake. Warnings here previously only went to stderr.
@@ -1081,15 +1064,8 @@ def _build_additional_filters(additional_filters: Optional[Dict[str, str]]) -> L
 
 
 def _format_priority_results(all_results: list, max_results: int) -> Dict[str, Any]:
-    """Format paginated results into a standard response dict."""
-    if not all_results:
-        return {"result": [], "message": NO_RECORDS_FOUND}
-    result_count = len(all_results)
-    limit_note = f" (limited to {max_results})" if result_count == max_results else ""
-    return {
-        "result": all_results,
-        "message": f"Found {result_count} records{limit_note}"
-    }
+    """Format paginated results into the list-contract shape. Empty is success."""
+    return list_response(all_results, truncated=len(all_results) >= max_results)
 
 
 async def get_records_by_priority(
@@ -1104,18 +1080,18 @@ async def get_records_by_priority(
     # Validate table supports priority
     table_config = TABLE_CONFIGS.get(table_name)
     if not table_config or not table_config.get("priority_field"):
-        return {"error": TABLE_NO_PRIORITY_SUPPORT_ERROR.format(table_name=table_name)}
+        return error_response("VALIDATION", TABLE_NO_PRIORITY_SUPPORT_ERROR.format(table_name=table_name))
 
     fields = DETAIL_FIELDS.get(table_name, []) if detailed else ESSENTIAL_FIELDS.get(table_name, [])
     if not fields:
-        return {"error": NO_FIELD_CONFIG_ERROR.format(table_name=table_name)}
+        return error_response("INTERNAL", NO_FIELD_CONFIG_ERROR.format(table_name=table_name))
 
     # Build priority filter + the additional-filter list. Both escape their
     # values, so both can refuse one.
     try:
         priority_filter = _build_priority_filter(priorities)
         if not priority_filter:
-            return {"error": NO_VALID_PRIORITIES_ERROR}
+            return error_response("VALIDATION", NO_VALID_PRIORITIES_ERROR)
         filters = [priority_filter] + _build_additional_filters(additional_filters)
     except QueryValueError as refusal:
         return refusal.to_error_dict()
@@ -1142,5 +1118,5 @@ async def get_records_by_priority(
         # is flattened into the REQUEST_FAILED_ERROR string and the code is lost.
         return error.to_error_dict()
     except Exception as e:
-        return {"error": REQUEST_FAILED_ERROR.format(error=str(e))}
+        return error_response("INTERNAL", REQUEST_FAILED_ERROR.format(error=str(e)))
 

--- a/Table_Tools/generic_table_tools.py
+++ b/Table_Tools/generic_table_tools.py
@@ -11,7 +11,6 @@ import re
 from constants import (
     ESSENTIAL_FIELDS,
     DETAIL_FIELDS,
-    RECORD_NOT_FOUND,
     CONNECTION_ERROR,
     REQUEST_FAILED_ERROR,
     NO_FIELD_CONFIG_ERROR,
@@ -195,9 +194,13 @@ def _text_search_envelope(rows: List[Dict[str, Any]]) -> dict[str, Any]:
 
 
 async def get_record_description(table_name: str, record_number: str) -> dict[str, Any]:
-    """Generic function to get short_description for any record."""
+    """Internal: fetch a record's short_description, in the §3.1 single-record shape.
+
+    Not a registered tool — the seed lookup behind find_similar. Returns
+    `{"record": row|None}`; a failed read maps to the error contract.
+    """
     if not _is_safe_record_number(record_number):
-        return {"result": [], "message": RECORD_NOT_FOUND}
+        return record_response(None)
     # `encode_query_value` cannot refuse here: `_is_safe_record_number` already
     # rejected `^`. It is applied for the `%` case — an unescaped "INC%41" used to
     # be decoded by the transport into "INCA", a lookup for a different record.
@@ -233,23 +236,27 @@ async def get_record_details(table_name: str, record_number: str) -> dict[str, A
 
 
 def _record_envelope(data: Optional[dict[str, Any]]) -> dict[str, Any]:
-    """Single-record read shape. A successful read with no rows is not-found.
+    """Single-record read shape (§3.1): {"record": row|None}.
 
-    Before v4.4 this label was also produced when the request itself failed
-    (the read path returned `None` for both). Failures are mapped by the caller
-    now, so RECORD_NOT_FOUND means only what it says.
+    A successful read with no rows is a miss (record None), never a failure —
+    failures are mapped by the caller. Tier 3.1-rest folded this onto
+    record_response so the module no longer carries the old
+    {"result": [], "message": RECORD_NOT_FOUND} dialect alongside the contract.
     """
-    if not data or not data.get("result"):
-        return {"result": [], "message": RECORD_NOT_FOUND}
-    return data
+    rows = data.get("result") if data else None
+    return record_response(rows[0] if rows else None)
 
 
 def _first_short_description(desc_data: dict[str, Any]) -> str:
-    """Pull the first row's short_description out of a description response."""
-    rows = desc_data.get('result') or []
-    if not rows:
-        return ""
-    return (rows[0].get('short_description') or "").strip()
+    """Pull the seed record's short_description out of a description response.
+
+    Reads the §3.1 `record` shape; still tolerates a legacy `result` list so a
+    caller passing either shape keeps working.
+    """
+    record = desc_data.get("record")
+    if record is None and desc_data.get("result"):
+        record = desc_data["result"][0]
+    return ((record or {}).get("short_description") or "").strip()
 
 
 def _exclude_original_record(similar_data: dict[str, Any], record_number: str) -> dict[str, Any]:

--- a/Table_Tools/generic_tool_wrappers.py
+++ b/Table_Tools/generic_tool_wrappers.py
@@ -14,6 +14,7 @@ from constants import (
     TABLE_LACKS_RECORD_IDENTITY,
 )
 from param_coercion import OptJsonList
+from .response import error_response
 from .generic_table_tools import (
     query_table_by_text,
     get_record_details,
@@ -27,9 +28,12 @@ INVALID_TABLE_ERROR = "Invalid table '{table}'. Supported tables: {tables}"
 
 
 def _validate_table(table: str) -> Optional[Dict[str, Any]]:
-    """Return an error dict if *table* is not in TABLE_CONFIGS, else None."""
+    """Return a VALIDATION error dict if *table* is not in TABLE_CONFIGS, else None."""
     if table not in TABLE_CONFIGS:
-        return {"error": INVALID_TABLE_ERROR.format(table=table, tables=", ".join(SUPPORTED_TABLES))}
+        return error_response(
+            "VALIDATION",
+            INVALID_TABLE_ERROR.format(table=table, tables=", ".join(SUPPORTED_TABLES)),
+        )
     return None
 
 
@@ -49,7 +53,7 @@ def _validate_identity_table(table: str) -> Optional[Dict[str, Any]]:
     if error:
         return error
     if table in TABLES_WITHOUT_RECORD_IDENTITY:
-        return {"error": TABLE_LACKS_RECORD_IDENTITY.format(table=table)}
+        return error_response("VALIDATION", TABLE_LACKS_RECORD_IDENTITY.format(table=table))
     return None
 
 
@@ -80,7 +84,7 @@ async def search_records(table: str, query: str) -> Dict[str, Any]:
         query: Free-text search string
 
     Returns:
-        {"result": [...], "message": "..."}
+        {"result": [...], "returned_count": N, "truncated": bool}
     """
     error = _validate_identity_table(table)
     if error:
@@ -108,7 +112,7 @@ async def get_record(table: str, number: str) -> Dict[str, Any]:
         number: Record number (e.g. "CHG0054321")
 
     Returns:
-        {"result": [{...all DETAIL_FIELDS...}]}
+        {"record": {...all DETAIL_FIELDS...}}  (record is None if no such record)
     """
     error = _validate_identity_table(table)
     if error:
@@ -138,7 +142,7 @@ async def find_similar(table: str, number: str) -> Dict[str, Any]:
         number: Record number to find similarities for
 
     Returns:
-        {"result": [...], "message": "..."}
+        {"result": [...], "returned_count": N, "truncated": bool}
     """
     error = _validate_identity_table(table)
     if error:
@@ -198,6 +202,8 @@ async def filter_records(
         allowed = set(DETAIL_FIELDS.get(table, []))
         bad = [f for f in fields if f not in allowed]
         if bad:
-            return {"error": f"Unsupported field(s) for {table}: {', '.join(bad)}"}
+            return error_response(
+                "VALIDATION", f"Unsupported field(s) for {table}: {', '.join(bad)}"
+            )
     params = TableFilterParams(filters=filters, fields=fields, max_results=max_results)
     return await query_table_with_filters(table, params)

--- a/Table_Tools/kb_article_tools.py
+++ b/Table_Tools/kb_article_tools.py
@@ -25,6 +25,7 @@ import anyio
 import httpx
 import structlog
 from .read_helpers import is_read_failure
+from .response import error_response, list_response, record_response
 from .write_helpers import map_http_error, unwrap_write_response
 from param_coercion import JsonList
 from constants import (
@@ -77,7 +78,7 @@ class KbDuplicateCheckInconclusive(Exception):
         self.reason = reason
 
 
-def _handle_kb_error(error: httpx.HTTPStatusError, operation: str) -> str:
+def _handle_kb_error(error: httpx.HTTPStatusError, operation: str) -> Dict[str, Any]:
     error_map = {
         401: ERROR_KB_ARTICLE_AUTH_FAILED.format(operation=operation),
         403: ERROR_KB_ARTICLE_ACCESS_DENIED.format(operation=operation),
@@ -94,11 +95,12 @@ def _handle_kb_error(error: httpx.HTTPStatusError, operation: str) -> str:
     )
 
 
-def _unwrap_kb_write_response(result: Any, operation: str) -> Dict[str, Any] | str:
+def _unwrap_kb_write_response(result: Any, operation: str) -> Dict[str, Any]:
     return unwrap_write_response(
         result,
         ERROR_KB_WRITE_UNCONFIRMED.format(operation=operation),
         fields=KB_WRITE_RESPONSE_FIELDS,
+        success_message=f"KB article {operation} succeeded.",
     )
 
 
@@ -107,7 +109,7 @@ async def _write_kb_article(
     url: str,
     payload: Dict[str, Any],
     operation: str,
-) -> Dict[str, Any] | str:
+) -> Dict[str, Any]:
     # Bound the write with an anyio cancel scope — the pooled client runs with
     # timeout=None, so without this a held/half-open connection hangs forever.
     # anyio.fail_after raises builtin TimeoutError on breach, caught below.
@@ -117,7 +119,7 @@ async def _write_kb_article(
     except httpx.HTTPStatusError as e:
         return _handle_kb_error(e, operation)
     except Exception:
-        return ERROR_KB_ARTICLE_REQUEST_FAILED.format(operation=operation)
+        return error_response("INTERNAL", ERROR_KB_ARTICLE_REQUEST_FAILED.format(operation=operation))
     return _unwrap_kb_write_response(result, operation)
 
 
@@ -238,12 +240,12 @@ async def _check_kb_duplicates(short_description: str, exclude_number: str) -> l
     return []
 
 
-async def _call_kb_workflow(sys_id: str, action: str) -> Dict[str, Any] | str:
+async def _call_kb_workflow(sys_id: str, action: str) -> Dict[str, Any]:
     # Custom Scripted REST API (qonv/publish) — invokes KnowledgeUIAction server-side.
     # Direct Table API writes to workflow_state are ignored by ServiceNow.
     url = f"{NWS_API_BASE}/api/qonv/mateco_knowledge/articles/{sys_id}/{action}"
     result = await _write_kb_article("POST", url, {}, action)
-    if isinstance(result, str):
+    if isinstance(result, dict) and result.get("error"):
         _log.error("kb_workflow_error", action=action, sys_id=sys_id, url=url, result=result)
     return result
 
@@ -280,11 +282,13 @@ async def _verify_kb_published(article_number: str) -> Dict[str, Any] | None:
     return data["result"][0]
 
 
-async def _fire_publish(sys_id: str) -> str | None:
-    """Fire the publish workflow. Returns None on success, error string on fire-time failure.
+async def _fire_publish(sys_id: str) -> Any:
+    """Fire the publish workflow. Returns None on success, or a fire-time failure.
 
     A fire-time timeout is recoverable: the publish may still commit server-side,
-    so we return a marker and let _publish_with_verify poll for the Published row.
+    so we return the "fire timeout" sentinel and let _publish_with_verify poll for
+    the Published row. An HTTPStatusError becomes a coded error_response dict
+    (`_handle_kb_error`), passed through by `_publish_failure` if retries exhaust.
     The deadline now comes from anyio.fail_after (builtin TimeoutError); the
     httpx.TimeoutException arm is kept for any transport-level timeout.
     """
@@ -297,15 +301,19 @@ async def _fire_publish(sys_id: str) -> str | None:
         return _handle_kb_error(e, "publish")
 
 
-async def _publish_with_verify(sys_id: str, article_number: str) -> Dict[str, Any] | str:
+async def _publish_with_verify(sys_id: str, article_number: str) -> Dict[str, Any]:
     """Fire the publish workflow then verify by polling for a Published row.
 
     Treats verify as the source of truth — a fire-time TimeoutException or
     HTTPStatusError is recoverable if the article ends up Published. Only
     retries when verify confirms still-draft. Caps at KB_PUBLISH_MAX_RETRIES.
+
+    Returns the §3.1 write shape: `record_response(published_row, message=...)`
+    on a confirmed publish, `error_response(...)` when it could not be confirmed,
+    or the `_publish_unconfirmed` shape when the confirming read itself failed.
     """
     current_sys_id = sys_id
-    last_fire_error: str | None = None
+    last_fire_error: Any = None
 
     for attempt in range(KB_PUBLISH_MAX_RETRIES + 1):
         last_fire_error = await _fire_publish(current_sys_id)
@@ -319,12 +327,28 @@ async def _publish_with_verify(sys_id: str, article_number: str) -> Dict[str, An
             # became two publish workflows and a second published version.
             return _publish_unconfirmed(article_number, error)
         if published:
-            return published
+            return record_response(
+                published, message=f"KB article {article_number} published."
+            )
 
         if attempt < KB_PUBLISH_MAX_RETRIES:
             current_sys_id = await _refresh_draft_sys_id(article_number, current_sys_id)
 
-    return last_fire_error or ERROR_KB_PUBLISH_NOT_CONFIRMED.format(number=article_number)
+    return _publish_failure(article_number, last_fire_error)
+
+
+def _publish_failure(article_number: str, last_fire_error: Any) -> Dict[str, Any]:
+    """Normalise the exhausted-retries outcome into a coded error_response.
+
+    `last_fire_error` is whatever the final `_fire_publish` returned: a coded
+    error_response dict (HTTPStatusError at fire time — passed through), the
+    "fire timeout" sentinel (→ TIMEOUT), or None (fired fine but no Published row
+    ever appeared → INTERNAL, i.e. the workflow never reflected the change).
+    """
+    if isinstance(last_fire_error, dict):
+        return last_fire_error
+    code = "TIMEOUT" if last_fire_error == "fire timeout" else "INTERNAL"
+    return error_response(code, ERROR_KB_PUBLISH_NOT_CONFIRMED.format(number=article_number))
 
 
 def _publish_unconfirmed(article_number: str, error: ServiceNowRequestError) -> Dict[str, Any]:
@@ -358,7 +382,7 @@ async def _refresh_draft_sys_id(article_number: str, current_sys_id: str) -> str
     return refreshed or current_sys_id
 
 
-async def update_knowledge_article(article_number: str, update_data: Dict[str, Any]) -> Dict[str, Any] | str:
+async def update_knowledge_article(article_number: str, update_data: Dict[str, Any]) -> Dict[str, Any]:
     """Update fields on a knowledge article by article number (e.g. KB0001234).
 
     WHEN TO USE: change an article's content or metadata — "update the body
@@ -376,14 +400,17 @@ async def update_knowledge_article(article_number: str, update_data: Dict[str, A
             kb_category, meta, meta_description).
 
     Returns:
-        Updated article record dict, or error string on failure.
+        {"record": {...}, "message": ...} on success, or
+        {"error": {"code", "message"}} on failure.
     """
     if not update_data:
-        return ERROR_KB_NO_UPDATE_DATA
+        return error_response("VALIDATION", ERROR_KB_NO_UPDATE_DATA)
 
     bad = [k for k in update_data if k not in KB_UPDATABLE_FIELDS]
     if bad:
-        return f"Rejected non-updatable field(s): {', '.join(bad)}"
+        return error_response(
+            "VALIDATION", f"Rejected non-updatable field(s): {', '.join(bad)}"
+        )
 
     # Per-step stderr timing — localises a stall to the sys_id GET vs the PATCH
     # when an update hangs. stdout is reserved for the MCP JSON-RPC frame stream.
@@ -399,7 +426,7 @@ async def update_knowledge_article(article_number: str, update_data: Dict[str, A
     t1 = time.monotonic()
     print(f"[kb] {article_number} sys_id GET took {t1 - t0:.1f}s", file=sys.stderr)
     if not sys_id:
-        return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
+        return error_response("NOT_FOUND", ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number))
     fields = ",".join(KB_WRITE_RESPONSE_FIELDS)
     url = f"{NWS_API_BASE}/api/now/table/kb_knowledge/{sys_id}?sysparm_fields={fields}"
     result = await _write_kb_article("PATCH", url, update_data, "update")
@@ -407,7 +434,7 @@ async def update_knowledge_article(article_number: str, update_data: Dict[str, A
     return result
 
 
-async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str:
+async def publish_knowledge_article(article_number: str) -> Dict[str, Any]:
     """Publish ONE knowledge article via the ServiceNow workflow endpoint.
 
     WHEN TO USE: publish a single article — "publish knowledge article
@@ -426,7 +453,12 @@ async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str
         article_number: The KB article number (e.g. KB0001234).
 
     Returns:
-        Updated article record dict, duplicate warning dict, or error string on failure.
+        On a confirmed publish, {"record": {...}, "message": ...}. On failure,
+        {"error": {"code", "message"}}. When a guard refuses (duplicates found or
+        the duplicate check could not answer) or the publish could not be
+        confirmed, a status dict with success=False and structured detail
+        (duplicates / duplicate_check / publish_confirmed) — an intentional
+        exception to the plain record/error shapes (see test_tool_response_contract).
 
     Fail-closed: the publish only proceeds on a duplicate check that positively
     came back clear. A check that could not run blocks the publish and writes
@@ -437,7 +469,7 @@ async def publish_knowledge_article(article_number: str) -> Dict[str, Any] | str
     except (ServiceNowRequestError, QueryValueError) as error:
         return error.to_error_dict()
     if not meta:
-        return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
+        return error_response("NOT_FOUND", ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number))
 
     try:
         duplicates = await _check_kb_duplicates(meta['short_description'], article_number)
@@ -581,9 +613,11 @@ async def check_kb_duplicates(
         does: as a reason not to publish, not as a clean result.
     """
     if not article_numbers:
-        return {"result": []}
+        return list_response([])
     if len(article_numbers) > 50:
-        return {"error": "check_kb_duplicates accepts at most 50 article numbers per call."}
+        return error_response(
+            "VALIDATION", "check_kb_duplicates accepts at most 50 article numbers per call."
+        )
 
     semaphore = asyncio.Semaphore(min(max(1, concurrency), KB_MAX_BATCH_CONCURRENCY))
 
@@ -594,7 +628,7 @@ async def check_kb_duplicates(
     outcomes = await asyncio.gather(
         *(_bounded(n) for n in article_numbers), return_exceptions=True
     )
-    return {"result": _rows_from_outcomes(article_numbers, outcomes, _duplicate_row_inconclusive)}
+    return list_response(_rows_from_outcomes(article_numbers, outcomes, _duplicate_row_inconclusive))
 
 
 def _normalize_publish_result(article_number: str, result: Dict[str, Any] | str) -> Dict[str, Any]:
@@ -639,10 +673,12 @@ def _normalize_publish_result(article_number: str, result: Dict[str, Any] | str)
         if result.get("duplicate_check"):
             row["duplicate_check"] = result["duplicate_check"]
         return row
+    # Success is the §3.1 write shape now: {"record": {...}, "message": ...}, so
+    # the published row's workflow_state lives under "record", not at top level.
     return {
         "number": article_number,
         "status": "published",
-        "workflow_state": result.get("workflow_state"),
+        "workflow_state": (result.get("record") or {}).get("workflow_state"),
     }
 
 
@@ -680,9 +716,11 @@ async def publish_knowledge_articles(
         It may have committed; do not blind-retry.
     """
     if not article_numbers:
-        return {"result": []}
+        return list_response([])
     if len(article_numbers) > 20:
-        return {"error": "publish_knowledge_articles accepts at most 20 article numbers per call."}
+        return error_response(
+            "VALIDATION", "publish_knowledge_articles accepts at most 20 article numbers per call."
+        )
 
     semaphore = asyncio.Semaphore(min(max(1, concurrency), KB_MAX_BATCH_CONCURRENCY))
 
@@ -700,10 +738,10 @@ async def publish_knowledge_articles(
     outcomes = await asyncio.gather(
         *(_bounded(n) for n in article_numbers), return_exceptions=True
     )
-    return {"result": _rows_from_outcomes(article_numbers, outcomes, _error_row)}
+    return list_response(_rows_from_outcomes(article_numbers, outcomes, _error_row))
 
 
-async def retire_knowledge_article(article_number: str) -> Dict[str, Any] | str:
+async def retire_knowledge_article(article_number: str) -> Dict[str, Any]:
     """Retire a knowledge article via the ServiceNow workflow endpoint.
 
     WHEN TO USE: take a published article out of service — "retire knowledge
@@ -719,12 +757,13 @@ async def retire_knowledge_article(article_number: str) -> Dict[str, Any] | str:
         article_number: The KB article number (e.g. KB0001234).
 
     Returns:
-        Updated article record dict, or error string on failure.
+        {"record": {...}, "message": ...} on success, or
+        {"error": {"code", "message"}} on failure.
     """
     try:
         sys_id = await _get_kb_article_sys_id(article_number, workflow_state="published")
     except (ServiceNowRequestError, QueryValueError) as error:
         return error.to_error_dict()
     if not sys_id:
-        return ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number)
+        return error_response("NOT_FOUND", ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number=article_number))
     return await _call_kb_workflow(sys_id, "retire")

--- a/Table_Tools/response.py
+++ b/Table_Tools/response.py
@@ -3,14 +3,22 @@
 The target shapes for every tool. The discriminator is the presence of `error`;
 there is no `success`/`ok` boolean and no bare-string return.
 
-**Migration status:** as of this change, only the **CMDB tools** (`cmdb_tools.py`)
-are on this contract. The rest of the surface still carries its v4 shapes and is
-migrated in later Tier 3.1 work: the generic reads still use
-`{"result": [...], "message": ...}` for single-record misses, the generic
-validation errors use `{"error": <str>}`, the write tools return bare dicts, and
-`health_check` returns a status bag that can coexist with `error`. The promised
-surface-wide test (`tests/test_tool_response_contract.py`) lands with that pass,
-enumerating any deliberate exceptions.
+**Migration status:** the WHOLE registered surface is on this contract as of the
+Tier 3.1-rest pass — generic reads (list_response / record_response), the
+validation errors (`error_response("VALIDATION", ...)`), consolidated
+priority/KB-state/SLA reads, and the write path (`write_helpers` →
+record_response / error_response, no more bare strings). `tests/
+test_tool_response_contract.py` drives every tool in `tools.tools` through the
+real dispatcher and enforces the shapes below; it derives the tool set from
+`tools.tools`, so a new tool with no case fails it by name.
+
+Deliberate exceptions, pinned by that test:
+  * `health_check` returns a diagnostic STATUS BAG — `error` may sit beside
+    `connection`/`server`/`auth`. Not a data tool.
+  * `publish_knowledge_article` fail-closed guard outcomes (duplicates found /
+    inconclusive / unconfirmed) carry `success: False` and, when the confirming
+    read fails, `error` beside status flags. The write itself may have landed.
+  * the partial-page shape carries rows AND `error` together (see below).
 
 | case                  | shape                                                        |
 |-----------------------|--------------------------------------------------------------|

--- a/Table_Tools/vtb_task_tools.py
+++ b/Table_Tools/vtb_task_tools.py
@@ -14,6 +14,7 @@ from filter import QueryValueError, encode_query_value
 from typing import Any, Dict
 import anyio
 import httpx
+from .response import error_response
 from .write_helpers import map_http_error, unwrap_write_response
 from constants import (
     ERROR_SHORT_DESC_REQUIRED,
@@ -30,8 +31,8 @@ from constants import (
     VTB_UPDATABLE_FIELDS
 )
 
-def _handle_http_error(error: httpx.HTTPStatusError, operation: str) -> str:
-    """Handle HTTP errors consistently."""
+def _handle_http_error(error: httpx.HTTPStatusError, operation: str) -> Dict[str, Any]:
+    """Map an HTTP error to the {"error": {code, message}} contract shape."""
     error_map = {
         401: ERROR_PRIVATE_TASK_AUTH_FAILED.format(operation=operation),
         403: ERROR_PRIVATE_TASK_ACCESS_DENIED.format(operation=operation),
@@ -42,10 +43,12 @@ def _handle_http_error(error: httpx.HTTPStatusError, operation: str) -> str:
         error, error_map, ERROR_PRIVATE_TASK_SERVER_ERROR.format(operation=operation)
     )
 
-def _unwrap_write_response(result: Any, operation: str) -> Dict[str, Any] | str:
-    """Extract the inner result payload from a write response."""
+def _unwrap_write_response(result: Any, operation: str) -> Dict[str, Any]:
+    """Extract the inner result payload into the §3.1 write shape."""
     return unwrap_write_response(
-        result, ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation=operation)
+        result,
+        ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation=operation),
+        success_message=f"Private task {operation} succeeded.",
     )
 
 async def _write_private_task(
@@ -53,7 +56,7 @@ async def _write_private_task(
     url: str,
     payload: Dict[str, Any],
     operation: str,
-) -> Dict[str, Any] | str:
+) -> Dict[str, Any]:
     """Send a write request through make_nws_request, mapping errors locally."""
     try:
         with anyio.fail_after(VTB_WRITE_TIMEOUT_SECONDS):
@@ -61,7 +64,7 @@ async def _write_private_task(
     except httpx.HTTPStatusError as e:
         return _handle_http_error(e, operation)
     except Exception:
-        return ERROR_PRIVATE_TASK_REQUEST_FAILED.format(operation=operation)
+        return error_response("INTERNAL", ERROR_PRIVATE_TASK_REQUEST_FAILED.format(operation=operation))
 
     return _unwrap_write_response(result, operation)
 
@@ -108,7 +111,7 @@ async def _get_task_sys_id(task_number: str) -> str | None:
 
     return sys_id_data['result'][0]['sys_id']
 
-async def create_private_task(task_data: Dict[str, Any]) -> dict[str, Any] | str:
+async def create_private_task(task_data: Dict[str, Any]) -> Dict[str, Any]:
     """Create a NEW private task (vtb_task) record.
 
     WHEN TO USE: the user wants a brand-new private task opened.
@@ -125,17 +128,18 @@ async def create_private_task(task_data: Dict[str, Any]) -> dict[str, Any] | str
                   Optional fields: description, priority, assigned_to, assignment_group, due_date, parent, etc.
 
     Returns:
-        A dictionary containing the created private task details or an error message if the request fails.
+        {"record": {...created task...}, "message": ...} on success, or
+        {"error": {"code", "message"}} on failure.
     """
     if not task_data.get('short_description'):
-        return ERROR_SHORT_DESC_REQUIRED
+        return error_response("VALIDATION", ERROR_SHORT_DESC_REQUIRED)
 
     create_data = _prepare_task_create_data(task_data)
     url = f"{NWS_API_BASE}/api/now/table/vtb_task"
 
     return await _write_private_task("POST", url, create_data, "creation")
 
-async def update_private_task(task_number: str, update_data: Dict[str, Any]) -> dict[str, Any] | str:
+async def update_private_task(task_number: str, update_data: Dict[str, Any]) -> Dict[str, Any]:
     """Update / change an EXISTING private task (vtb_task), addressed by number.
 
     WHEN TO USE: the task already exists and the user wants to set, close,
@@ -152,14 +156,17 @@ async def update_private_task(task_number: str, update_data: Dict[str, Any]) -> 
         update_data: Dictionary containing the fields to update.
 
     Returns:
-        A dictionary containing the updated private task details or an error message if the request fails.
+        {"record": {...updated task...}, "message": ...} on success, or
+        {"error": {"code", "message"}} on failure.
     """
     if not update_data:
-        return ERROR_NO_UPDATE_DATA
+        return error_response("VALIDATION", ERROR_NO_UPDATE_DATA)
 
     bad = [k for k in update_data if k not in VTB_UPDATABLE_FIELDS]
     if bad:
-        return f"Rejected non-updatable field(s): {', '.join(bad)}"
+        return error_response(
+            "VALIDATION", f"Rejected non-updatable field(s): {', '.join(bad)}"
+        )
 
     try:
         sys_id = await _get_task_sys_id(task_number)
@@ -170,7 +177,7 @@ async def update_private_task(task_number: str, update_data: Dict[str, Any]) -> 
         # and both types expose the same `to_error_dict()`.
         return error.to_error_dict()
     if not sys_id:
-        return PRIVATE_TASK_NOT_FOUND_UPDATE
+        return error_response("NOT_FOUND", PRIVATE_TASK_NOT_FOUND_UPDATE)
 
     url = f"{NWS_API_BASE}/api/now/table/vtb_task/{sys_id}"
     return await _write_private_task("PATCH", url, update_data, "update")

--- a/Table_Tools/write_helpers.py
+++ b/Table_Tools/write_helpers.py
@@ -1,10 +1,23 @@
 """Shared helpers for ServiceNow write-path responses (KB + VTB CRUD).
 
-Both write subsystems map HTTP status codes to localized error strings and
+Both write subsystems map HTTP status codes to localized error messages and
 unwrap the single-record result envelope. The mechanism is identical; only
 the message tables (and KB's response-field filter) differ, so the caller
 passes those in. Centralizing the mechanism means the detail-extraction and
 unwrap logic live in one place instead of being duplicated per subsystem.
+
+Response contract (v5.0 "Boron" Tier 3.1). Both helpers now return the §3.1
+shapes from `Table_Tools/response.py`, never a bare string:
+
+  * `map_http_error` → `error_response(code, message)`. The status→code map
+    (401→AUTH, 403→FORBIDDEN, 400→VALIDATION, 404→NOT_FOUND, 408→TIMEOUT, else
+    HTTP) is the write-path twin of `http_layer.errors.classify_read_failure`;
+    the localized message table the caller passes is unchanged.
+  * `unwrap_write_response` → `record_response(record, message=...)` on a
+    confirmed single-record write, and `error_response("INTERNAL", ...)` for the
+    UNCONFIRMED case (2xx with no record body). Unconfirmed is not success
+    (v4.4 Tier 0.3): an empty response cannot establish that the write landed,
+    so it must not read as one.
 """
 from __future__ import annotations
 
@@ -13,7 +26,23 @@ from typing import Any, Dict, Iterable, Optional
 import httpx
 import structlog
 
+from .response import error_response, record_response
+
 _log = structlog.get_logger("write")
+
+# Write-path status→code map — the twin of classify_read_failure for the codes a
+# write can surface. Unmapped statuses fall to HTTP.
+_STATUS_TO_CODE = {
+    400: "VALIDATION",
+    401: "AUTH",
+    403: "FORBIDDEN",
+    404: "NOT_FOUND",
+    408: "TIMEOUT",
+}
+
+
+def _status_to_code(status: int) -> str:
+    return _STATUS_TO_CODE.get(status, "HTTP")
 
 
 def _extract_error_detail(error: httpx.HTTPStatusError) -> Any:
@@ -31,13 +60,16 @@ def map_http_error(
     *,
     detail_codes: Iterable[int] = (),
     detail_on_default: bool = False,
-) -> str:
-    """Map an HTTPStatusError to a localized message.
+) -> Dict[str, Any]:
+    """Map an HTTPStatusError to a `{"error": {"code", "message"}}` dict.
 
     error_map: {status_code: message}; ``default`` is used for unmapped codes.
+    The code comes from the status (see `_status_to_code`); the message is the
+    localized base text from the caller's table.
+
     detail_codes / detail_on_default: for those codes, the response body is
         logged server-side (structlog, stderr) for debugging — it is never
-        included in the returned string, which stays the stable base message
+        included in the returned message, which stays the stable base text
         so ServiceNow internals (response bodies, stack traces, ACL hints)
         never reach the MCP client.
     """
@@ -46,7 +78,7 @@ def map_http_error(
     is_default = status not in error_map
     if status in set(detail_codes) or (is_default and detail_on_default):
         _log.error("write_http_error", status=status, detail=_extract_error_detail(error))
-    return base
+    return error_response(_status_to_code(status), base)
 
 
 def unwrap_write_response(
@@ -54,24 +86,27 @@ def unwrap_write_response(
     unconfirmed_message: str,
     *,
     fields: Optional[Iterable[str]] = None,
-) -> Dict[str, Any] | str:
-    """Extract the single-record payload from a write response.
+    success_message: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Extract the single-record write payload into the §3.1 write shape.
 
-    fields: when given, filter a dict record down to these keys (KB write).
-    unconfirmed_message: returned when the response carried no record.
+    Confirmed write → `record_response(record, message=success_message)`
+    (`{"record": {...}, "message": ...}`). `fields`, when given, filters the
+    record down to those keys (KB write).
 
-    An empty response is UNCONFIRMED, not successful (v4.4 Tier 0.3). This
-    previously returned a message reading "<operation> successful but no data
-    returned" — it asserted the write had landed on the strength of an empty
-    response, which is the one thing an empty response cannot establish. #59
-    fixed the transport half (a failed write now raises instead of returning
-    None), so a falsy value reaching here means ServiceNow answered 2xx with no
-    record: real, rare, and not a success.
+    An empty response is UNCONFIRMED, not successful (v4.4 Tier 0.3), so it maps
+    to `error_response("INTERNAL", unconfirmed_message)`. This previously
+    returned a message reading "<operation> successful but no data returned" — it
+    asserted the write had landed on the strength of an empty response, which is
+    the one thing an empty response cannot establish. #59 fixed the transport
+    half (a failed write now raises instead of returning None), so a falsy value
+    reaching here means ServiceNow answered 2xx with no record: real, rare, and
+    not a success.
     """
     if result and isinstance(result, dict) and result.get("result"):
         record = result["result"]
         if fields is not None and isinstance(record, dict):
             allowed = set(fields)
-            return {k: v for k, v in record.items() if k in allowed}
-        return record
-    return result if result else unconfirmed_message
+            record = {k: v for k, v in record.items() if k in allowed}
+        return record_response(record, message=success_message)
+    return error_response("INTERNAL", unconfirmed_message)

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -254,13 +254,13 @@ class TestGetKbArticlesByState:
             assert result["truncated"] is True
 
     @pytest.mark.asyncio
-    async def test_empty_result_returns_message(self):
+    async def test_empty_result_is_list_contract_shape(self):
         with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
             mock_query.return_value = {"result": [], "truncated": False}
             result = await get_kb_articles_by_state()
             assert result["result"] == []
-            assert "message" in result
             assert result["returned_count"] == 0
+            assert result["truncated"] is False
 
 
 class TestSLATools:

--- a/tests/test_generic_table_tools.py
+++ b/tests/test_generic_table_tools.py
@@ -585,25 +585,23 @@ class TestAsyncTableOperations:
 
             result = await get_record_description("incident", "INC001")
 
-            assert result is not None
-            assert "result" in result
+            assert result == {"record": {"short_description": "Test description"}}
 
     @pytest.mark.asyncio
     async def test_get_record_description_not_found(self):
-        """A successful read with no rows is not-found.
+        """A successful read with no rows is a record miss (§3.1: {"record": None}).
 
         v4.4 Tier 0.3 inverted this test: it used to mock `None` — the value the
-        read path returned for BOTH "no such record" and "the request failed" —
-        and assert the not-found message. A failed read now raises, so the
-        not-found label is reached only by an actual empty result set.
+        read path returned for BOTH "no such record" and "the request failed".
+        A failed read now raises, so the miss is reached only by an actual empty
+        result set. Tier 3.1-rest then moved the miss onto record_response.
         """
         with patch("Table_Tools.generic_table_tools.make_nws_request") as mock_request:
             mock_request.return_value = {"result": []}
 
             result = await get_record_description("incident", "INC999")
 
-            assert result["result"] == []
-            assert "message" in result
+            assert result == {"record": None}
             assert "error" not in result
 
     @pytest.mark.asyncio

--- a/tests/test_generic_table_tools.py
+++ b/tests/test_generic_table_tools.py
@@ -543,7 +543,8 @@ class TestAsyncTableOperations:
 
             assert result["result"] is not None
             assert len(result["result"]) > 0
-            assert "Found" in result["message"]
+            assert result["returned_count"] == 1
+            assert result["truncated"] is False
 
     @pytest.mark.asyncio
     async def test_query_table_by_text_uses_like_operator(self):
@@ -572,7 +573,7 @@ class TestAsyncTableOperations:
             result = await query_table_by_text("incident", "nonexistent keyword")
 
             assert result["result"] == []
-            assert "message" in result
+            assert result["returned_count"] == 0
 
     @pytest.mark.asyncio
     async def test_get_record_description_success(self):
@@ -616,7 +617,7 @@ class TestAsyncTableOperations:
             result = await get_record_details("incident", "INC001")
 
             assert result is not None
-            assert "result" in result
+            assert result["record"] == {"number": "INC001", "short_description": "Test"}
 
     @pytest.mark.asyncio
     async def test_find_similar_records_success(self):
@@ -647,7 +648,7 @@ class TestAsyncTableOperations:
             result = await find_similar_records("incident", "INC999")
 
             assert result["result"] == []
-            assert "message" in result
+            assert result["returned_count"] == 0
 
     @pytest.mark.asyncio
     async def test_query_table_with_filters_success(self):
@@ -676,8 +677,8 @@ class TestAsyncTableOperations:
             result = await query_table_with_filters("incident", params)
 
             assert result["result"] == []
-            assert "message" in result
             assert result["returned_count"] == 0
+            assert result["truncated"] is False
 
     @pytest.mark.asyncio
     async def test_query_table_with_filters_reference_field_hint_on_empty(self):
@@ -784,8 +785,8 @@ class TestEdgeCases:
 
             result = await find_similar_records("incident", "INC001")
 
-            assert result["result"] == []
-            assert "message" in result
+            # A bare-exception path is a failure now, not a soft empty result.
+            assert result["error"]["code"] == "INTERNAL"
 
     @pytest.mark.asyncio
     async def test_get_records_by_priority_with_additional_filters(self):

--- a/tests/test_generic_tool_wrappers.py
+++ b/tests/test_generic_tool_wrappers.py
@@ -26,9 +26,10 @@ class TestValidateTable:
     def test_invalid_table(self):
         result = _validate_table("nonexistent_table")
         assert result is not None
-        assert "error" in result
-        assert "nonexistent_table" in result["error"]
-        assert "incident" in result["error"]  # lists supported tables
+        assert result["error"]["code"] == "VALIDATION"
+        message = result["error"]["message"]
+        assert "nonexistent_table" in message
+        assert "incident" in message  # lists supported tables
 
     def test_supported_tables_list(self):
         assert "incident" in SUPPORTED_TABLES

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -124,8 +124,8 @@ class TestReadPipelineEndToEnd:
 
         result = await search_records("not_a_real_table", "anything")
 
-        assert "error" in result
-        assert "Invalid table" in result["error"]
+        assert result["error"]["code"] == "VALIDATION"
+        assert "Invalid table" in result["error"]["message"]
 
     @staticmethod
     def _sysparm_query(url: str) -> str:
@@ -216,7 +216,7 @@ class TestWritePipelineEndToEnd:
 
             result = await create_private_task({"short_description": "Integration test"})
 
-        assert result == {"number": "VTB0001234"}
+        assert result["record"] == {"number": "VTB0001234"}
         # Confirm the write was delegated to oauth_client with raise_for_status=True
         call = mock_client.make_authenticated_request.call_args
         assert call.args[0] == "POST"
@@ -243,7 +243,7 @@ class TestWritePipelineEndToEnd:
 
             result = await update_private_task("VTB0001234", {"state": "3"})
 
-        assert result == {"number": "VTB0001234", "state": "3"}
+        assert result["record"] == {"number": "VTB0001234", "state": "3"}
         call = mock_client.make_authenticated_request.call_args
         assert call.args[0] == "PATCH"
         assert "abc123" in call.args[1]  # sys_id reached the PATCH URL
@@ -254,7 +254,7 @@ class TestWritePipelineEndToEnd:
 # ---------------------------------------------------------------------------
 
 class TestErrorPropagationEndToEnd:
-    """HTTPStatusError raised at the OAuth boundary surfaces as a domain error string."""
+    """HTTPStatusError at the OAuth boundary surfaces as an {"error": {code, message}} dict."""
 
     @pytest.mark.parametrize("status_code,fragment", [
         (401, "Authentication failed"),
@@ -280,5 +280,5 @@ class TestErrorPropagationEndToEnd:
 
             result = await create_private_task({"short_description": "boom"})
 
-        assert isinstance(result, str)
-        assert fragment.lower() in result.lower()
+        assert result["error"]["code"] in {"AUTH", "FORBIDDEN", "VALIDATION", "NOT_FOUND", "HTTP"}
+        assert fragment.lower() in result["error"]["message"].lower()

--- a/tests/test_kb_article_tools.py
+++ b/tests/test_kb_article_tools.py
@@ -76,6 +76,7 @@ class TestUnwrapKbWriteResponse:
     def test_unwrap_with_inner_result(self):
         result = _unwrap_kb_write_response({"result": {"number": "KB0001234"}}, "update")
         assert result["record"] == {"number": "KB0001234"}
+        assert result["message"] == "KB article update succeeded."
 
     def test_unwrap_empty_dict_is_unconfirmed_not_success(self):
         """An empty write response cannot establish that the write landed."""
@@ -108,6 +109,7 @@ class TestWriteKbArticle:
             )
 
             assert result["record"] == {"number": "KB0001234", "workflow_state": "published"}
+            assert result["message"] == "KB article publish succeeded."
             mock_request.assert_called_once_with(
                 "https://test.service-now.com/api/now/table/kb_knowledge/abc123",
                 method="PATCH",
@@ -231,6 +233,7 @@ class TestUpdateKnowledgeArticle:
             result = await update_knowledge_article("KB0001234", {"short_description": "Updated"})
 
             assert result["record"]["number"] == "KB0001234"
+            assert result["message"] == "KB article update succeeded."
             kwargs = mock_request.call_args.kwargs
             assert kwargs["method"] == "PATCH"
             assert kwargs["json_data"] == {"short_description": "Updated"}
@@ -505,6 +508,7 @@ class TestRetireKnowledgeArticle:
             result = await retire_knowledge_article("KB0001234")
 
             assert result["record"]["workflow_state"] == "retired"
+            assert result["message"] == "KB article retire succeeded."
             call_url = mock_request.call_args.args[0]
             call_kwargs = mock_request.call_args.kwargs
             assert "/api/qonv/mateco_knowledge/articles/abc123/retire" in call_url

--- a/tests/test_kb_article_tools.py
+++ b/tests/test_kb_article_tools.py
@@ -47,45 +47,50 @@ class TestHandleKbError:
 
     def test_401_returns_auth_failed(self):
         result = _handle_kb_error(_make_http_status_error(401), "publish")
-        assert "Authentication failed" in result
+        assert result["error"]["code"] == "AUTH"
+        assert "Authentication failed" in result["error"]["message"]
 
     def test_403_returns_access_denied(self):
         result = _handle_kb_error(_make_http_status_error(403), "retire")
-        assert "Access denied" in result
+        assert result["error"]["code"] == "FORBIDDEN"
+        assert "Access denied" in result["error"]["message"]
 
     def test_400_returns_invalid_request(self):
         result = _handle_kb_error(_make_http_status_error(400), "update")
-        assert "Invalid request" in result
+        assert result["error"]["code"] == "VALIDATION"
+        assert "Invalid request" in result["error"]["message"]
 
     def test_404_returns_not_found(self):
         result = _handle_kb_error(_make_http_status_error(404), "update")
-        assert "not found" in result.lower()
+        assert result["error"]["code"] == "NOT_FOUND"
+        assert "not found" in result["error"]["message"].lower()
 
     def test_500_returns_server_error(self):
         result = _handle_kb_error(_make_http_status_error(500), "publish")
-        assert "server error" in result.lower()
+        assert result["error"]["code"] == "HTTP"
+        assert "server error" in result["error"]["message"].lower()
 
 
 class TestUnwrapKbWriteResponse:
 
     def test_unwrap_with_inner_result(self):
         result = _unwrap_kb_write_response({"result": {"number": "KB0001234"}}, "update")
-        assert result == {"number": "KB0001234"}
+        assert result["record"] == {"number": "KB0001234"}
 
     def test_unwrap_empty_dict_is_unconfirmed_not_success(self):
         """An empty write response cannot establish that the write landed."""
         result = _unwrap_kb_write_response({}, "publish")
-        assert result == ERROR_KB_WRITE_UNCONFIRMED.format(operation="publish")
-        assert "successful" not in result
+        assert result == {"error": {"code": "INTERNAL", "message": ERROR_KB_WRITE_UNCONFIRMED.format(operation="publish")}}
+        assert "successful" not in result["error"]["message"]
 
     def test_unwrap_none_is_unconfirmed_not_success(self):
         result = _unwrap_kb_write_response(None, "retire")
-        assert result == ERROR_KB_WRITE_UNCONFIRMED.format(operation="retire")
-        assert "successful" not in result
+        assert result == {"error": {"code": "INTERNAL", "message": ERROR_KB_WRITE_UNCONFIRMED.format(operation="retire")}}
+        assert "successful" not in result["error"]["message"]
 
-    def test_unwrap_dict_without_result_key_returns_as_is(self):
+    def test_unwrap_dict_without_result_key_is_unconfirmed(self):
         result = _unwrap_kb_write_response({"some": "value"}, "update")
-        assert result == {"some": "value"}
+        assert result["error"]["code"] == "INTERNAL"
 
 
 class TestWriteKbArticle:
@@ -102,7 +107,7 @@ class TestWriteKbArticle:
                 "publish",
             )
 
-            assert result == {"number": "KB0001234", "workflow_state": "published"}
+            assert result["record"] == {"number": "KB0001234", "workflow_state": "published"}
             mock_request.assert_called_once_with(
                 "https://test.service-now.com/api/now/table/kb_knowledge/abc123",
                 method="PATCH",
@@ -115,8 +120,8 @@ class TestWriteKbArticle:
             mock_request.return_value = None
 
             result = await _write_kb_article("PATCH", "http://x", {}, "update")
-            assert result == ERROR_KB_WRITE_UNCONFIRMED.format(operation="update")
-            assert "successful" not in result
+            assert result == {"error": {"code": "INTERNAL", "message": ERROR_KB_WRITE_UNCONFIRMED.format(operation="update")}}
+            assert "successful" not in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_http_status_error_mapped(self):
@@ -124,7 +129,8 @@ class TestWriteKbArticle:
             mock_request.side_effect = _make_http_status_error(401)
 
             result = await _write_kb_article("PATCH", "http://x", {}, "publish")
-            assert "Authentication failed" in result
+            assert result["error"]["code"] == "AUTH"
+            assert "Authentication failed" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_generic_exception_returns_request_failed(self):
@@ -132,7 +138,8 @@ class TestWriteKbArticle:
             mock_request.side_effect = Exception("Network error")
 
             result = await _write_kb_article("PATCH", "http://x", {}, "retire")
-            assert "Request failed" in result
+            assert result["error"]["code"] == "INTERNAL"
+            assert "Request failed" in result["error"]["message"]
 
 
 class TestGetKbArticleSysId:
@@ -201,7 +208,8 @@ class TestUpdateKnowledgeArticle:
     @pytest.mark.asyncio
     async def test_empty_update_data_returns_error(self):
         result = await update_knowledge_article("KB0001234", {})
-        assert "No update data provided" in result
+        assert result["error"]["code"] == "VALIDATION"
+        assert "No update data provided" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_article_not_found_returns_error(self):
@@ -209,8 +217,9 @@ class TestUpdateKnowledgeArticle:
             mock_sys_id.return_value = None
 
             result = await update_knowledge_article("KB9999999", {"short_description": "x"})
-            assert "KB9999999" in result
-            assert "not found" in result.lower()
+            assert result["error"]["code"] == "NOT_FOUND"
+            assert "KB9999999" in result["error"]["message"]
+            assert "not found" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_success_returns_updated_record(self):
@@ -221,7 +230,7 @@ class TestUpdateKnowledgeArticle:
 
             result = await update_knowledge_article("KB0001234", {"short_description": "Updated"})
 
-            assert result["number"] == "KB0001234"
+            assert result["record"]["number"] == "KB0001234"
             kwargs = mock_request.call_args.kwargs
             assert kwargs["method"] == "PATCH"
             assert kwargs["json_data"] == {"short_description": "Updated"}
@@ -241,9 +250,11 @@ class TestUpdateKnowledgeArticle:
         result = await update_knowledge_article(
             "KB0001234", {"workflow_state": "published", "sys_id": "x"}
         )
-        assert "Rejected non-updatable field(s)" in result
-        assert "workflow_state" in result
-        assert "sys_id" in result
+        message = result["error"]["message"]
+        assert result["error"]["code"] == "VALIDATION"
+        assert "Rejected non-updatable field(s)" in message
+        assert "workflow_state" in message
+        assert "sys_id" in message
 
     @pytest.mark.asyncio
     async def test_accepts_meta_and_meta_description(self):
@@ -264,8 +275,8 @@ class TestUpdateKnowledgeArticle:
 
             result = await update_knowledge_article("KB0001234", payload)
 
-            assert result["meta"] == "leave, absence, policy"
-            assert result["meta_description"] == "How to request leave"
+            assert result["record"]["meta"] == "leave, absence, policy"
+            assert result["record"]["meta_description"] == "How to request leave"
             assert mock_request.call_args.kwargs["json_data"] == payload
 
 
@@ -424,7 +435,8 @@ class TestPublishKnowledgeArticle:
             mock_meta.return_value = None
 
             result = await publish_knowledge_article("KB9999999")
-            assert "KB9999999" in result
+            assert result["error"]["code"] == "NOT_FOUND"
+            assert "KB9999999" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_duplicate_found_blocks_publish(self):
@@ -459,7 +471,7 @@ class TestPublishKnowledgeArticle:
 
             result = await publish_knowledge_article("KB0001234")
 
-            assert result["workflow_state"] == "Published"
+            assert result["record"]["workflow_state"] == "Published"
             assert "/api/qonv/mateco_knowledge/articles/abc123/publish" in post_url["url"]
 
     @pytest.mark.asyncio
@@ -480,7 +492,8 @@ class TestRetireKnowledgeArticle:
             mock_sys_id.return_value = None
 
             result = await retire_knowledge_article("KB9999999")
-            assert "KB9999999" in result
+            assert result["error"]["code"] == "NOT_FOUND"
+            assert "KB9999999" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_success_posts_to_scripted_rest_retire(self):
@@ -491,7 +504,7 @@ class TestRetireKnowledgeArticle:
 
             result = await retire_knowledge_article("KB0001234")
 
-            assert result["workflow_state"] == "retired"
+            assert result["record"]["workflow_state"] == "retired"
             call_url = mock_request.call_args.args[0]
             call_kwargs = mock_request.call_args.kwargs
             assert "/api/qonv/mateco_knowledge/articles/abc123/retire" in call_url
@@ -512,13 +525,13 @@ class TestCheckKbDuplicatesTool:
     @pytest.mark.asyncio
     async def test_empty_list_returns_empty_result(self):
         result = await check_kb_duplicates([])
-        assert result == {"result": []}
+        assert result["result"] == []
 
     @pytest.mark.asyncio
     async def test_over_50_returns_error(self):
         result = await check_kb_duplicates([f"KB{i:07d}" for i in range(51)])
-        assert "error" in result
-        assert "50" in result["error"]
+        assert result["error"]["code"] == "VALIDATION"
+        assert "50" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_single_article_no_duplicates(self):
@@ -606,9 +619,13 @@ class TestNormalizePublishResult:
         assert row["blockers"] == [{"number": "KB999"}]
 
     def test_success_record_becomes_published_row(self):
+        # Publish success is now the §3.1 write shape: {"record": {...}, "message": ...}.
         row = _normalize_publish_result(
             "KB001",
-            {"number": "KB001", "sys_id": "abc", "workflow_state": "published", "short_description": "x"},
+            {
+                "record": {"number": "KB001", "sys_id": "abc", "workflow_state": "published", "short_description": "x"},
+                "message": "KB article KB001 published.",
+            },
         )
         assert row == {"number": "KB001", "status": "published", "workflow_state": "published"}
 
@@ -618,13 +635,13 @@ class TestPublishKnowledgeArticles:
     @pytest.mark.asyncio
     async def test_empty_list_returns_empty_result(self):
         result = await publish_knowledge_articles([])
-        assert result == {"result": []}
+        assert result["result"] == []
 
     @pytest.mark.asyncio
     async def test_over_20_returns_error(self):
         result = await publish_knowledge_articles([f"KB{i:07d}" for i in range(21)])
-        assert "error" in result
-        assert "20" in result["error"]
+        assert result["error"]["code"] == "VALIDATION"
+        assert "20" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_mixed_batch_yields_per_article_status(self):
@@ -761,7 +778,7 @@ class TestPublishWithVerify:
              patch('Table_Tools.kb_article_tools.asyncio.sleep', new_callable=AsyncMock):
             result = await _publish_with_verify("abc123", "KB0001234")
             assert isinstance(result, dict)
-            assert result["number"] == "KB0001234"
+            assert result["record"]["number"] == "KB0001234"
 
     @pytest.mark.asyncio
     async def test_fire_timeout_but_verify_finds_published(self):
@@ -775,7 +792,7 @@ class TestPublishWithVerify:
              patch('Table_Tools.kb_article_tools.asyncio.sleep', new_callable=AsyncMock):
             result = await _publish_with_verify("abc123", "KB0001234")
             assert isinstance(result, dict)
-            assert result["number"] == "KB0001234"
+            assert result["record"]["number"] == "KB0001234"
 
     @pytest.mark.asyncio
     async def test_fire_anyio_timeout_but_verify_finds_published(self):
@@ -791,7 +808,7 @@ class TestPublishWithVerify:
              patch('Table_Tools.kb_article_tools.asyncio.sleep', new_callable=AsyncMock):
             result = await _publish_with_verify("abc123", "KB0001234")
             assert isinstance(result, dict)
-            assert result["number"] == "KB0001234"
+            assert result["record"]["number"] == "KB0001234"
 
     @pytest.mark.asyncio
     async def test_fire_http_error_but_verify_finds_published(self):
@@ -838,8 +855,8 @@ class TestPublishWithVerify:
              patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_refresh:
             mock_refresh.return_value = "abc123"
             result = await _publish_with_verify("abc123", "KB0001234")
-            assert isinstance(result, str)
-            assert "could not be confirmed" in result
+            assert result["error"]["code"] == "INTERNAL"
+            assert "could not be confirmed" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_returns_http_error_string_when_both_attempts_fail(self):
@@ -855,8 +872,8 @@ class TestPublishWithVerify:
              patch('Table_Tools.kb_article_tools._get_kb_article_sys_id') as mock_refresh:
             mock_refresh.return_value = "abc123"
             result = await _publish_with_verify("abc123", "KB0001234")
-            assert isinstance(result, str)
-            assert "Authentication failed" in result
+            assert result["error"]["code"] == "AUTH"
+            assert "Authentication failed" in result["error"]["message"]
 
 
 class TestWritePathTimeoutPropagation:

--- a/tests/test_security_sanitization.py
+++ b/tests/test_security_sanitization.py
@@ -93,7 +93,7 @@ def _status_error(status: int, body: str) -> httpx.HTTPStatusError:
 
 def test_map_http_error_does_not_leak_body_on_default():
     err = _status_error(500, "Traceback: internal ACL failure at sys_id=abc")
-    msg = map_http_error(err, {}, "Server error.", detail_on_default=True)
+    msg = map_http_error(err, {}, "Server error.", detail_on_default=True)["error"]["message"]
     assert msg == "Server error."
     assert "sys_id" not in msg
     assert "Traceback" not in msg
@@ -101,7 +101,7 @@ def test_map_http_error_does_not_leak_body_on_default():
 
 def test_map_http_error_does_not_leak_body_on_detail_code():
     err = _status_error(400, "invalid field xyz")
-    msg = map_http_error(err, {400: "Bad request."}, "Server error.", detail_codes={400})
+    msg = map_http_error(err, {400: "Bad request."}, "Server error.", detail_codes={400})["error"]["message"]
     assert msg == "Bad request."
     assert "xyz" not in msg
 

--- a/tests/test_task_sla_guard.py
+++ b/tests/test_task_sla_guard.py
@@ -61,8 +61,8 @@ class TestIdentityToolsRejectTaskSla:
         with patch("http_layer.request_dispatcher.make_oauth_request", new=capture):
             result = await call()
 
-        assert "error" in result
-        assert "task_sla" in result["error"]
+        assert result["error"]["code"] == "VALIDATION"
+        assert "task_sla" in result["error"]["message"]
         assert capture.urls == [], "must refuse before touching ServiceNow"
 
     @pytest.mark.asyncio
@@ -70,7 +70,7 @@ class TestIdentityToolsRejectTaskSla:
         """A refusal that does not say what to use instead just moves the dead end."""
         result = await get_record("task_sla", "SLA0001")
 
-        message = result["error"]
+        message = result["error"]["message"]
         assert "get_sla_details" in message
         assert "query_slas_by_task" in message
         assert "filter_records" in message
@@ -89,7 +89,7 @@ class TestIdentityToolsRejectTaskSla:
         """The identity guard must not mask the plain unsupported-table error."""
         result = await get_record("not_a_real_table", "X0001")
 
-        assert "Invalid table" in result["error"]
+        assert "Invalid table" in result["error"]["message"]
 
 
 class TestFilterRecordsStillAcceptsTaskSla:

--- a/tests/test_token_footprint.py
+++ b/tests/test_token_footprint.py
@@ -234,6 +234,98 @@ class TestSLATokenFootprint:
         assert tokens <= BUDGET_QUERY_SLAS_STANDARD_LIST
 
 
+# ---------------------------------------------------------------------------
+# Per-response envelope overhead (v5.0 "Boron" Tier 3.1).
+#
+# The §3.1 contract's headline risk is a re-introduced unconditional `meta`
+# envelope (tool/table/query/fields/duration_ms) — the v2 plan's worst error,
+# a 100-300% regression on a call like get_sla_details. These guards pin the
+# ENVELOPE OVERHEAD: tokens(response) minus tokens({"result": rows}) — i.e.
+# everything the tool adds around the data. list_response adds only
+# returned_count + truncated (+ max_results); record_response adds only the
+# `record` key. A meta envelope would blow straight past the ceiling.
+#
+# Measuring overhead, not an absolute count, keeps the guard immune to row-count
+# and per-row data churn while still catching a structural regression — exactly
+# the property the loose SLA budgets above were reaching for.
+# ---------------------------------------------------------------------------
+
+# list_response wraps rows in {result, returned_count, truncated, (max_results)}.
+# Those keys + small int/bool values tokenize to ~12; 40 leaves headroom for a
+# `suggestions` hint or a CMDB descriptor key, but not for a meta envelope.
+BUDGET_LIST_ENVELOPE_OVERHEAD = 40
+# record_response is just {"record": row} on a read — a handful of tokens.
+BUDGET_RECORD_ENVELOPE_OVERHEAD = 15
+
+_GENERIC_ROW = {
+    "number": "INC0010001",
+    "short_description": "Server crashed during nightly backup window",
+    "priority": "1",
+    "state": "2",
+    "assignment_group": "SN Fleet",
+    "sys_created_on": "2026-04-15 10:30:00",
+}
+_CI_ROW = {
+    "number": "SRV0001234",
+    "name": "host-app-01",
+    "sys_class_name": "cmdb_ci_server",
+    "operational_status": "1",
+    "install_status": "1",
+    "sys_created_on": "2026-04-15 10:30:00",
+    "sys_updated_on": "2026-04-20 09:00:00",
+}
+
+
+def _list_envelope_overhead(resp) -> int:
+    """tokens(resp) - tokens({"result": resp["result"]}) — the wrapper's cost."""
+    return _count_tokens(resp) - _count_tokens({"result": resp["result"]})
+
+
+class TestPerResponseEnvelopeFootprint:
+    """No unconditional meta envelope on the default read path (plan §3.1)."""
+
+    @pytest.mark.asyncio
+    async def test_filter_records_envelope_is_thin(self):
+        from Table_Tools.generic_tool_wrappers import filter_records
+        rows = [dict(_GENERIC_ROW) for _ in range(100)]
+        with patch("Table_Tools.generic_table_tools._make_paginated_request",
+                   return_value=rows):
+            resp = await filter_records("incident", {"priority": "1"})
+        assert resp["result"] and "message" not in resp
+        assert _list_envelope_overhead(resp) <= BUDGET_LIST_ENVELOPE_OVERHEAD
+
+    @pytest.mark.asyncio
+    async def test_search_records_envelope_is_thin(self):
+        from Table_Tools.generic_tool_wrappers import search_records
+        rows = [dict(_GENERIC_ROW) for _ in range(50)]
+        with patch("Table_Tools.generic_table_tools._make_paginated_request",
+                   return_value=rows):
+            resp = await search_records("incident", "server crash backup")
+        assert resp["result"] and "message" not in resp
+        assert _list_envelope_overhead(resp) <= BUDGET_LIST_ENVELOPE_OVERHEAD
+
+    @pytest.mark.asyncio
+    async def test_get_record_envelope_is_thin(self):
+        from Table_Tools.generic_tool_wrappers import get_record
+        with patch("Table_Tools.generic_table_tools.make_nws_request",
+                   return_value={"result": [dict(_GENERIC_ROW)]}):
+            resp = await get_record("incident", "INC0010001")
+        assert "record" in resp and "result" not in resp
+        overhead = _count_tokens(resp) - _count_tokens({"record": resp["record"]})
+        assert overhead <= BUDGET_RECORD_ENVELOPE_OVERHEAD
+
+    @pytest.mark.asyncio
+    async def test_cmdb_list_envelope_is_thin(self):
+        from Table_Tools.cmdb_tools import find_cis_by_type
+        rows = [dict(_CI_ROW) for _ in range(100)]
+        with patch("Table_Tools.cmdb_tools.make_nws_request",
+                   return_value={"result": rows}):
+            resp = await find_cis_by_type("cmdb_ci_server")
+        assert resp["result"] and "message" not in resp
+        # CMDB list carries a `ci_type` descriptor key; still well under budget.
+        assert _list_envelope_overhead(resp) <= BUDGET_LIST_ENVELOPE_OVERHEAD
+
+
 class TestSLATokenBudgetConstants:
     """Lock budget constants — accidental relaxation should fail review."""
 

--- a/tests/test_tool_response_contract.py
+++ b/tests/test_tool_response_contract.py
@@ -1,0 +1,321 @@
+"""Surface-wide response-contract test (v5.0 "Boron", plan §3.1).
+
+Every registered tool in `tools.tools` must return one of the §3.1 shapes:
+
+    list success   {"result": [...], "returned_count": int, "truncated": bool}
+    single record  {"record": {...} | None}
+    write success  {"record": {...}, "message": str}
+    failure        {"error": {"code": <ERROR_CODES>, "message": str}}
+    partial page   list shape + {"partial": true, "error": {...}}   (data + error)
+
+Forbidden: a bare `str` return; a `{"message": ...}` success dialect parallel to
+`error`; `result`/`record` sitting next to `error` (outside the partial-page and
+diagnostic exceptions); `code` values outside the seven-code vocabulary.
+
+The tools are driven through the REAL dispatcher (`http_layer.request_dispatcher`)
+so this exercises the shapes the modules actually build, not a mock of them. Two
+transports: one that makes every round-trip succeed, one that makes every
+round-trip fail with a classified timeout.
+
+Documented intentional exceptions (see `_EXCEPTION_TOOLS`):
+  * `health_check` returns a diagnostic STATUS BAG — `error` may sit beside
+    `connection`/`server`/`auth`. It is not a data tool.
+  * `publish_knowledge_article` can return a fail-closed guard outcome
+    (duplicates / inconclusive / unconfirmed) carrying `success: False` and, in
+    the unconfirmed case, `error` beside status flags. Covered explicitly below.
+  * the partial-page shape carries rows AND `error` together by design.
+
+`test_every_registered_tool_has_a_contract_case` derives the tool set from
+`tools.tools` at run time ([[derive_lists_from_code]]) — adding a tool without a
+contract case fails the suite by name, so this cannot silently under-cover.
+"""
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import tools
+from Table_Tools.response import ERROR_CODES
+
+# A row rich enough to satisfy every reader: generic (number/short_description),
+# CMDB (name/sys_class_name/location/operational_status), KB dedup/meta (sys_id).
+_ROW = {
+    "sys_id": "26bc0f3b47c1120010c43d3171e36d99",
+    "number": "REC0001234",
+    "short_description": "sample record",
+    "name": "host-01",
+    "sys_class_name": "cmdb_ci_server",
+    "location": "Brussels",
+    "operational_status": "1",
+    "workflow_state": "Published",
+    "state": "3",
+}
+
+# Tools that touch ServiceNow via the dispatcher (so the failure pass applies).
+# get_query_syntax_help is pure reference data — it never calls the transport.
+_NO_TRANSPORT = {"get_query_syntax_help"}
+
+# Batch tools run each article independently and record a per-row failure inside
+# the row; the batch itself still succeeds, so a transport failure yields a valid
+# list_response with error-bearing rows, NOT a top-level error.
+_BATCH_TOOLS = {"publish_knowledge_articles", "check_kb_duplicates"}
+
+
+async def _invoke(factory):
+    """Call a case factory, awaiting only if it produced a coroutine.
+
+    get_query_syntax_help is a plain sync function; every other tool is async."""
+    resp = factory()
+    if inspect.isawaitable(resp):
+        resp = await resp
+    return resp
+
+# Tools whose success/failure shape legitimately carries companions to `error`
+# or is a non-data payload (see module docstring).
+_EXCEPTION_TOOLS = {"health_check", "publish_knowledge_article"}
+
+
+def _success_read(url: str):
+    """A GET that succeeds for every caller. Dedup queries come back clear so a
+    publish is allowed to proceed to its verify step."""
+    if "short_descriptionLIKE" in url:
+        return {"result": []}  # KB dedup: no duplicates -> clear to publish
+    if "sys_db_object" in url:
+        return {"result": [{"name": "cmdb_ci_server", "label": "Server", "number_ref": "x"}]}
+    return {"result": [dict(_ROW)]}
+
+
+def _fail_read(url: str):
+    raise TimeoutError("transport down")
+
+
+class _FakeOAuthClient:
+    """Write branch: make_authenticated_request returns a single-record body."""
+
+    def __init__(self, *, fail: bool = False):
+        self._fail = fail
+
+    async def make_authenticated_request(self, method, url, **kwargs):
+        if self._fail:
+            import httpx
+
+            response = MagicMock()
+            response.status_code = 500
+            raise httpx.HTTPStatusError("boom", request=MagicMock(), response=response)
+        return {"result": dict(_ROW)}
+
+
+@pytest.fixture
+def transport(monkeypatch):
+    """Patch the dispatcher's read + write seams. `mode` picks success/failure."""
+    import http_layer.request_dispatcher as dispatcher
+    import Table_Tools.kb_article_tools as kb
+
+    def install(mode: str):
+        read = _success_read if mode == "success" else _fail_read
+
+        async def _read(url):
+            return read(url)
+
+        monkeypatch.setattr(dispatcher, "make_oauth_request", _read)
+        monkeypatch.setattr(
+            dispatcher, "get_oauth_client", lambda: _FakeOAuthClient(fail=(mode != "success"))
+        )
+        # publish polls with asyncio.sleep between fire and verify — skip the wait.
+        monkeypatch.setattr(kb.asyncio, "sleep", AsyncMock())
+
+    return install
+
+
+# Each case: name, a zero-arg coroutine factory, and the success kind.
+# kind ∈ {"list", "record", "diagnostic", "reference"}.
+def _cases():
+    from Table_Tools.generic_tool_wrappers import (
+        search_records, get_record, find_similar, filter_records,
+    )
+    from Table_Tools.consolidated_tools import (
+        get_priority_incidents, get_kb_articles_by_state,
+        get_sla_details, query_slas_by_task, query_slas_by_status, query_slas_custom,
+    )
+    from Table_Tools.vtb_task_tools import create_private_task, update_private_task
+    from Table_Tools.kb_article_tools import (
+        update_knowledge_article, publish_knowledge_article, publish_knowledge_articles,
+        retire_knowledge_article, check_kb_duplicates,
+    )
+    from Table_Tools.cmdb_tools import (
+        find_cis_by_type, search_cis_by_attributes, get_ci_details,
+        similar_cis_for_ci, get_all_ci_types, quick_ci_search,
+    )
+    from utility_tools import health_check
+    from Table_Tools.intelligent_query_tools import get_query_syntax_help
+
+    return [
+        ("health_check", lambda: health_check(), "diagnostic"),
+        ("search_records", lambda: search_records("incident", "server down"), "list"),
+        ("get_record", lambda: get_record("incident", "INC0012345"), "record"),
+        ("find_similar", lambda: find_similar("incident", "INC0012345"), "list"),
+        ("filter_records", lambda: filter_records("incident", {"priority": "1"}), "list"),
+        ("get_priority_incidents", lambda: get_priority_incidents(["1"]), "list"),
+        ("get_kb_articles_by_state", lambda: get_kb_articles_by_state(), "list"),
+        ("create_private_task", lambda: create_private_task({"short_description": "x"}), "record"),
+        ("update_private_task", lambda: update_private_task("VTB0001234", {"comments": "x"}), "record"),
+        ("update_knowledge_article", lambda: update_knowledge_article("KB0001234", {"short_description": "x"}), "record"),
+        ("publish_knowledge_article", lambda: publish_knowledge_article("KB0001234"), "record"),
+        ("publish_knowledge_articles", lambda: publish_knowledge_articles(["KB0001234"]), "list"),
+        ("retire_knowledge_article", lambda: retire_knowledge_article("KB0001234"), "record"),
+        ("check_kb_duplicates", lambda: check_kb_duplicates(["KB0001234"]), "list"),
+        ("get_sla_details", lambda: get_sla_details(_ROW["sys_id"]), "list"),
+        ("query_slas_by_task", lambda: query_slas_by_task("INC0012345"), "list"),
+        ("query_slas_by_status", lambda: query_slas_by_status("active"), "list"),
+        ("query_slas_custom", lambda: query_slas_custom({"active": "true"}), "list"),
+        ("find_cis_by_type", lambda: find_cis_by_type("cmdb_ci_server"), "list"),
+        ("search_cis_by_attributes", lambda: search_cis_by_attributes(name="host-01"), "list"),
+        ("get_ci_details", lambda: get_ci_details("CI0001000"), "record"),
+        ("similar_cis_for_ci", lambda: similar_cis_for_ci("CI0001000"), "list"),
+        ("get_all_ci_types", lambda: get_all_ci_types(), "list"),
+        ("quick_ci_search", lambda: quick_ci_search("host-01"), "list"),
+        ("get_query_syntax_help", lambda: get_query_syntax_help(), "reference"),
+    ]
+
+
+CASES = _cases()
+
+
+def _assert_error_shape(err):
+    assert isinstance(err, dict), f"error must be a dict, got {type(err)}"
+    assert set(err) >= {"code", "message"}, f"error must carry code+message, got {err}"
+    assert err["code"] in ERROR_CODES, f"code {err['code']!r} outside the vocabulary"
+    assert isinstance(err["message"], str) and err["message"]
+
+
+def assert_contract(resp, *, tool_name):
+    """The §3.1 invariants. `error` present with companions is allowed only for
+    the documented exception tools and the partial-page shape."""
+    assert isinstance(resp, dict), f"{tool_name} returned a non-dict {type(resp)} — bare returns are forbidden"
+
+    if "error" in resp:
+        _assert_error_shape(resp["error"])
+        is_partial = resp.get("partial") is True
+        if not is_partial and tool_name not in _EXCEPTION_TOOLS:
+            assert "result" not in resp and "record" not in resp, (
+                f"{tool_name}: error must not sit beside result/record (got keys {sorted(resp)})"
+            )
+
+    if "result" in resp:
+        assert isinstance(resp["result"], list), f"{tool_name}: result must be a list"
+        assert isinstance(resp.get("returned_count"), int), f"{tool_name}: list needs int returned_count"
+        assert isinstance(resp.get("truncated"), bool), f"{tool_name}: list needs bool truncated"
+
+    if "record" in resp:
+        rec = resp["record"]
+        assert rec is None or isinstance(rec, dict), f"{tool_name}: record must be dict|None"
+
+    # The forbidden success dialect: a top-level `message` with neither error,
+    # record, nor result to anchor it (that is the killed {"message": ...} shape).
+    if "message" in resp and not ({"error", "record", "result"} & set(resp)):
+        pytest.fail(f"{tool_name}: bare top-level message dialect {resp}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name,factory,kind", CASES, ids=[c[0] for c in CASES])
+async def test_success_shape_conforms(name, factory, kind, transport):
+    transport("success")
+    resp = await _invoke(factory)
+    assert_contract(resp, tool_name=name)
+
+    if kind == "list":
+        assert "result" in resp and isinstance(resp["result"], list)
+    elif kind == "record":
+        assert "record" in resp, f"{name} should return a single-record shape, got {sorted(resp)}"
+    elif kind == "diagnostic":
+        assert "connection" in resp  # health_check status bag
+    elif kind == "reference":
+        assert isinstance(resp, dict) and "error" not in resp
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name,factory,kind",
+    [c for c in CASES if c[0] not in _NO_TRANSPORT],
+    ids=[c[0] for c in CASES if c[0] not in _NO_TRANSPORT],
+)
+async def test_failure_shape_conforms(name, factory, kind, transport):
+    """Every transport-touching tool maps a classified failure to the contract."""
+    transport("failure")
+    resp = await _invoke(factory)
+    assert_contract(resp, tool_name=name)
+
+    if name == "health_check":
+        # Documented exception: diagnostic status bag reports the failure under
+        # `error` alongside connection="failed".
+        assert resp["connection"] == "failed"
+        _assert_error_shape(resp["error"])
+    elif name in _BATCH_TOOLS:
+        # A batch stays a valid list; the per-article failure lands inside its row.
+        assert isinstance(resp["result"], list) and resp["result"]
+    else:
+        assert "error" in resp, f"{name} should surface a failure as {{'error': ...}}, got {sorted(resp)}"
+        _assert_error_shape(resp["error"])
+
+
+def test_every_registered_tool_has_a_contract_case():
+    """Derive the tool set from tools.tools, never from a hand-list.
+
+    A new registered tool with no contract case fails here by name, so this
+    cannot silently under-cover the surface ([[derive_lists_from_code]]).
+    """
+    registered = {fn.__name__ for fn in tools.tools}
+    covered = {c[0] for c in CASES}
+    missing = registered - covered
+    extra = covered - registered
+    assert not missing, f"registered tools with no contract case: {sorted(missing)}"
+    assert not extra, f"contract cases for tools that are not registered: {sorted(extra)}"
+
+
+class TestDocumentedExceptions:
+    """The shapes that intentionally deviate — pinned so the deviation stays deliberate."""
+
+    @pytest.mark.asyncio
+    async def test_publish_unconfirmed_carries_error_beside_status_flags(self, transport):
+        """publish_knowledge_article: verify-read failure => unconfirmed, an
+        intentional exception where `error` coexists with success flags."""
+        import Table_Tools.kb_article_tools as kb
+        transport("success")
+
+        async def meta(number, workflow_state=None):
+            return {"sys_id": _ROW["sys_id"], "short_description": "x"}
+
+        async def clear(short_description, exclude_number):
+            return []
+
+        from http_layer.errors import ErrorCode, ServiceNowRequestError
+
+        async def verify_fails(article_number):
+            raise ServiceNowRequestError(ErrorCode.TIMEOUT, "verify timed out", retryable=True)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(kb, "_get_kb_article_meta", meta)
+            mp.setattr(kb, "_check_kb_duplicates", clear)
+            mp.setattr(kb, "_verify_kb_published", verify_fails)
+            mp.setattr(kb, "_fire_publish", AsyncMock(return_value=None))
+            resp = await kb.publish_knowledge_article("KB0001234")
+
+        assert resp["publish_confirmed"] is False
+        _assert_error_shape(resp["error"])
+
+    @pytest.mark.asyncio
+    async def test_partial_page_carries_rows_and_error(self):
+        """The one sanctioned data+error shape."""
+        from Table_Tools.generic_table_tools import _partial_envelope, PartialPageReadError
+        from Table_Tools.response import list_response
+        from http_layer.errors import ErrorCode, ServiceNowRequestError
+
+        partial = PartialPageReadError(
+            [dict(_ROW)], ServiceNowRequestError(ErrorCode.TIMEOUT, "page 2 died", retryable=True)
+        )
+        resp = _partial_envelope(list_response([dict(_ROW)], truncated=False), partial)
+        assert_contract(resp, tool_name="filter_records")
+        assert resp["partial"] is True
+        assert resp["result"] and "error" in resp

--- a/tests/test_tool_response_contract.py
+++ b/tests/test_tool_response_contract.py
@@ -154,17 +154,17 @@ def _cases():
     return [
         ("health_check", lambda: health_check(), "diagnostic"),
         ("search_records", lambda: search_records("incident", "server down"), "list"),
-        ("get_record", lambda: get_record("incident", "INC0012345"), "record"),
+        ("get_record", lambda: get_record("incident", "INC0012345"), "record_read"),
         ("find_similar", lambda: find_similar("incident", "INC0012345"), "list"),
         ("filter_records", lambda: filter_records("incident", {"priority": "1"}), "list"),
         ("get_priority_incidents", lambda: get_priority_incidents(["1"]), "list"),
         ("get_kb_articles_by_state", lambda: get_kb_articles_by_state(), "list"),
-        ("create_private_task", lambda: create_private_task({"short_description": "x"}), "record"),
-        ("update_private_task", lambda: update_private_task("VTB0001234", {"comments": "x"}), "record"),
-        ("update_knowledge_article", lambda: update_knowledge_article("KB0001234", {"short_description": "x"}), "record"),
-        ("publish_knowledge_article", lambda: publish_knowledge_article("KB0001234"), "record"),
+        ("create_private_task", lambda: create_private_task({"short_description": "x"}), "record_write"),
+        ("update_private_task", lambda: update_private_task("VTB0001234", {"comments": "x"}), "record_write"),
+        ("update_knowledge_article", lambda: update_knowledge_article("KB0001234", {"short_description": "x"}), "record_write"),
+        ("publish_knowledge_article", lambda: publish_knowledge_article("KB0001234"), "record_write"),
         ("publish_knowledge_articles", lambda: publish_knowledge_articles(["KB0001234"]), "list"),
-        ("retire_knowledge_article", lambda: retire_knowledge_article("KB0001234"), "record"),
+        ("retire_knowledge_article", lambda: retire_knowledge_article("KB0001234"), "record_write"),
         ("check_kb_duplicates", lambda: check_kb_duplicates(["KB0001234"]), "list"),
         ("get_sla_details", lambda: get_sla_details(_ROW["sys_id"]), "list"),
         ("query_slas_by_task", lambda: query_slas_by_task("INC0012345"), "list"),
@@ -207,6 +207,15 @@ def assert_contract(resp, *, tool_name):
         assert isinstance(resp["result"], list), f"{tool_name}: result must be a list"
         assert isinstance(resp.get("returned_count"), int), f"{tool_name}: list needs int returned_count"
         assert isinstance(resp.get("truncated"), bool), f"{tool_name}: list needs bool truncated"
+        # A list success must NOT carry a top-level prose `message` — that is the
+        # {"result": [...], "message": "Found N records"} dialect this tier removed.
+        # `message` is legal only beside `record` (write success) or on a
+        # documented exception tool.
+        if tool_name not in _EXCEPTION_TOOLS:
+            assert "message" not in resp, (
+                f"{tool_name}: list success must not carry a prose `message` "
+                f"(reintroduced success dialect): {sorted(resp)}"
+            )
 
     if "record" in resp:
         rec = resp["record"]
@@ -227,8 +236,18 @@ async def test_success_shape_conforms(name, factory, kind, transport):
 
     if kind == "list":
         assert "result" in resp and isinstance(resp["result"], list)
-    elif kind == "record":
+    elif kind == "record_read":
+        # Read hit: {"record": {...}} with NO top-level message (reads never
+        # carry the write-success message).
         assert "record" in resp, f"{name} should return a single-record shape, got {sorted(resp)}"
+        assert "message" not in resp, f"{name}: a read must not carry a top-level message"
+    elif kind == "record_write":
+        # Write success: {"record": {...}, "message": str}. The §3.1 write shape
+        # REQUIRES the message, so dropping success_message= now fails here.
+        assert "record" in resp and resp["record"] is not None, f"{name}: write should return a record"
+        assert isinstance(resp.get("message"), str) and resp["message"], (
+            f"{name}: write success must carry a non-empty `message` (§3.1 write shape)"
+        )
     elif kind == "diagnostic":
         assert "connection" in resp  # health_check status bag
     elif kind == "reference":

--- a/tests/test_typed_read_generic_table_tools.py
+++ b/tests/test_typed_read_generic_table_tools.py
@@ -75,21 +75,20 @@ class TestSingleRecordReads:
         _assert_plain_failure(result, ErrorCode.FORBIDDEN)
 
     @pytest.mark.asyncio
-    async def test_empty_result_still_says_not_found(self):
+    async def test_empty_result_is_a_record_miss_not_a_failure(self):
         with patch("Table_Tools.generic_table_tools.make_nws_request") as mock_request:
             mock_request.return_value = {"result": []}
             result = await get_record_details("incident", "INC0099999")
-        assert result["result"] == []
-        assert "message" in result
+        assert result == {"record": None}
         assert "error" not in result
 
     @pytest.mark.asyncio
-    async def test_rows_pass_through_untouched(self):
-        payload = {"result": [{"number": "INC0012345", "short_description": "db down"}]}
+    async def test_row_returns_under_record_key(self):
+        row = {"number": "INC0012345", "short_description": "db down"}
         with patch("Table_Tools.generic_table_tools.make_nws_request") as mock_request:
-            mock_request.return_value = payload
+            mock_request.return_value = {"result": [row]}
             result = await get_record_details("incident", "INC0012345")
-        assert result == payload
+        assert result == {"record": row}
 
 
 class TestPaginationPartialReads:
@@ -208,8 +207,8 @@ class TestFilteredQueryEnvelopes:
             side_effect=RuntimeError("boom"),
         ):
             result = await get_records_by_priority("incident", ["1", "2"])
-        assert "error" in result
-        assert isinstance(result["error"], str)
+        assert result["error"]["code"] == "INTERNAL"
+        assert isinstance(result["error"]["message"], str)
 
 
 class TestFindSimilarRecords:
@@ -334,7 +333,7 @@ class TestConsumersThatReWrap:
             mock_request.return_value = {"result": []}
             result = await get_kb_articles_by_state(workflow_state="published")
         assert result["result"] == []
-        assert result["message"] == "No matching KB articles."
+        assert result["returned_count"] == 0
         assert "error" not in result
 
     @pytest.mark.asyncio
@@ -407,5 +406,5 @@ class TestEndToEndThroughTheRealDispatcher:
 
         monkeypatch.setattr(dispatcher, "make_oauth_request", empty)
         result = await get_record("incident", "INC0099999")
-        assert result["result"] == []
+        assert result == {"record": None}
         assert "error" not in result

--- a/tests/test_typed_read_kb_article_tools.py
+++ b/tests/test_typed_read_kb_article_tools.py
@@ -164,7 +164,7 @@ class TestPublishGuardIsFailClosed:
             new=AsyncMock(return_value=None),
         ):
             result = await publish_knowledge_article("KB9999999")
-        assert result == ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB9999999")
+        assert result == {"error": {"code": "NOT_FOUND", "message": ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB9999999")}}
 
 
 class TestDuplicateCheckOutcomes:
@@ -391,7 +391,10 @@ class TestNormalizePublishResultNeverInventsSuccess:
         assert row["blockers"] == [{"number": "KB0009999"}]
 
     def test_a_published_row_is_still_published(self):
-        row = _normalize_publish_result("KB0001234", PUBLISHED_ROW)
+        # Publish success is the §3.1 write shape now: {"record": {...}, "message": ...}.
+        row = _normalize_publish_result(
+            "KB0001234", {"record": PUBLISHED_ROW, "message": "KB article KB0001234 published."}
+        )
         assert row["status"] == "published"
         assert row["workflow_state"] == "Published"
 
@@ -543,7 +546,7 @@ class TestPreWriteReadsDistinguishAbsentFromFailed:
             new=AsyncMock(return_value=None),
         ):
             result = await update_knowledge_article("KB9999999", {"short_description": "x"})
-        assert result == ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB9999999")
+        assert result == {"error": {"code": "NOT_FOUND", "message": ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB9999999")}}
 
     @pytest.mark.asyncio
     async def test_retire_failed_lookup_is_not_not_found(self):
@@ -565,7 +568,7 @@ class TestPreWriteReadsDistinguishAbsentFromFailed:
             new=AsyncMock(return_value=None),
         ):
             result = await retire_knowledge_article("KB9999999")
-        assert result == ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB9999999")
+        assert result == {"error": {"code": "NOT_FOUND", "message": ERROR_KB_ARTICLE_NOT_FOUND_OP.format(number="KB9999999")}}
 
 
 class TestEndToEndThroughTheRealDispatcher:
@@ -646,7 +649,7 @@ class TestEndToEndThroughTheRealDispatcher:
 
         assert len(writes) == 1
         assert writes[0][0] == "POST"
-        assert result == PUBLISHED_ROW
+        assert result["record"] == PUBLISHED_ROW
 
     @pytest.mark.asyncio
     async def test_verify_timeout_leaves_exactly_one_write(self, transport):

--- a/tests/test_typed_read_vtb_task_tools.py
+++ b/tests/test_typed_read_vtb_task_tools.py
@@ -69,7 +69,7 @@ class TestPreWriteLookup:
             result = await update_private_task("VTB9999999", {"comments": "hi"})
 
         write.assert_not_called()
-        assert result == PRIVATE_TASK_NOT_FOUND_UPDATE
+        assert result == {"error": {"code": "NOT_FOUND", "message": PRIVATE_TASK_NOT_FOUND_UPDATE}}
 
     @pytest.mark.asyncio
     async def test_found_task_still_writes(self):
@@ -92,7 +92,7 @@ class TestPreWriteLookup:
         with patch("Table_Tools.vtb_task_tools._get_task_sys_id") as lookup:
             result = await update_private_task("VTB0001234", {"sys_id": "nope"})
         lookup.assert_not_called()
-        assert "Rejected non-updatable field(s)" in result
+        assert "Rejected non-updatable field(s)" in result["error"]["message"]
 
 
 class TestEndToEndThroughTheRealDispatcher:
@@ -150,7 +150,7 @@ class TestEndToEndThroughTheRealDispatcher:
         result = await update_private_task("VTB9999999", {"comments": "hi"})
 
         assert writes == []
-        assert result == PRIVATE_TASK_NOT_FOUND_UPDATE
+        assert result == {"error": {"code": "NOT_FOUND", "message": PRIVATE_TASK_NOT_FOUND_UPDATE}}
 
     @pytest.mark.asyncio
     async def test_successful_lookup_writes_once(self, transport):
@@ -160,7 +160,7 @@ class TestEndToEndThroughTheRealDispatcher:
         assert len(writes) == 1
         assert writes[0][0] == "PATCH"
         assert SYS_ID in writes[0][1]
-        assert result == {"number": "VTB0001234"}
+        assert result["record"] == {"number": "VTB0001234"}
 
 
 class TestReadFailureStillRaisesAtTheHelperBoundary:

--- a/tests/test_vtb_task_tools.py
+++ b/tests/test_vtb_task_tools.py
@@ -45,6 +45,7 @@ class TestWritePrivateTask:
             )
 
             assert result["record"] == {"number": "VTB0001234", "short_description": "Test task"}
+            assert result["message"] == "Private task creation succeeded."
             mock_request.assert_called_once_with(
                 "https://test.service-now.com/api/now/table/vtb_task",
                 method="POST",
@@ -178,6 +179,7 @@ class TestUnwrapWriteResponse:
     def test_unwrap_with_inner_result(self):
         result = _unwrap_write_response({"result": {"number": "VTB0001"}}, "creation")
         assert result["record"] == {"number": "VTB0001"}
+        assert result["message"] == "Private task creation succeeded."
 
     def test_unwrap_empty_dict_is_unconfirmed_not_success(self):
         """An empty write response cannot establish that the write landed."""
@@ -397,6 +399,7 @@ class TestUpdatePrivateTask:
 
             assert result["record"]["number"] == "VTB0001234"
             assert result["record"]["state"] == "3"
+            assert result["message"] == "Private task update succeeded."
             mock_sys_id.assert_called_once_with("VTB0001234")
             mock_request.assert_called_once()
             kwargs = mock_request.call_args.kwargs

--- a/tests/test_vtb_task_tools.py
+++ b/tests/test_vtb_task_tools.py
@@ -44,7 +44,7 @@ class TestWritePrivateTask:
                 "creation",
             )
 
-            assert result == {"number": "VTB0001234", "short_description": "Test task"}
+            assert result["record"] == {"number": "VTB0001234", "short_description": "Test task"}
             mock_request.assert_called_once_with(
                 "https://test.service-now.com/api/now/table/vtb_task",
                 method="POST",
@@ -63,8 +63,8 @@ class TestWritePrivateTask:
                 "creation",
             )
 
-            assert result == ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="creation")
-            assert "successful" not in result
+            assert result == {"error": {"code": "INTERNAL", "message": ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="creation")}}
+            assert "successful" not in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_write_none_result_returns_fallback_string(self):
@@ -78,8 +78,8 @@ class TestWritePrivateTask:
                 "creation",
             )
 
-            assert result == ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="creation")
-            assert "successful" not in result
+            assert result == {"error": {"code": "INTERNAL", "message": ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="creation")}}
+            assert "successful" not in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_write_401_returns_auth_failed(self):
@@ -93,7 +93,8 @@ class TestWritePrivateTask:
                 "creation",
             )
 
-            assert "Authentication failed" in result
+            assert result["error"]["code"] == "AUTH"
+            assert "Authentication failed" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_write_403_returns_access_denied(self):
@@ -107,7 +108,8 @@ class TestWritePrivateTask:
                 "update",
             )
 
-            assert "Access denied" in result
+            assert result["error"]["code"] == "FORBIDDEN"
+            assert "Access denied" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_write_400_returns_invalid_request(self):
@@ -121,7 +123,8 @@ class TestWritePrivateTask:
                 "creation",
             )
 
-            assert "Invalid request" in result
+            assert result["error"]["code"] == "VALIDATION"
+            assert "Invalid request" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_write_404_returns_not_found(self):
@@ -135,7 +138,8 @@ class TestWritePrivateTask:
                 "update",
             )
 
-            assert "not found" in result
+            assert result["error"]["code"] == "NOT_FOUND"
+            assert "not found" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_write_500_returns_server_error(self):
@@ -149,7 +153,8 @@ class TestWritePrivateTask:
                 "creation",
             )
 
-            assert "server error" in result.lower()
+            assert result["error"]["code"] == "HTTP"
+            assert "server error" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_write_generic_exception_returns_request_failed(self):
@@ -163,7 +168,8 @@ class TestWritePrivateTask:
                 "deletion",
             )
 
-            assert "request failed" in result.lower()
+            assert result["error"]["code"] == "INTERNAL"
+            assert "request failed" in result["error"]["message"].lower()
 
 
 class TestUnwrapWriteResponse:
@@ -171,22 +177,23 @@ class TestUnwrapWriteResponse:
 
     def test_unwrap_with_inner_result(self):
         result = _unwrap_write_response({"result": {"number": "VTB0001"}}, "creation")
-        assert result == {"number": "VTB0001"}
+        assert result["record"] == {"number": "VTB0001"}
 
     def test_unwrap_empty_dict_is_unconfirmed_not_success(self):
         """An empty write response cannot establish that the write landed."""
         result = _unwrap_write_response({}, "creation")
-        assert result == ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="creation")
-        assert "successful" not in result
+        assert result == {"error": {"code": "INTERNAL", "message": ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="creation")}}
+        assert "successful" not in result["error"]["message"]
 
     def test_unwrap_none_is_unconfirmed_not_success(self):
         result = _unwrap_write_response(None, "update")
-        assert result == ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="update")
-        assert "successful" not in result
+        assert result == {"error": {"code": "INTERNAL", "message": ERROR_PRIVATE_TASK_WRITE_UNCONFIRMED.format(operation="update")}}
+        assert "successful" not in result["error"]["message"]
 
-    def test_unwrap_dict_without_result_key(self):
+    def test_unwrap_dict_without_result_key_is_unconfirmed(self):
+        """A 2xx body with no `result` key is not a confirmed record — unconfirmed."""
         result = _unwrap_write_response({"some": "value"}, "creation")
-        assert result == {"some": "value"}
+        assert result["error"]["code"] == "INTERNAL"
 
 
 class TestHttpErrorHandler:
@@ -204,7 +211,8 @@ class TestHttpErrorHandler:
     )
     def test_handle_http_error(self, status_code, operation, expected, case_insensitive):
         result = _handle_http_error(_make_http_status_error(status_code), operation)
-        haystack = result.lower() if case_insensitive else result
+        message = result["error"]["message"]
+        haystack = message.lower() if case_insensitive else message
         assert expected in haystack
 
 
@@ -333,7 +341,7 @@ class TestCreatePrivateTask:
             task_data = {"short_description": "Test task"}
             result = await create_private_task(task_data)
 
-            assert result["number"] == "VTB0001234"
+            assert result["record"]["number"] == "VTB0001234"
             mock_request.assert_called_once()
             kwargs = mock_request.call_args.kwargs
             assert kwargs["method"] == "POST"
@@ -345,7 +353,8 @@ class TestCreatePrivateTask:
 
         result = await create_private_task(task_data)
 
-        assert "short_description is required" in result
+        assert result["error"]["code"] == "VALIDATION"
+        assert "short_description is required" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_create_private_task_with_all_fields(self):
@@ -365,7 +374,7 @@ class TestCreatePrivateTask:
 
             result = await create_private_task(task_data)
 
-            assert result["number"] == "VTB0001234"
+            assert result["record"]["number"] == "VTB0001234"
             mock_request.assert_called_once()
 
 
@@ -386,8 +395,8 @@ class TestUpdatePrivateTask:
             update_data = {"state": "3"}
             result = await update_private_task("VTB0001234", update_data)
 
-            assert result["number"] == "VTB0001234"
-            assert result["state"] == "3"
+            assert result["record"]["number"] == "VTB0001234"
+            assert result["record"]["state"] == "3"
             mock_sys_id.assert_called_once_with("VTB0001234")
             mock_request.assert_called_once()
             kwargs = mock_request.call_args.kwargs
@@ -398,7 +407,8 @@ class TestUpdatePrivateTask:
         """Test update fails without update data."""
         result = await update_private_task("VTB0001234", {})
 
-        assert "No update data provided" in result
+        assert result["error"]["code"] == "VALIDATION"
+        assert "No update data provided" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_update_private_task_not_found(self):
@@ -409,4 +419,5 @@ class TestUpdatePrivateTask:
             update_data = {"state": "3"}
             result = await update_private_task("VTB9999999", update_data)
 
-            assert "not found" in result
+            assert result["error"]["code"] == "NOT_FOUND"
+            assert "not found" in result["error"]["message"]


### PR DESCRIPTION
## Tier 3.1-rest — complete the §3.1 response contract across the tool surface

Stacked PR **1 of 3** for v5.0 "Boron" Tier 3. **Base: `main`.**

PR #72 put the response contract on CMDB only. This extends it to the whole registered surface, killing the last bare-string returns and the result-is-sometimes-a-dict polymorphism. Every tool now returns a shape from `Table_Tools/response.py`.

### 2a — reads
- `generic_table_tools`: list results via `list_response` (drop the `{"message": ...}` success dialect); `get_record_details` → `record_response` (`{"record": {...}|None}`, the arity fix); priority-path error strings → `error_response`.
- `generic_tool_wrappers`: table/identity validation + `filter_records` field-allowlist → `error_response("VALIDATION", ...)`.
- `consolidated_tools`: priority (incl. `include_metadata`), `get_kb_articles_by_state`, SLA tools normalise onto `list_response`.

### 2b — writes (hard write-API break)
- `write_helpers.map_http_error` → `error_response(code, message)` via a status→code map; `unwrap_write_response` → `record_response` on a confirmed write, `error_response("INTERNAL")` for the 2xx-empty unconfirmed case.
- `vtb_task_tools` / `kb_article_tools`: create/update/publish/retire successes → `{"record", "message"}`; batch tools + caps → `list_response`/`error_response`; publish normalizer reads `workflow_state` from `record`.

### Decisions (contract-dictated)
- `get_record` is single-record → `record_response`, not a 1-row list.
- write-unconfirmed (2xx, no body) is a failure → `error_response("INTERNAL")` (an empty response cannot establish the write landed).
- list successes drop the parallel `message` dialect.

Documented exceptions: `health_check` status bag, publish fail-closed guard/unconfirmed outcomes, partial-page rows+error.

### Tests
- NEW `tests/test_tool_response_contract.py` drives every tool in `tools.tools` through the real dispatcher (success + failure); derives the tool set from `tools.tools`.
- `tests/test_token_footprint.py` gains per-response envelope-overhead budgets (filter/search/get_record/CMDB) — the anti-meta-envelope guard.
- 93 existing shape assertions migrated.

**Suite: 1106 passed, 0 skipped.**
