### PR TITLE
refactor(v5.0): TableSpec — one source of truth per table (Tier 3.2)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -4,6 +4,13 @@ Constants used throughout the ServiceNow MCP server.
 
 import os
 
+# Per-table configuration is now defined once, in table_spec.TABLE_SPECS (v5.0
+# "Boron" Tier 3.2). The collections below (TABLE_CONFIGS, ESSENTIAL_FIELDS,
+# DETAIL_FIELDS, TABLE_ERROR_MESSAGES, TABLES_WITHOUT_RECORD_IDENTITY, the
+# text-search map) are DERIVED from it so existing `from constants import ...`
+# consumers are unaffected. Change a table there, not here.
+from table_spec import TABLE_SPECS, TableSpec
+
 # HTTP Content Types
 APPLICATION_JSON = "application/json"
 
@@ -182,17 +189,8 @@ KB_UPDATABLE_FIELDS = [
     "short_description", "text", "kb_category", "meta", "meta_description",
 ]
 
-# Table-specific error messages
-TABLE_ERROR_MESSAGES = {
-    "incident": "Incident not found.",
-    "change_request": "Change not found.",
-    "sc_req_item": "Request Item not found.",
-    "sc_task": "Service Catalog Task not found.",
-    "kb_knowledge": "Knowledge article not found.",
-    "vtb_task": "Private task not found.",
-    "universal_request": "Universal Request not found.",
-    "task_sla": "SLA record not found."
-}
+# Table-specific error messages (derived from TABLE_SPECS — Tier 3.2).
+TABLE_ERROR_MESSAGES = {name: spec.error_message for name, spec in TABLE_SPECS.items()}
 
 # ---------------------------------------------------------------------------
 # Text search and record identity
@@ -207,25 +205,31 @@ TEXT_SEARCH_FIELD = "short_description"
 # failure mode as the 1.2M-token get_sla_details bug). Dot-walk instead.
 TASK_SLA_TEXT_SEARCH_FIELD = "task.short_description"
 
-# Per-table override of the text-search field. Absent means TEXT_SEARCH_FIELD.
-# Config, not a branch in the query code: every path that free-text searches
-# resolves through this map, so a new table with an unusual description column
-# is one entry here rather than a fix in each call site. Getting it wrong is
-# silent — a condition on a missing field is dropped, not rejected.
+# Per-table free-text search field, derived from TABLE_SPECS (Tier 3.2). Getting
+# it wrong is silent — a condition on a missing field is dropped, not rejected —
+# which is why the field lives on the spec rather than being chosen per call site.
 TEXT_SEARCH_FIELD_BY_TABLE = {
-    "task_sla": TASK_SLA_TEXT_SEARCH_FIELD,
+    name: spec.text_search_field
+    for name, spec in TABLE_SPECS.items()
+    if spec.text_search_field != TEXT_SEARCH_FIELD
 }
 
 
 def text_search_field_for(table_name: str) -> str:
     """The field a free-text search must target for *table_name*."""
-    return TEXT_SEARCH_FIELD_BY_TABLE.get(table_name, TEXT_SEARCH_FIELD)
+    spec = TABLE_SPECS.get(table_name)
+    return spec.text_search_field if spec else TEXT_SEARCH_FIELD
 
 # Tables the number- and text-addressed generic tools cannot query at all.
-# task_sla has neither `number` (number_prefix is None) nor its own
-# `short_description`, so get_record / find_similar / search_records can only
-# build queries against fields that do not exist.
-TABLES_WITHOUT_RECORD_IDENTITY = frozenset({"task_sla"})
+# DERIVED from TABLE_SPECS (Tier 3.2): a spec with number_field=None has no
+# record identity, so it lands here structurally — a table can no longer be
+# addressable-by-number in one place and forgotten in this guard. task_sla has
+# neither `number` nor its own `short_description`, so get_record /
+# find_similar / search_records could only build queries against fields that do
+# not exist.
+TABLES_WITHOUT_RECORD_IDENTITY = frozenset(
+    name for name, spec in TABLE_SPECS.items() if not spec.has_record_identity
+)
 
 TABLE_LACKS_RECORD_IDENTITY = (
     "Table '{table}' has no 'number' or 'short_description' field, so this tool "
@@ -235,28 +239,11 @@ TABLE_LACKS_RECORD_IDENTITY = (
     "or filter_records('{table}', filters)."
 )
 
-# Table Field Definitions
-ESSENTIAL_FIELDS = {
-    "incident": ["number", "short_description", "priority", "state", "category", "sys_created_on"],
-    "change_request": ["number", "short_description", "priority", "state", "sys_created_on"],
-    "universal_request": ["number", "short_description", "priority", "state", "sys_created_on"],
-    "kb_knowledge": ["number", "short_description", "kb_category", "workflow_state", "sys_created_on"],
-    "vtb_task": ["number", "short_description", "priority", "state", "sys_created_on"],
-    "task_sla": ["task", "sla", "stage", "business_percentage", "active", "sys_created_on"],
-    "sc_req_item": ["number", "short_description", "priority", "state", "sys_created_on", "cat_item"],
-    "sc_task": ["number", "short_description", "priority", "state", "sys_created_on", "request_item"]
-}
+# Table field definitions, derived from TABLE_SPECS (Tier 3.2). Lists (not the
+# specs' tuples) to preserve the historical public type of these dicts.
+ESSENTIAL_FIELDS = {name: list(spec.essential_fields) for name, spec in TABLE_SPECS.items()}
 
-DETAIL_FIELDS = {
-    "incident": ["number", "short_description", "description", "priority", "state", "category", "sys_created_on", "sys_updated_on", "opened_at", "assigned_to", "assignment_group", "work_notes", "comments", "u_reference_1", "company", "cmdb_ci", "correlation_id", "major_incident_state"],
-    "change_request": ["number", "short_description", "description", "priority", "state", "sys_created_on", "sys_updated_on", "opened_at", "assigned_to", "assignment_group", "work_notes", "comments", "u_reference_1", "company", "cmdb_ci", "type", "urgency", "impact", "risk", "start_date", "end_date", "implementation_plan", "backout_plan", "test_plan", "u_communication"],
-    "universal_request": ["number", "short_description", "priority", "state", "sys_created_on", "sys_updated_on", "assigned_to", "assignment_group", "comments", "u_reference_1", "company", "cmdb_ci"],
-    "kb_knowledge": ["number", "short_description", "text", "kb_category", "workflow_state", "sys_created_on", "assigned_to", "meta", "meta_description"],
-    "vtb_task": ["number", "short_description", "priority", "state", "sys_created_on", "assigned_to", "assignment_group", "work_notes", "comments"],
-    "task_sla": ["task", "sla", "stage", "business_percentage", "active", "sys_created_on", "breach_time", "business_time_left", "duration", "has_breached", "business_duration", "business_elapsed_time", "planned_end_time"],
-    "sc_req_item": ["number", "short_description", "description", "priority", "state", "sys_created_on", "assigned_to", "assignment_group", "comments", "cat_item", "request", "stage"],
-    "sc_task": ["number", "short_description", "description", "priority", "state", "sys_created_on", "sys_updated_on", "opened_at", "assigned_to", "assignment_group", "comments", "request_item", "request"]
-}
+DETAIL_FIELDS = {name: list(spec.detail_fields) for name, spec in TABLE_SPECS.items()}
 
 # VTB Task specific field definitions
 COMMON_VTB_TASK_FIELDS = [
@@ -457,80 +444,20 @@ ENABLE_COMPLETE_QUERY = os.getenv("ENABLE_COMPLETE_QUERY", "false").strip().lowe
 # LogicMonitor integration caller sys_id, used for exclusion filters.
 LOGICMONITOR_CALLER_SYS_ID = os.getenv("LOGICMONITOR_CALLER_SYS_ID", "1727339e47d99190c43d3171e36d43ad")
 
-# ServiceNow table configurations
+# ServiceNow table configurations, derived from TABLE_SPECS (Tier 3.2). Same
+# dict-of-dicts shape and keys as before; api_name has always equalled the table
+# key. Consumers reading TABLE_CONFIGS[t]["number_prefix"] etc. are unchanged.
 TABLE_CONFIGS = {
-    "incident": {
-        "display_name": "Incident",
-        "api_name": "incident",
-        "supports_work_notes": True,
-        "supports_comments": True,
-        "number_prefix": "INC",
-        "priority_field": "priority",
-        "state_field": "state"
-    },
-    "change_request": {
-        "display_name": "Change Request", 
-        "api_name": "change_request",
-        "supports_work_notes": True,
-        "supports_comments": True,
-        "number_prefix": "CHG",
-        "priority_field": "priority",
-        "state_field": "state"
-    },
-    "sc_req_item": {
-        "display_name": "Service Catalog Request Item",
-        "api_name": "sc_req_item",
-        "supports_work_notes": False,
-        "supports_comments": True,
-        "number_prefix": "RITM",
-        "priority_field": "priority",
-        "state_field": "state"
-    },
-    "sc_task": {
-        "display_name": "Service Catalog Task",
-        "api_name": "sc_task",
-        "supports_work_notes": True,
-        "supports_comments": True,
-        "number_prefix": "SCTASK",
-        "priority_field": "priority",
-        "state_field": "state"
-    },
-    "universal_request": {
-        "display_name": "Universal Request",
-        "api_name": "universal_request",
-        "supports_work_notes": False,
-        "supports_comments": True,
-        "number_prefix": "UR",
-        "priority_field": "priority",
-        "state_field": "state"
-    },
-    "kb_knowledge": {
-        "display_name": "Knowledge Base Article",
-        "api_name": "kb_knowledge",
-        "supports_work_notes": False,
-        "supports_comments": False,
-        "number_prefix": "KB",
-        "priority_field": None,
-        "state_field": "workflow_state"
-    },
-    "vtb_task": {
-        "display_name": "Private Task",
-        "api_name": "vtb_task",
-        "supports_work_notes": True,
-        "supports_comments": True,
-        "number_prefix": "VTB",
-        "priority_field": "priority",
-        "state_field": "state"
-    },
-    "task_sla": {
-        "display_name": "Task SLA",
-        "api_name": "task_sla",
-        "supports_work_notes": False,
-        "supports_comments": False,
-        "number_prefix": None,
-        "priority_field": None,
-        "state_field": "stage"
+    name: {
+        "display_name": spec.display_name,
+        "api_name": name,
+        "supports_work_notes": spec.supports_work_notes,
+        "supports_comments": spec.supports_comments,
+        "number_prefix": spec.number_prefix,
+        "priority_field": spec.priority_field,
+        "state_field": spec.state_field,
     }
+    for name, spec in TABLE_SPECS.items()
 }
 
 # API endpoint patterns

--- a/constants.py
+++ b/constants.py
@@ -9,7 +9,11 @@ import os
 # DETAIL_FIELDS, TABLE_ERROR_MESSAGES, TABLES_WITHOUT_RECORD_IDENTITY, the
 # text-search map) are DERIVED from it so existing `from constants import ...`
 # consumers are unaffected. Change a table there, not here.
-from table_spec import TABLE_SPECS, TableSpec
+from table_spec import (
+    TABLE_SPECS,
+    DEFAULT_TEXT_SEARCH_FIELD,
+    TASK_SLA_TEXT_SEARCH_FIELD,
+)
 
 # HTTP Content Types
 APPLICATION_JSON = "application/json"
@@ -195,15 +199,14 @@ TABLE_ERROR_MESSAGES = {name: spec.error_message for name, spec in TABLE_SPECS.i
 # ---------------------------------------------------------------------------
 # Text search and record identity
 # ---------------------------------------------------------------------------
-# Default field the free-text search path matches against.
-TEXT_SEARCH_FIELD = "short_description"
-
-# task_sla carries no short_description of its own — the description lives on
-# the referenced task. A filter against a field a table does not have is
-# SILENTLY DROPPED by ServiceNow, so searching short_description on task_sla
-# produced an unfiltered page of arbitrary SLAs labelled as matches (the same
-# failure mode as the 1.2M-token get_sla_details bug). Dot-walk instead.
-TASK_SLA_TEXT_SEARCH_FIELD = "task.short_description"
+# Free-text search fields come from table_spec's SSOT literals (Tier 3.2) so the
+# public constants and the specs cannot drift. TASK_SLA_TEXT_SEARCH_FIELD is
+# already bound in this namespace by the table_spec import above; TEXT_SEARCH_FIELD
+# aliases the shared default. task_sla carries no short_description of its own — the
+# description lives on the referenced task; a filter against a field a table lacks
+# is SILENTLY DROPPED by ServiceNow (the 1.2M-token get_sla_details failure mode),
+# so it dot-walks instead.
+TEXT_SEARCH_FIELD = DEFAULT_TEXT_SEARCH_FIELD
 
 # Per-table free-text search field, derived from TABLE_SPECS (Tier 3.2). Getting
 # it wrong is silent — a condition on a missing field is dropped, not rejected —

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -35,6 +35,7 @@ ROOT_FILES = [
     "audit_middleware.py",
     "auth_middleware.py",
     "param_coercion.py",
+    "table_spec.py",
     "manifest.json",
     "pyproject.toml",
     "LICENSE",

--- a/table_spec.py
+++ b/table_spec.py
@@ -1,0 +1,205 @@
+"""One spec per supported table — the single source of truth (v5.0 "Boron" Tier 3.2).
+
+Before this, a table's configuration was scattered across five collections in
+`constants.py`: `TABLE_CONFIGS`, `ESSENTIAL_FIELDS`, `DETAIL_FIELDS`,
+`TABLE_ERROR_MESSAGES`, and the `TABLES_WITHOUT_RECORD_IDENTITY` / text-search
+maps. Commit cf2d7e2 ("allow meta and meta_description on knowledge article
+updates") needed coordinated edits to three of them for one logical change, and
+nothing stopped a table being added to one and forgotten in another.
+
+`TABLE_SPECS` collapses all of it into one `TableSpec` per table. `constants.py`
+derives the old dicts from it (compatibility views — every existing
+`from constants import ESSENTIAL_FIELDS` still works), so the surface is
+unchanged; only the source of truth moved. Change a table in exactly one place.
+
+The `task_sla` foot-gun is now structural, not a hand-maintained exclusion list:
+`number_field=None` means "cannot be addressed by number", and
+`TABLES_WITHOUT_RECORD_IDENTITY` is *derived* from that. A table with no number
+field cannot be left out of the guard, because the guard IS the set of
+number_field-less specs. (task_sla has no `number` and no `short_description` of
+its own — a filter against either is silently dropped by ServiceNow, the same
+failure mode as the 1.2M-token get_sla_details bug.)
+
+`tests/test_table_spec.py` pins the key-set consistency the scattered dicts never
+had: every derived view has exactly the TABLE_SPECS key set, and each spec is
+well-formed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+# Default free-text search column, and the task_sla dot-walk override. task_sla
+# carries no short_description of its own — the text lives on the referenced task.
+_DEFAULT_TEXT_SEARCH_FIELD = "short_description"
+_TASK_SLA_TEXT_SEARCH_FIELD = "task.short_description"
+
+
+@dataclass(frozen=True)
+class TableSpec:
+    """Everything the server needs to know about one ServiceNow table.
+
+    `number_field` is the structural identity marker: `None` means the table
+    cannot be addressed by a record number (task_sla), which is what makes the
+    number-/text-addressed generic tools refuse it up front rather than build a
+    query against a field that does not exist.
+    """
+    key: str
+    display_name: str
+    number_prefix: Optional[str]
+    number_field: Optional[str]
+    priority_field: Optional[str]
+    state_field: str
+    text_search_field: str
+    supports_work_notes: bool
+    supports_comments: bool
+    essential_fields: Tuple[str, ...]
+    detail_fields: Tuple[str, ...]
+    error_message: str
+
+    @property
+    def has_record_identity(self) -> bool:
+        """True when the table can be addressed by a record number."""
+        return self.number_field is not None
+
+
+def _spec(**kwargs) -> TableSpec:
+    # Every table addressable by number uses the literal `number` field, and
+    # short_description as its text-search column; the two exceptions (task_sla)
+    # pass explicit values. Defaults keep the registry below readable.
+    kwargs.setdefault("number_field", "number")
+    kwargs.setdefault("text_search_field", _DEFAULT_TEXT_SEARCH_FIELD)
+    return TableSpec(**kwargs)
+
+
+TABLE_SPECS = {
+    "incident": _spec(
+        key="incident",
+        display_name="Incident",
+        number_prefix="INC",
+        priority_field="priority",
+        state_field="state",
+        supports_work_notes=True,
+        supports_comments=True,
+        essential_fields=("number", "short_description", "priority", "state", "category", "sys_created_on"),
+        detail_fields=(
+            "number", "short_description", "description", "priority", "state", "category",
+            "sys_created_on", "sys_updated_on", "opened_at", "assigned_to", "assignment_group",
+            "work_notes", "comments", "u_reference_1", "company", "cmdb_ci", "correlation_id",
+            "major_incident_state",
+        ),
+        error_message="Incident not found.",
+    ),
+    "change_request": _spec(
+        key="change_request",
+        display_name="Change Request",
+        number_prefix="CHG",
+        priority_field="priority",
+        state_field="state",
+        supports_work_notes=True,
+        supports_comments=True,
+        essential_fields=("number", "short_description", "priority", "state", "sys_created_on"),
+        detail_fields=(
+            "number", "short_description", "description", "priority", "state", "sys_created_on",
+            "sys_updated_on", "opened_at", "assigned_to", "assignment_group", "work_notes",
+            "comments", "u_reference_1", "company", "cmdb_ci", "type", "urgency", "impact", "risk",
+            "start_date", "end_date", "implementation_plan", "backout_plan", "test_plan",
+            "u_communication",
+        ),
+        error_message="Change not found.",
+    ),
+    "sc_req_item": _spec(
+        key="sc_req_item",
+        display_name="Service Catalog Request Item",
+        number_prefix="RITM",
+        priority_field="priority",
+        state_field="state",
+        supports_work_notes=False,
+        supports_comments=True,
+        essential_fields=("number", "short_description", "priority", "state", "sys_created_on", "cat_item"),
+        detail_fields=(
+            "number", "short_description", "description", "priority", "state", "sys_created_on",
+            "assigned_to", "assignment_group", "comments", "cat_item", "request", "stage",
+        ),
+        error_message="Request Item not found.",
+    ),
+    "sc_task": _spec(
+        key="sc_task",
+        display_name="Service Catalog Task",
+        number_prefix="SCTASK",
+        priority_field="priority",
+        state_field="state",
+        supports_work_notes=True,
+        supports_comments=True,
+        essential_fields=("number", "short_description", "priority", "state", "sys_created_on", "request_item"),
+        detail_fields=(
+            "number", "short_description", "description", "priority", "state", "sys_created_on",
+            "sys_updated_on", "opened_at", "assigned_to", "assignment_group", "comments",
+            "request_item", "request",
+        ),
+        error_message="Service Catalog Task not found.",
+    ),
+    "universal_request": _spec(
+        key="universal_request",
+        display_name="Universal Request",
+        number_prefix="UR",
+        priority_field="priority",
+        state_field="state",
+        supports_work_notes=False,
+        supports_comments=True,
+        essential_fields=("number", "short_description", "priority", "state", "sys_created_on"),
+        detail_fields=(
+            "number", "short_description", "priority", "state", "sys_created_on", "sys_updated_on",
+            "assigned_to", "assignment_group", "comments", "u_reference_1", "company", "cmdb_ci",
+        ),
+        error_message="Universal Request not found.",
+    ),
+    "kb_knowledge": _spec(
+        key="kb_knowledge",
+        display_name="Knowledge Base Article",
+        number_prefix="KB",
+        priority_field=None,
+        state_field="workflow_state",
+        supports_work_notes=False,
+        supports_comments=False,
+        essential_fields=("number", "short_description", "kb_category", "workflow_state", "sys_created_on"),
+        detail_fields=(
+            "number", "short_description", "text", "kb_category", "workflow_state",
+            "sys_created_on", "assigned_to", "meta", "meta_description",
+        ),
+        error_message="Knowledge article not found.",
+    ),
+    "vtb_task": _spec(
+        key="vtb_task",
+        display_name="Private Task",
+        number_prefix="VTB",
+        priority_field="priority",
+        state_field="state",
+        supports_work_notes=True,
+        supports_comments=True,
+        essential_fields=("number", "short_description", "priority", "state", "sys_created_on"),
+        detail_fields=(
+            "number", "short_description", "priority", "state", "sys_created_on", "assigned_to",
+            "assignment_group", "work_notes", "comments",
+        ),
+        error_message="Private task not found.",
+    ),
+    "task_sla": _spec(
+        key="task_sla",
+        display_name="Task SLA",
+        number_prefix=None,
+        number_field=None,  # no record number -> structurally lacks record identity
+        priority_field=None,
+        state_field="stage",
+        text_search_field=_TASK_SLA_TEXT_SEARCH_FIELD,  # no short_description of its own
+        supports_work_notes=False,
+        supports_comments=False,
+        essential_fields=("task", "sla", "stage", "business_percentage", "active", "sys_created_on"),
+        detail_fields=(
+            "task", "sla", "stage", "business_percentage", "active", "sys_created_on", "breach_time",
+            "business_time_left", "duration", "has_breached", "business_duration",
+            "business_elapsed_time", "planned_end_time",
+        ),
+        error_message="SLA record not found.",
+    ),
+}

--- a/table_spec.py
+++ b/table_spec.py
@@ -27,12 +27,17 @@ well-formed.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Optional, Tuple
 
 # Default free-text search column, and the task_sla dot-walk override. task_sla
 # carries no short_description of its own — the text lives on the referenced task.
-_DEFAULT_TEXT_SEARCH_FIELD = "short_description"
-_TASK_SLA_TEXT_SEARCH_FIELD = "task.short_description"
+# Public (not underscored) because constants.TEXT_SEARCH_FIELD /
+# TASK_SLA_TEXT_SEARCH_FIELD are derived from these SAME literals — the exact
+# columns whose mismatch historically caused silent ServiceNow drops live in one
+# place, not two independent copies.
+DEFAULT_TEXT_SEARCH_FIELD = "short_description"
+TASK_SLA_TEXT_SEARCH_FIELD = "task.short_description"
 
 
 @dataclass(frozen=True)
@@ -62,17 +67,45 @@ class TableSpec:
         """True when the table can be addressed by a record number."""
         return self.number_field is not None
 
+    def __post_init__(self) -> None:
+        """Enforce the number_field / number_prefix co-movement invariant.
+
+        The old hand-maintained exclusion list implicitly tied "no number" to "no
+        prefix". Splitting them into two fields would let a future edit desync
+        them — `number_prefix="X"` with `number_field=None` (guard refuses
+        identity tools while the prefix looks real), or the reverse. Both are
+        nonsense; refuse them at construction so `has_record_identity` and the
+        prefix consumers can never disagree.
+        """
+        if (self.number_field is None) != (self.number_prefix is None):
+            raise ValueError(
+                f"{self.key}: number_field and number_prefix must both be set "
+                f"or both be None (got number_field={self.number_field!r}, "
+                f"number_prefix={self.number_prefix!r})"
+            )
+        if self.number_field is not None:
+            if self.number_field != "number":
+                raise ValueError(
+                    f"{self.key}: an addressable table's number_field must be "
+                    f"'number', got {self.number_field!r}"
+                )
+            if not self.number_prefix:
+                raise ValueError(f"{self.key}: an addressable table needs a non-empty number_prefix")
+
 
 def _spec(**kwargs) -> TableSpec:
     # Every table addressable by number uses the literal `number` field, and
     # short_description as its text-search column; the two exceptions (task_sla)
     # pass explicit values. Defaults keep the registry below readable.
     kwargs.setdefault("number_field", "number")
-    kwargs.setdefault("text_search_field", _DEFAULT_TEXT_SEARCH_FIELD)
+    kwargs.setdefault("text_search_field", DEFAULT_TEXT_SEARCH_FIELD)
     return TableSpec(**kwargs)
 
 
-TABLE_SPECS = {
+# Read-only mapping: the SSOT registry is the one structure that most benefits
+# from immutability, since constants.py snapshots derived views at import — an
+# accidental TABLE_SPECS[...] = ... / .pop after import would desync them.
+TABLE_SPECS = MappingProxyType({
     "incident": _spec(
         key="incident",
         display_name="Incident",
@@ -191,7 +224,7 @@ TABLE_SPECS = {
         number_field=None,  # no record number -> structurally lacks record identity
         priority_field=None,
         state_field="stage",
-        text_search_field=_TASK_SLA_TEXT_SEARCH_FIELD,  # no short_description of its own
+        text_search_field=TASK_SLA_TEXT_SEARCH_FIELD,  # no short_description of its own
         supports_work_notes=False,
         supports_comments=False,
         essential_fields=("task", "sla", "stage", "business_percentage", "active", "sys_created_on"),
@@ -202,4 +235,4 @@ TABLE_SPECS = {
         ),
         error_message="SLA record not found.",
     ),
-}
+})

--- a/tests/test_pyproject_sync.py
+++ b/tests/test_pyproject_sync.py
@@ -7,6 +7,8 @@ and declared user config. A drift here silently ships a broken extension.
 """
 from __future__ import annotations
 
+import ast
+import importlib.util
 import json
 import re
 import tomllib
@@ -15,6 +17,35 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_build_mcpb():
+    spec = importlib.util.spec_from_file_location(
+        "build_mcpb", REPO_ROOT / "scripts" / "build_mcpb.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _local_top_level_names() -> set[str]:
+    """Repo-local importable top-level names: root .py modules + packages."""
+    names = {p.stem for p in REPO_ROOT.glob("*.py")}
+    for d in REPO_ROOT.iterdir():
+        if d.is_dir() and (d / "__init__.py").is_file():
+            names.add(d.name)
+    return names
+
+
+def _top_level_imports(py_path: Path) -> set[str]:
+    tree = ast.parse(py_path.read_text(encoding="utf-8"))
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            out.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            out.add(node.module.split(".")[0])
+    return out
 
 
 def _load_pyproject() -> dict:
@@ -62,6 +93,35 @@ def test_versions_aligned():
     assert manifest_v == pyproject_v == main_v, (
         f"version mismatch: manifest={manifest_v}, "
         f"pyproject={pyproject_v}, __version__={main_v}"
+    )
+
+
+@pytest.mark.unit
+def test_every_root_import_of_a_local_module_is_staged():
+    """Every repo-local module a staged root file imports must itself be staged.
+
+    The .mcpb bundle copies only ROOT_FILES + PACKAGE_DIRS. A root file that
+    imports a repo-local module which is NOT staged ships a bundle that fails at
+    import (ModuleNotFoundError) — e.g. constants.py importing table_spec without
+    table_spec.py in ROOT_FILES. This scan is the guard that class of bug lacked.
+    """
+    build = _load_build_mcpb()
+    staged = {f[:-3] for f in build.ROOT_FILES if f.endswith(".py")} | set(build.PACKAGE_DIRS)
+    local = _local_top_level_names()
+
+    missing: dict[str, set[str]] = {}
+    for name in build.ROOT_FILES:
+        if not name.endswith(".py"):
+            continue
+        for imported in _top_level_imports(REPO_ROOT / name):
+            if imported in local and imported not in staged:
+                missing.setdefault(name, set()).add(imported)
+
+    assert not missing, (
+        "staged root file(s) import a repo-local module that is NOT staged into "
+        "the .mcpb bundle — add it to ROOT_FILES (or PACKAGE_DIRS) in "
+        f"scripts/build_mcpb.py: {{k: sorted(v) for k, v in missing.items()}}"
+        f"\n  {dict((k, sorted(v)) for k, v in missing.items())}"
     )
 
 

--- a/tests/test_table_spec.py
+++ b/tests/test_table_spec.py
@@ -1,0 +1,92 @@
+"""TableSpec consistency (v5.0 "Boron" Tier 3.2).
+
+The scattered per-table dicts never had this: nothing forced TABLE_CONFIGS,
+ESSENTIAL_FIELDS, DETAIL_FIELDS and TABLE_ERROR_MESSAGES to describe the SAME set
+of tables, so a table could be added to one and forgotten in another (the class
+of coordination bug cf2d7e2 hit). Now they are all derived from TABLE_SPECS;
+these tests pin that the derivation stays faithful and every spec is well-formed.
+"""
+from __future__ import annotations
+
+import constants as c
+from table_spec import TABLE_SPECS, TableSpec
+
+_SPEC_KEYS = set(TABLE_SPECS)
+
+
+class TestKeySetConsistency:
+    """Every derived view covers exactly the TABLE_SPECS table set."""
+
+    def test_derived_dicts_share_the_spec_key_set(self):
+        for name, view in [
+            ("TABLE_CONFIGS", c.TABLE_CONFIGS),
+            ("ESSENTIAL_FIELDS", c.ESSENTIAL_FIELDS),
+            ("DETAIL_FIELDS", c.DETAIL_FIELDS),
+            ("TABLE_ERROR_MESSAGES", c.TABLE_ERROR_MESSAGES),
+        ]:
+            assert set(view) == _SPEC_KEYS, f"{name} key set drifted from TABLE_SPECS"
+
+    def test_registry_key_matches_spec_key_field(self):
+        for name, spec in TABLE_SPECS.items():
+            assert spec.key == name, f"{name}: spec.key={spec.key!r} disagrees with its registry key"
+
+    def test_table_configs_api_name_equals_key(self):
+        for name, cfg in c.TABLE_CONFIGS.items():
+            assert cfg["api_name"] == name
+
+
+class TestStructuralIdentityGuard:
+    """The task_sla foot-gun is derived from number_field, not a hand list."""
+
+    def test_identity_guard_is_the_set_of_number_field_less_specs(self):
+        expected = frozenset(n for n, s in TABLE_SPECS.items() if s.number_field is None)
+        assert c.TABLES_WITHOUT_RECORD_IDENTITY == expected
+
+    def test_task_sla_has_no_record_identity(self):
+        assert TABLE_SPECS["task_sla"].number_field is None
+        assert not TABLE_SPECS["task_sla"].has_record_identity
+        assert "task_sla" in c.TABLES_WITHOUT_RECORD_IDENTITY
+
+    def test_every_other_table_has_record_identity(self):
+        for name, spec in TABLE_SPECS.items():
+            if name == "task_sla":
+                continue
+            assert spec.number_field == "number", name
+            assert spec.has_record_identity
+            assert name not in c.TABLES_WITHOUT_RECORD_IDENTITY
+
+
+class TestSpecWellFormed:
+    """Each spec carries the fields consumers rely on, with sane types."""
+
+    def test_every_spec_is_a_tablespec(self):
+        assert all(isinstance(s, TableSpec) for s in TABLE_SPECS.values())
+
+    def test_required_string_fields_present(self):
+        for name, spec in TABLE_SPECS.items():
+            assert spec.display_name and isinstance(spec.display_name, str), name
+            assert spec.state_field and isinstance(spec.state_field, str), name
+            assert spec.text_search_field and isinstance(spec.text_search_field, str), name
+            assert spec.error_message.endswith("."), name
+
+    def test_field_lists_are_non_empty_and_start_with_essentials_subset(self):
+        for name, spec in TABLE_SPECS.items():
+            assert spec.essential_fields, name
+            assert spec.detail_fields, name
+            # Essentials should be a subset of detail (detail is the superset view).
+            missing = set(spec.essential_fields) - set(spec.detail_fields)
+            assert not missing, f"{name}: essential fields missing from detail: {missing}"
+
+    def test_optional_fields_typed_none_or_str(self):
+        for name, spec in TABLE_SPECS.items():
+            for attr in ("number_prefix", "number_field", "priority_field"):
+                val = getattr(spec, attr)
+                assert val is None or isinstance(val, str), f"{name}.{attr}"
+
+    def test_text_search_field_default_or_dotwalk(self):
+        # A table searches its own short_description unless it dot-walks (task_sla).
+        for name, spec in TABLE_SPECS.items():
+            if name == "task_sla":
+                assert "." in spec.text_search_field
+            else:
+                assert spec.text_search_field == c.TEXT_SEARCH_FIELD

--- a/tests/test_table_spec.py
+++ b/tests/test_table_spec.py
@@ -8,6 +8,8 @@ these tests pin that the derivation stays faithful and every spec is well-formed
 """
 from __future__ import annotations
 
+import pytest
+
 import constants as c
 from table_spec import TABLE_SPECS, TableSpec
 
@@ -87,6 +89,85 @@ class TestSpecWellFormed:
         # A table searches its own short_description unless it dot-walks (task_sla).
         for name, spec in TABLE_SPECS.items():
             if name == "task_sla":
-                assert "." in spec.text_search_field
+                assert spec.text_search_field == c.TASK_SLA_TEXT_SEARCH_FIELD == "task.short_description"
             else:
-                assert spec.text_search_field == c.TEXT_SEARCH_FIELD
+                assert spec.text_search_field == c.TEXT_SEARCH_FIELD == "short_description"
+
+
+class TestDerivationFidelity:
+    """Each derived collection maps the CORRECT spec attribute — not just the right
+    key set. A wrong wiring in constants.py (error_message→display_name, swapped
+    essential/detail, wrong supports_* field) would pass the key-set tests but
+    break consumers; this locks the byte-identical-vs-HEAD claim structurally."""
+
+    def test_field_lists_derived_correctly(self):
+        for name, spec in TABLE_SPECS.items():
+            assert c.ESSENTIAL_FIELDS[name] == list(spec.essential_fields), name
+            assert c.DETAIL_FIELDS[name] == list(spec.detail_fields), name
+
+    def test_error_messages_derived_correctly(self):
+        for name, spec in TABLE_SPECS.items():
+            assert c.TABLE_ERROR_MESSAGES[name] == spec.error_message, name
+
+    def test_table_configs_fields_derived_correctly(self):
+        for name, spec in TABLE_SPECS.items():
+            cfg = c.TABLE_CONFIGS[name]
+            assert cfg["api_name"] == name, name
+            assert cfg["display_name"] == spec.display_name, name
+            assert cfg["number_prefix"] == spec.number_prefix, name
+            assert cfg["priority_field"] == spec.priority_field, name
+            assert cfg["state_field"] == spec.state_field, name
+            assert cfg["supports_work_notes"] == spec.supports_work_notes, name
+            assert cfg["supports_comments"] == spec.supports_comments, name
+
+    def test_text_search_map_is_the_non_default_overrides(self):
+        for name, spec in TABLE_SPECS.items():
+            assert c.text_search_field_for(name) == spec.text_search_field, name
+        overrides = {
+            n: s.text_search_field
+            for n, s in TABLE_SPECS.items()
+            if s.text_search_field != c.TEXT_SEARCH_FIELD
+        }
+        assert c.TEXT_SEARCH_FIELD_BY_TABLE == overrides
+
+
+class TestConstructionInvariants:
+    """__post_init__ refuses number_field / number_prefix desync, and the registry
+    is read-only so derived views cannot silently drift from it."""
+
+    def test_prefix_without_number_field_is_rejected(self):
+        with pytest.raises(ValueError):
+            TableSpec(
+                key="x", display_name="X", number_prefix="X", number_field=None,
+                priority_field=None, state_field="state",
+                text_search_field="short_description",
+                supports_work_notes=False, supports_comments=False,
+                essential_fields=("number",), detail_fields=("number",),
+                error_message="X not found.",
+            )
+
+    def test_number_field_without_prefix_is_rejected(self):
+        with pytest.raises(ValueError):
+            TableSpec(
+                key="x", display_name="X", number_prefix=None, number_field="number",
+                priority_field=None, state_field="state",
+                text_search_field="short_description",
+                supports_work_notes=False, supports_comments=False,
+                essential_fields=("number",), detail_fields=("number",),
+                error_message="X not found.",
+            )
+
+    def test_non_number_identity_field_is_rejected(self):
+        with pytest.raises(ValueError):
+            TableSpec(
+                key="x", display_name="X", number_prefix="X", number_field="task",
+                priority_field=None, state_field="state",
+                text_search_field="short_description",
+                supports_work_notes=False, supports_comments=False,
+                essential_fields=("number",), detail_fields=("number",),
+                error_message="X not found.",
+            )
+
+    def test_registry_is_read_only(self):
+        with pytest.raises(TypeError):
+            TABLE_SPECS["incident"] = None  # type: ignore[index]


### PR DESCRIPTION
## Tier 3.2 — TableSpec: one source of truth per table

Stacked PR **2 of 3** for v5.0 "Boron" Tier 3. **Base: `feature/v5.0_response-contract-rest`** (merge PR 1 first).

Per-table config was scattered across five collections in `constants.py`. `cf2d7e2` needed coordinated edits to three of them for one logical change, and nothing forced them to describe the same table set.

New `table_spec.TABLE_SPECS` collapses it into one `TableSpec` per table. `constants.py` now **derives** the five collections (`TABLE_CONFIGS`, `ESSENTIAL_FIELDS`, `DETAIL_FIELDS`, `TABLE_ERROR_MESSAGES`, `TABLES_WITHOUT_RECORD_IDENTITY` + text-search map) from it — same shapes, same keys, **byte-identical values (verified against HEAD)**. Every `from constants import ...` consumer is unchanged.

The `task_sla` record-identity foot-gun is now **structural**: `number_field=None` means "no record number", and `TABLES_WITHOUT_RECORD_IDENTITY` is derived as the set of number_field-less specs — a table with no number field cannot be left out of the guard.

NEW `tests/test_table_spec.py` pins the key-set consistency the scattered dicts never had, the derived identity guard, and per-spec well-formedness.

**Suite: 1117 passed.** No behavior change; no consumer edits.
