### PR TITLE
refactor(v5.0): tool-guidance registry + footer injection (Tier 3.3)

### DIFF
--- a/Table_Tools/cmdb_tools.py
+++ b/Table_Tools/cmdb_tools.py
@@ -62,7 +62,6 @@ _CI_TYPE_PATTERN = re.compile(r'cmdb_ci[a-z0-9_]*')
 #     no `partial` shape in this module; `truncated` is len == the limit.
 # ---------------------------------------------------------------------------
 
-
 def _ci_type_error(ci_type: str) -> Optional[str]:
     """Return an error message if ci_type is not a usable cmdb_ci* table, else None.
 
@@ -74,7 +73,6 @@ def _ci_type_error(ci_type: str) -> Optional[str]:
     if not _CI_TYPE_PATTERN.fullmatch(ci_type):
         return INVALID_CI_TYPE.format(ci_type=ci_type)
     return None
-
 
 # Essential fields for CI discovery
 ESSENTIAL_CI_FIELDS = [
@@ -93,11 +91,6 @@ DETAILED_CI_FIELDS = [
 async def find_cis_by_type(ci_type: str, detailed: bool = False) -> Dict[str, Any]:
     """Find all Configuration Items of a specific type/class.
 
-    WHEN TO USE: the user names a CI class — "list every Linux server
-        configuration item".
-    WHEN NOT TO USE: searching by attributes like location/IP/status
-        (search_cis_by_attributes); one CI by number (get_ci_details).
-    PREFER OVER: search_cis_by_attributes when the filter is purely the class.
     TABLES: any cmdb_ci* class table.
     SIDE EFFECT: read-only.
     EXAMPLE: list every Linux server configuration item.
@@ -147,11 +140,6 @@ async def search_cis_by_attributes(
 ) -> Dict[str, Any]:
     """Search Configuration Items by multiple attributes.
 
-    WHEN TO USE: the user filters CIs by attribute — location, IP, status,
-        name — "configuration items at location Brussels with status installed".
-    WHEN NOT TO USE: a whole class with no attribute filter (find_cis_by_type);
-        one CI by number (get_ci_details).
-    PREFER OVER: find_cis_by_type when the ask includes location/IP/status.
     TABLES: cmdb_ci (or a given cmdb_ci* class).
     SIDE EFFECT: read-only.
     EXAMPLE: configuration items at location Brussels with status installed.
@@ -243,15 +231,9 @@ async def _probe_ci_table(table: str, ci_number: str) -> Optional[Dict[str, Any]
         return data['result'][0]
     return None
 
-
 async def get_ci_details(ci_number: str, ci_type: Optional[str] = None) -> Dict[str, Any]:
     """Get comprehensive details for a specific Configuration Item by number.
 
-    WHEN TO USE: you know the CI number and want its complete record — "get all
-        details for configuration item SRV0001234".
-    WHEN NOT TO USE: searching by class (find_cis_by_type) or attributes
-        (search_cis_by_attributes); a loose name/IP lookup (quick_ci_search).
-    PREFER OVER: quick_ci_search when you have an exact CI number.
     TABLES: probes the cmdb_ci* class tables (most-specific first).
     SIDE EFFECT: read-only.
     EXAMPLE: get all details for configuration item SRV0001234.
@@ -355,11 +337,6 @@ def _build_similar_ci_response(ci_number: str, search_attrs: Dict, filtered_resu
 async def similar_cis_for_ci(ci_number: str) -> Dict[str, Any]:
     """Find Configuration Items similar to a given CI, by shared attributes.
 
-    WHEN TO USE: you have one CI and want others like it (same class, location,
-        status).
-    WHEN NOT TO USE: attribute search from scratch (search_cis_by_attributes);
-        one CI's own detail (get_ci_details).
-    PREFER OVER: search_cis_by_attributes when the seed is an existing CI.
     TABLES: cmdb_ci* class tables.
     SIDE EFFECT: read-only.
     EXAMPLE: find configuration items similar to CI0001000.
@@ -430,11 +407,6 @@ async def similar_cis_for_ci(ci_number: str) -> Dict[str, Any]:
 async def get_all_ci_types() -> Dict[str, Any]:
     """Get all available CI types/classes in the CMDB.
 
-    WHEN TO USE: the user wants the list of CI classes this instance defines —
-        "which CI classes exist in this CMDB".
-    WHEN NOT TO USE: rows of one class (find_cis_by_type); a specific CI
-        (get_ci_details).
-    PREFER OVER: nothing; this is the class-discovery path.
     TABLES: sys_db_object (live class list).
     SIDE EFFECT: read-only.
     EXAMPLE: which CI classes exist in this CMDB.
@@ -477,10 +449,6 @@ async def get_all_ci_types() -> Dict[str, Any]:
 async def quick_ci_search(search_term: str) -> Dict[str, Any]:
     """Quick search for CIs by name, IP, or number (OR across all three).
 
-    WHEN TO USE: you have one loose term and don't know which field it is.
-    WHEN NOT TO USE: an exact CI number (get_ci_details); structured attribute
-        filters (search_cis_by_attributes); a whole class (find_cis_by_type).
-    PREFER OVER: get_ci_details only when the term may not be a CI number.
     TABLES: cmdb_ci (base).
     SIDE EFFECT: read-only.
     EXAMPLE: quickly find a CI by name, IP, or number.

--- a/Table_Tools/consolidated_tools.py
+++ b/Table_Tools/consolidated_tools.py
@@ -26,14 +26,17 @@ from typing import Any, Dict, Optional, List
 from constants import TABLE_ERROR_MESSAGES, TASK_NUMBER_FIELD
 from param_coercion import OptJsonList, OptJsonDict
 
-logger = logging.getLogger(__name__)
+# v5.0 "Boron" Tier 3.3: get_priority_incidents dropped its **deprecated_kwargs
+# backwards-compat path (deprecated since v4.0). Extra field filters go through
+# `additional_filters` now; the hand-rolled _mcp_get_priority_incidents shim in
+# tools.py (which only existed because fastmcp rejects **kwargs) is gone with it.
 
+logger = logging.getLogger(__name__)
 
 # Helper function to get table-specific error message
 def _get_error_message(table_name: str, default: str = "Record not found.") -> str:
     """Get table-specific error message with cognitive complexity < 15."""
     return TABLE_ERROR_MESSAGES.get(table_name, default)
-
 
 # ---------------------------------------------------------------------------
 # Priority Incidents (unique date logic + metadata)
@@ -49,24 +52,13 @@ def _validate_date_param(date_string: Optional[str], param_name: str) -> Optiona
         return error_response("VALIDATION", f"Invalid {param_name}: {error}")
     return None
 
-
 def _merge_filters(
     additional_filters: Optional[Dict[str, Any]],
-    deprecated_kwargs: Dict[str, Any],
     start_date: Optional[str],
     end_date: Optional[str]
 ) -> Dict[str, Any]:
-    """Merge additional filters, deprecated kwargs, and date filters into one dict."""
-    if deprecated_kwargs:
-        logger.warning(
-            "Passing filters as **kwargs is deprecated. "
-            "Use additional_filters dict instead. Got: %s",
-            list(deprecated_kwargs.keys())
-        )
-        merged = (additional_filters or {}).copy()
-        merged.update(deprecated_kwargs)
-    else:
-        merged = additional_filters.copy() if additional_filters else {}
+    """Merge additional filters and the date window into one filter dict."""
+    merged = additional_filters.copy() if additional_filters else {}
 
     date_filter = build_date_filter(start_date, end_date)
     if date_filter:
@@ -74,7 +66,6 @@ def _merge_filters(
         logger.debug("Built date filter: %s", date_filter)
 
     return merged
-
 
 def _build_metadata(
     result: Dict[str, Any],
@@ -106,24 +97,16 @@ def _build_metadata(
         },
     )
 
-
 async def get_priority_incidents(
     priorities: List[str],
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    additional_filters: Optional[Dict[str, Any]] = None,
+    additional_filters: OptJsonDict = None,
     include_metadata: bool = False,
-    **deprecated_kwargs
 ) -> Dict[str, Any]:
     """
     Get incidents filtered by priority value, with an optional date window.
 
-    WHEN TO USE: the user names a priority (P1/P2/"priority 1") and wants the
-        matching incidents, optionally within a date range.
-    WHEN NOT TO USE: free-text topic search ("incidents about X") — use
-        search_records; arbitrary field filters — use filter_records.
-    PREFER OVER: filter_records only for the priority-plus-date shape, which
-        this tool builds with reliable >= / <= operators.
     TABLES: incident only.
     SIDE EFFECT: read-only.
     EXAMPLE: show me all P1 incidents from last week.
@@ -150,7 +133,7 @@ async def get_priority_incidents(
             return error_result
 
     # Build merged filters
-    merged_filters = _merge_filters(additional_filters, deprecated_kwargs, start_date, end_date)
+    merged_filters = _merge_filters(additional_filters, start_date, end_date)
 
     logger.info(
         "Querying priority incidents: priorities=%s, start_date=%s, end_date=%s, filters=%s",
@@ -179,7 +162,6 @@ async def get_priority_incidents(
     )
     return carry_partial(enriched, result)
 
-
 def _build_priority_result_message(
     count: int,
     priorities: List[str],
@@ -199,7 +181,6 @@ def _build_priority_result_message(
 
     return msg
 
-
 # Convenience helper functions for common date range queries
 
 # ---------------------------------------------------------------------------
@@ -214,7 +195,6 @@ def _build_priority_result_message(
 # The old "smart" KB search silently discarded input_text when category/kb_base
 # was set; do not reintroduce it (plan §Tier 2).
 
-
 # Canonical workflow_state precedence for KB de-duplication.
 # Lower index = higher priority (= the row chosen as "current" when one number has multiple versions).
 # Rationale: published reflects live content; draft/review are in-flight; outdated is a versioning
@@ -225,7 +205,6 @@ _KB_DEDUP_FIELDS = [
     "number", "sys_id", "short_description", "workflow_state",
     "kb_category", "sys_updated_on",
 ]
-
 
 def _pick_canonical_kb_row(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
     """De-duplicate kb_knowledge rows by `number`, keeping the highest-priority workflow_state row.
@@ -249,7 +228,6 @@ def _pick_canonical_kb_row(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
                 entry["rank"] = rank
     return by_number
 
-
 def _format_deduped_kb_row(number: str, info: Dict[str, Any]) -> Dict[str, Any]:
     """Render a de-duplicated KB row in the public response shape."""
     row = info["row"]
@@ -263,7 +241,6 @@ def _format_deduped_kb_row(number: str, info: Dict[str, Any]) -> Dict[str, Any]:
         "sys_updated_on": row.get("sys_updated_on"),
     }
 
-
 async def get_kb_articles_by_state(
     workflow_state: Optional[str] = None,
     category: Optional[str] = None,
@@ -272,12 +249,6 @@ async def get_kb_articles_by_state(
 ) -> Dict[str, Any]:
     """List kb_knowledge articles de-duplicated by article number.
 
-    WHEN TO USE: the user asks which articles are in a given publication state
-        ("currently in published state", "drafts", "retired KB").
-    WHEN NOT TO USE: subject search (search_records on kb_knowledge); one
-        category with no state question (filter_records with kb_category).
-    PREFER OVER: filter_records — this collapses ServiceNow's version rows that
-        a raw filter would return duplicated.
     TABLES: kb_knowledge only.
     SIDE EFFECT: read-only.
     EXAMPLE: which knowledge articles are currently in published state.
@@ -341,7 +312,6 @@ async def get_kb_articles_by_state(
         list_response(deduped, truncated=bool(raw.get("truncated", False))), raw
     )
 
-
 # ---------------------------------------------------------------------------
 # SLA tools — v4.0 consolidation (10 -> 5)
 # ---------------------------------------------------------------------------
@@ -363,20 +333,17 @@ _SLA_PERFORMANCE_FIELDS = [
     "business_time_left", "duration", "sys_created_on",
 ]
 
-
 # Per-preset filter builders. Each returns (filters, fields_or_None).
 # Extra filters and dispatch are handled by _build_sla_status_filter.
 
 def _sla_filter_active(**_kw) -> tuple[Dict[str, str], Optional[List[str]]]:
     return {"active": "true"}, None
 
-
 def _sla_filter_breached(days: Optional[int] = None, **_kw) -> tuple[Dict[str, str], Optional[List[str]]]:
     return {
         "has_breached": "true",
         "sys_created_on": build_last_n_days_filter(days if days is not None else 7),
     }, None
-
 
 def _sla_filter_breaching(threshold_minutes: Optional[int] = None, **_kw) -> tuple[Dict[str, str], Optional[List[str]]]:
     threshold = (threshold_minutes if threshold_minutes is not None else 60) * 60
@@ -386,7 +353,6 @@ def _sla_filter_breaching(threshold_minutes: Optional[int] = None, **_kw) -> tup
         "has_breached": "false",
     }, None
 
-
 def _sla_filter_critical(**_kw) -> tuple[Dict[str, str], Optional[List[str]]]:
     return {
         "active": "true",
@@ -394,19 +360,16 @@ def _sla_filter_critical(**_kw) -> tuple[Dict[str, str], Optional[List[str]]]:
         "business_percentage": ">80",
     }, _SLA_CRITICAL_FIELDS
 
-
 def _sla_filter_by_stage(stage: Optional[str] = None, **_kw) -> tuple[Dict[str, str], Optional[List[str]]]:
     if not stage:
         raise ValueError("query_slas_by_status(status='by_stage') requires the 'stage' argument")
     return {"stage": stage}, None
-
 
 def _sla_filter_performance(days: Optional[int] = None, **_kw) -> tuple[Dict[str, str], Optional[List[str]]]:
     return (
         {"sys_created_on": build_last_n_days_filter(days if days is not None else 30)},
         _SLA_PERFORMANCE_FIELDS,
     )
-
 
 _SLA_STATUS_DISPATCH = {
     "active": _sla_filter_active,
@@ -416,7 +379,6 @@ _SLA_STATUS_DISPATCH = {
     "by_stage": _sla_filter_by_stage,
     "performance": _sla_filter_performance,
 }
-
 
 def _build_sla_status_filter(
     status: str,
@@ -436,20 +398,14 @@ def _build_sla_status_filter(
         filters.update(extra_filters)
     return filters, fields
 
-
 # v5.0 "Boron" (Tier 2): similar_slas_for_text was culled. It queried a bare
 # short_description that task_sla lacks, so ServiceNow dropped the condition and
 # returned an arbitrary page of SLAs — it never worked. For a free-text task
 # search use filter_records("task_sla", {"task.short_description": "LIKE..."}).
 
-
 async def get_sla_details(sla_sys_id: str) -> Dict[str, Any]:
     """Get one SLA record by its sys_id (task_sla lookup).
 
-    WHEN TO USE: you hold the SLA's 32-char sys_id and want that single row.
-    WHEN NOT TO USE: you have a task number rather than a sys_id — use
-        query_slas_by_task; a status or stage query — use query_slas_by_status.
-    PREFER OVER: query_slas_custom for a known-sys_id point lookup.
     TABLES: task_sla only.
     SIDE EFFECT: read-only.
     EXAMPLE: get SLA sys_id 26bc0f3b47c1... .
@@ -461,23 +417,15 @@ async def get_sla_details(sla_sys_id: str) -> Dict[str, Any]:
     params = TableFilterParams(filters={"sys_id": sla_sys_id})
     return await query_table_with_filters("task_sla", params)
 
-
 async def query_slas_by_task(task_number: str) -> Dict[str, Any]:
     """Get every SLA record attached to one task, addressed by task number.
 
-    WHEN TO USE: you have a task number (INC/CHG/RITM/SCTASK/...) and want the
-        SLAs attached to it.
-    WHEN NOT TO USE: matching SLAs by the task's wording — use
-        filter_records('task_sla', {'task.short_description': 'LIKE...'});
-        filtering by status or stage — use query_slas_by_status.
-    PREFER OVER: query_slas_custom for this exact task-number lookup.
     TABLES: task_sla (filters on the task reference).
     SIDE EFFECT: read-only.
     EXAMPLE: all SLA records attached to INC0012345.
     """
     params = TableFilterParams(filters={TASK_NUMBER_FIELD: task_number})
     return await query_table_with_filters("task_sla", params)
-
 
 async def query_slas_by_status(
     status: str,
@@ -488,12 +436,6 @@ async def query_slas_by_status(
 ) -> Dict[str, Any]:
     """Query SLA records by a named status preset.
 
-    WHEN TO USE: the intent maps to a preset — breached, breaching, active,
-        critical, by_stage, performance ("which SLAs are breached").
-    WHEN NOT TO USE: SLAs for one task number (query_slas_by_task); a filter no
-        preset covers (query_slas_custom).
-    PREFER OVER: query_slas_custom whenever a preset fits — presets carry
-        curated field lists that protect the token budget.
     TABLES: task_sla only.
     SIDE EFFECT: read-only.
     EXAMPLE: which SLAs are breached.
@@ -523,7 +465,6 @@ async def query_slas_by_status(
     params = TableFilterParams(filters=filters, fields=fields)
     return await query_table_with_filters("task_sla", params)
 
-
 async def query_slas_custom(
     filters: Dict[str, str],
     fields: OptJsonList = None,
@@ -531,12 +472,6 @@ async def query_slas_custom(
 ) -> Dict[str, Any]:
     """Custom SLA query — escape hatch for filter shapes the presets do not cover.
 
-    WHEN TO USE: the SLA filter you need is not one of query_slas_by_status's
-        presets, and it is not a plain task-number or task-text lookup.
-    WHEN NOT TO USE: a preset fits (query_slas_by_status); one task number
-        (query_slas_by_task).
-    PREFER OVER: filter_records only when you want task_sla ESSENTIAL_FIELDS
-        defaulting and the optional last-N-days convenience.
     TABLES: task_sla only.
     SIDE EFFECT: read-only.
     EXAMPLE: SLA query with a filter shape the presets do not cover.

--- a/Table_Tools/generic_tool_wrappers.py
+++ b/Table_Tools/generic_tool_wrappers.py
@@ -26,7 +26,6 @@ from .generic_table_tools import (
 SUPPORTED_TABLES = sorted(TABLE_CONFIGS.keys())
 INVALID_TABLE_ERROR = "Invalid table '{table}'. Supported tables: {tables}"
 
-
 def _validate_table(table: str) -> Optional[Dict[str, Any]]:
     """Return a VALIDATION error dict if *table* is not in TABLE_CONFIGS, else None."""
     if table not in TABLE_CONFIGS:
@@ -35,7 +34,6 @@ def _validate_table(table: str) -> Optional[Dict[str, Any]]:
             INVALID_TABLE_ERROR.format(table=table, tables=", ".join(SUPPORTED_TABLES)),
         )
     return None
-
 
 def _validate_identity_table(table: str) -> Optional[Dict[str, Any]]:
     """Table validation for the tools that address records by number or description.
@@ -56,16 +54,9 @@ def _validate_identity_table(table: str) -> Optional[Dict[str, Any]]:
         return error_response("VALIDATION", TABLE_LACKS_RECORD_IDENTITY.format(table=table))
     return None
 
-
 async def search_records(table: str, query: str) -> Dict[str, Any]:
     """Search records in a ServiceNow table by free-text over short_description.
 
-    WHEN TO USE: the user describes a topic or symptom and wants matching
-        records — "incidents about a server crashing during backup".
-    WHEN NOT TO USE: you already know the record number (get_record); you need
-        field filters like state or priority (filter_records); a
-        priority-plus-date list (get_priority_incidents).
-    PREFER OVER: filter_records when the ask is words, not field values.
     FOOTGUNS: matching uses LIKE, never CONTAINS — CONTAINS is a GlideRecord
         scripting operator, silently ignored in an encoded query, and returns
         zero rows with no error. Reference fields (assignment_group,
@@ -91,16 +82,9 @@ async def search_records(table: str, query: str) -> Dict[str, Any]:
         return error
     return await query_table_by_text(table, query)
 
-
 async def get_record(table: str, number: str) -> Dict[str, Any]:
     """Get full detail fields for a single known record by number.
 
-    WHEN TO USE: you know the record number and want its complete detail —
-        "give me the full details of incident INC0012345".
-    WHEN NOT TO USE: a list view over many rows (filter_records); text search
-        (search_records).
-    PREFER OVER: filter_records when you have the number and want every field of
-        that one record; search_records when you have the number, not keywords.
     TABLES: incident, change_request, sc_req_item, sc_task, universal_request,
         kb_knowledge, vtb_task. NOT task_sla — that table has no number field;
         use get_sla_details(sla_sys_id) or query_slas_by_task(task_number).
@@ -119,15 +103,9 @@ async def get_record(table: str, number: str) -> Dict[str, Any]:
         return error
     return await get_record_details(table, number)
 
-
 async def find_similar(table: str, number: str) -> Dict[str, Any]:
     """Find records similar to an existing record (by short_description).
 
-    WHEN TO USE: you have one record's number and want others like it —
-        "find other incidents similar to this one".
-    WHEN NOT TO USE: you have search words, not a seed record (search_records);
-        you want that record's own fields (get_record).
-    PREFER OVER: search_records when the seed is an existing record, not text.
     TABLES: incident, change_request, sc_req_item, sc_task, universal_request,
         kb_knowledge, vtb_task. NOT task_sla — it has neither number nor
         short_description; use query_slas_by_task or filter_records('task_sla').
@@ -149,7 +127,6 @@ async def find_similar(table: str, number: str) -> Dict[str, Any]:
         return error
     return await find_similar_records(table, number)
 
-
 async def filter_records(
     table: str,
     filters: Dict[str, str],
@@ -158,14 +135,6 @@ async def filter_records(
 ) -> Dict[str, Any]:
     """Query a ServiceNow table with field-value filters.
 
-    WHEN TO USE: the user gives field conditions — state, priority, category,
-        date ranges — "list change requests where state is 3 and category is
-        network".
-    WHEN NOT TO USE: free-text topic search (search_records); a single record
-        by number (get_record); a priority-plus-date incident list
-        (get_priority_incidents); KB version rollups (get_kb_articles_by_state).
-    PREFER OVER: the table-specific tools when you need an arbitrary filter
-        shape they do not expose.
     SIDE EFFECT: read-only.
     EXAMPLE: list change requests where state is 3 and category is network.
 

--- a/Table_Tools/intelligent_query_tools.py
+++ b/Table_Tools/intelligent_query_tools.py
@@ -17,15 +17,9 @@ from typing import Any, Dict
 
 from constants import SERVICENOW_QUERY_OPERATORS, QUERY_SYNTAX_NOTES
 
-
 def get_query_syntax_help() -> Dict[str, Any]:
     """Return the authoritative ServiceNow encoded-query operator reference.
 
-    WHEN TO USE: you need the operator vocabulary in general — "which encoded
-        query operators does ServiceNow support".
-    WHEN NOT TO USE: running a query (search_records / filter_records);
-        inspecting the live connection (health_check).
-    PREFER OVER: guessing operator syntax when constructing a filter value.
     SIDE EFFECT: none — returns a static reference.
     EXAMPLE: which encoded query operators does ServiceNow support.
 

--- a/Table_Tools/kb_article_tools.py
+++ b/Table_Tools/kb_article_tools.py
@@ -62,7 +62,6 @@ from constants import (
 
 _log = structlog.get_logger("kb_write")
 
-
 class KbDuplicateCheckInconclusive(Exception):
     """The duplicate check could not produce a trustworthy answer.
 
@@ -76,7 +75,6 @@ class KbDuplicateCheckInconclusive(Exception):
     def __init__(self, reason: str) -> None:
         super().__init__(reason)
         self.reason = reason
-
 
 def _handle_kb_error(error: httpx.HTTPStatusError, operation: str) -> Dict[str, Any]:
     error_map = {
@@ -94,7 +92,6 @@ def _handle_kb_error(error: httpx.HTTPStatusError, operation: str) -> Dict[str, 
         detail_on_default=True,
     )
 
-
 def _unwrap_kb_write_response(result: Any, operation: str) -> Dict[str, Any]:
     return unwrap_write_response(
         result,
@@ -102,7 +99,6 @@ def _unwrap_kb_write_response(result: Any, operation: str) -> Dict[str, Any]:
         fields=KB_WRITE_RESPONSE_FIELDS,
         success_message=f"KB article {operation} succeeded.",
     )
-
 
 async def _write_kb_article(
     method: str,
@@ -121,7 +117,6 @@ async def _write_kb_article(
     except Exception:
         return error_response("INTERNAL", ERROR_KB_ARTICLE_REQUEST_FAILED.format(operation=operation))
     return _unwrap_kb_write_response(result, operation)
-
 
 async def _get_kb_article_sys_id(article_number: str, workflow_state: str | None = None) -> str | None:
     """Return the article's sys_id, or None if no such article exists.
@@ -145,7 +140,6 @@ async def _get_kb_article_sys_id(article_number: str, workflow_state: str | None
         return None
     return data['result'][0]['sys_id']
 
-
 async def _get_kb_article_meta(article_number: str, workflow_state: str | None = None) -> Dict[str, Any] | None:
     """Fetch sys_id + short_description in one GET — avoids a second round-trip in publish.
 
@@ -166,7 +160,6 @@ async def _get_kb_article_meta(article_number: str, workflow_state: str | None =
         return None
     return data['result'][0]
 
-
 def _dedup_query_defect(short_description: str) -> Optional[str]:
     """Why the dedup query would not faithfully carry *short_description*, if so.
 
@@ -184,7 +177,6 @@ def _dedup_query_defect(short_description: str) -> Optional[str]:
     if unsafe:
         return KB_DEDUP_REASON_UNSAFE_CHARS.format(chars=" ".join(unsafe))
     return None
-
 
 async def _check_kb_duplicates(short_description: str, exclude_number: str) -> list:
     """Return KB articles matching short_description exactly across live workflow states.
@@ -239,7 +231,6 @@ async def _check_kb_duplicates(short_description: str, exclude_number: str) -> l
         )
     return []
 
-
 async def _call_kb_workflow(sys_id: str, action: str) -> Dict[str, Any]:
     # Custom Scripted REST API (qonv/publish) — invokes KnowledgeUIAction server-side.
     # Direct Table API writes to workflow_state are ignored by ServiceNow.
@@ -249,7 +240,6 @@ async def _call_kb_workflow(sys_id: str, action: str) -> Dict[str, Any]:
         _log.error("kb_workflow_error", action=action, sys_id=sys_id, url=url, result=result)
     return result
 
-
 async def _call_kb_publish_workflow(sys_id: str) -> Dict[str, Any] | None:
     # Variant of _call_kb_workflow that propagates httpx exceptions instead
     # of mapping them to strings. _publish_with_verify needs the raw
@@ -257,7 +247,6 @@ async def _call_kb_publish_workflow(sys_id: str) -> Dict[str, Any] | None:
     url = f"{NWS_API_BASE}/api/qonv/mateco_knowledge/articles/{sys_id}/publish"
     with anyio.fail_after(KB_PUBLISH_TIMEOUT_SECONDS):
         return await make_nws_request(url, method="POST", json_data={})
-
 
 async def _verify_kb_published(article_number: str) -> Dict[str, Any] | None:
     """Return the published row for *article_number*, or None if not yet published.
@@ -281,7 +270,6 @@ async def _verify_kb_published(article_number: str) -> Dict[str, Any] | None:
         return None
     return data["result"][0]
 
-
 async def _fire_publish(sys_id: str) -> Any:
     """Fire the publish workflow. Returns None on success, or a fire-time failure.
 
@@ -299,7 +287,6 @@ async def _fire_publish(sys_id: str) -> Any:
         return "fire timeout"
     except httpx.HTTPStatusError as e:
         return _handle_kb_error(e, "publish")
-
 
 async def _publish_with_verify(sys_id: str, article_number: str) -> Dict[str, Any]:
     """Fire the publish workflow then verify by polling for a Published row.
@@ -336,7 +323,6 @@ async def _publish_with_verify(sys_id: str, article_number: str) -> Dict[str, An
 
     return _publish_failure(article_number, last_fire_error)
 
-
 def _publish_failure(article_number: str, last_fire_error: Any) -> Dict[str, Any]:
     """Normalise the exhausted-retries outcome into a coded error_response.
 
@@ -349,7 +335,6 @@ def _publish_failure(article_number: str, last_fire_error: Any) -> Dict[str, Any
         return last_fire_error
     code = "TIMEOUT" if last_fire_error == "fire timeout" else "INTERNAL"
     return error_response(code, ERROR_KB_PUBLISH_NOT_CONFIRMED.format(number=article_number))
-
 
 def _publish_unconfirmed(article_number: str, error: ServiceNowRequestError) -> Dict[str, Any]:
     """The publish fired but the confirming read failed — neither success nor failure.
@@ -367,7 +352,6 @@ def _publish_unconfirmed(article_number: str, error: ServiceNowRequestError) -> 
         "error": error.to_error_dict()["error"],
     }
 
-
 async def _refresh_draft_sys_id(article_number: str, current_sys_id: str) -> str:
     """Re-read the draft sys_id between publish attempts, best effort.
 
@@ -381,15 +365,9 @@ async def _refresh_draft_sys_id(article_number: str, current_sys_id: str) -> str
         return current_sys_id
     return refreshed or current_sys_id
 
-
 async def update_knowledge_article(article_number: str, update_data: Dict[str, Any]) -> Dict[str, Any]:
     """Update fields on a knowledge article by article number (e.g. KB0001234).
 
-    WHEN TO USE: change an article's content or metadata — "update the body
-        text of KB0001234".
-    WHEN NOT TO USE: changing publication state — publish
-        (publish_knowledge_article) or retire (retire_knowledge_article).
-    PREFER OVER: nothing; this is the kb_knowledge field-write path.
     TABLES: kb_knowledge only.
     SIDE EFFECT: WRITE — PATCHes one draft article.
     EXAMPLE: update the body text of KB0001234.
@@ -433,15 +411,9 @@ async def update_knowledge_article(article_number: str, update_data: Dict[str, A
     print(f"[kb] {article_number} PATCH took {time.monotonic() - t1:.1f}s", file=sys.stderr)
     return result
 
-
 async def publish_knowledge_article(article_number: str) -> Dict[str, Any]:
     """Publish ONE knowledge article via the ServiceNow workflow endpoint.
 
-    WHEN TO USE: publish a single article — "publish knowledge article
-        KB0001234".
-    WHEN NOT TO USE: several articles at once (use publish_knowledge_articles);
-        only checking for duplicates without publishing (check_kb_duplicates).
-    PREFER OVER: publish_knowledge_articles when there is exactly one article.
     TABLES: kb_knowledge only.
     SIDE EFFECT: WRITE — runs the publish workflow. Fail-closed on the dup check.
     EXAMPLE: publish knowledge article KB0001234.
@@ -487,7 +459,6 @@ async def publish_knowledge_article(article_number: str) -> Dict[str, Any]:
 
     return await _publish_with_verify(meta['sys_id'], article_number)
 
-
 def _duplicate_check_inconclusive(article_number: str, reason: str) -> Dict[str, Any]:
     """Refuse the publish because the duplicate check could not answer.
 
@@ -504,7 +475,6 @@ def _duplicate_check_inconclusive(article_number: str, reason: str) -> Dict[str,
         "duplicates": [],
     }
 
-
 def _duplicate_row_inconclusive(article_number: str, reason: str) -> Dict[str, Any]:
     """A row for an article whose duplicate status could not be determined.
 
@@ -520,7 +490,6 @@ def _duplicate_row_inconclusive(article_number: str, reason: str) -> Dict[str, A
         "duplicates": [],
         "error": reason,
     }
-
 
 async def _check_single_kb_duplicate(article_number: str) -> Dict[str, Any]:
     """Lookup meta then check duplicates for one article. Used by check_kb_duplicates fan-out."""
@@ -551,7 +520,6 @@ async def _check_single_kb_duplicate(article_number: str) -> Dict[str, Any]:
         ],
     }
 
-
 def _outcome_error_message(outcome: BaseException) -> str:
     """Message for an exception that escaped a per-article coroutine."""
     if isinstance(outcome, (ServiceNowRequestError, QueryValueError)):
@@ -559,7 +527,6 @@ def _outcome_error_message(outcome: BaseException) -> str:
     if isinstance(outcome, KbDuplicateCheckInconclusive):
         return outcome.reason
     return f"{type(outcome).__name__}: {outcome}"
-
 
 def _rows_from_outcomes(numbers, outcomes, error_row) -> List[Dict[str, Any]]:
     """Zip gathered outcomes back onto their article numbers, exceptions included.
@@ -577,18 +544,12 @@ def _rows_from_outcomes(numbers, outcomes, error_row) -> List[Dict[str, Any]]:
             rows.append(outcome)
     return rows
 
-
 async def check_kb_duplicates(
     article_numbers: JsonList,
     concurrency: int = 5,
 ) -> Dict[str, Any]:
     """Check for duplicate KB articles without publishing.
 
-    WHEN TO USE: confirm an article has no duplicates before publishing —
-        "check whether KB0001234 has duplicates before I publish it".
-    WHEN NOT TO USE: actually publishing (publish_knowledge_article /
-        publish_knowledge_articles run this check themselves first).
-    PREFER OVER: nothing; this is the standalone duplicate probe.
     TABLES: kb_knowledge only.
     SIDE EFFECT: read-only — never writes.
     EXAMPLE: check whether KB0001234 has duplicates before I publish it.
@@ -629,7 +590,6 @@ async def check_kb_duplicates(
         *(_bounded(n) for n in article_numbers), return_exceptions=True
     )
     return list_response(_rows_from_outcomes(article_numbers, outcomes, _duplicate_row_inconclusive))
-
 
 def _normalize_publish_result(article_number: str, result: Dict[str, Any] | str) -> Dict[str, Any]:
     """Normalize publish_knowledge_article output into a flat batch-result row.
@@ -681,19 +641,12 @@ def _normalize_publish_result(article_number: str, result: Dict[str, Any] | str)
         "workflow_state": (result.get("record") or {}).get("workflow_state"),
     }
 
-
 async def publish_knowledge_articles(
     article_numbers: JsonList,
     concurrency: int = KB_PUBLISH_BATCH_CONCURRENCY,
 ) -> Dict[str, Any]:
     """Publish MULTIPLE KB articles in one tool call (batch).
 
-    WHEN TO USE: two or more articles to publish together — "publish KB0001234,
-        KB0001235 and KB0001236 in one go".
-    WHEN NOT TO USE: exactly one article (use publish_knowledge_article);
-        checking duplicates without publishing (check_kb_duplicates).
-    PREFER OVER: calling publish_knowledge_article in a loop — this batches and
-        never lets one failure abort the rest.
     TABLES: kb_knowledge only.
     SIDE EFFECT: WRITE — runs the publish workflow per article.
     EXAMPLE: publish KB0001234, KB0001235 and KB0001236 in one go.
@@ -740,15 +693,9 @@ async def publish_knowledge_articles(
     )
     return list_response(_rows_from_outcomes(article_numbers, outcomes, _error_row))
 
-
 async def retire_knowledge_article(article_number: str) -> Dict[str, Any]:
     """Retire a knowledge article via the ServiceNow workflow endpoint.
 
-    WHEN TO USE: take a published article out of service — "retire knowledge
-        article KB0004321".
-    WHEN NOT TO USE: publishing (publish_knowledge_article); editing content
-        (update_knowledge_article).
-    PREFER OVER: nothing; this is the kb_knowledge retire path.
     TABLES: kb_knowledge only.
     SIDE EFFECT: WRITE — runs the retire workflow.
     EXAMPLE: retire knowledge article KB0004321.

--- a/Table_Tools/vtb_task_tools.py
+++ b/Table_Tools/vtb_task_tools.py
@@ -114,10 +114,6 @@ async def _get_task_sys_id(task_number: str) -> str | None:
 async def create_private_task(task_data: Dict[str, Any]) -> Dict[str, Any]:
     """Create a NEW private task (vtb_task) record.
 
-    WHEN TO USE: the user wants a brand-new private task opened.
-    WHEN NOT TO USE: to modify a task that already exists (its VTB number is
-        known) — use update_private_task instead.
-    PREFER OVER: nothing; this is the only insert path for vtb_task.
     TABLES: vtb_task only (the sole table with CRUD support).
     SIDE EFFECT: WRITE — inserts one record. Not idempotent.
     EXAMPLE: create a private task to review the firewall configuration.
@@ -142,11 +138,6 @@ async def create_private_task(task_data: Dict[str, Any]) -> Dict[str, Any]:
 async def update_private_task(task_number: str, update_data: Dict[str, Any]) -> Dict[str, Any]:
     """Update / change an EXISTING private task (vtb_task), addressed by number.
 
-    WHEN TO USE: the task already exists and the user wants to set, close,
-        reassign, or otherwise change it. A VTB number together with a change
-        verb (set / close / update / reassign) is always this tool.
-    WHEN NOT TO USE: opening a brand-new task — use create_private_task.
-    PREFER OVER: create_private_task whenever the record already exists.
     TABLES: vtb_task only.
     SIDE EFFECT: WRITE — patches one record; resolves sys_id by number first.
     EXAMPLE: set private task VTB0001234 to closed complete.

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -36,6 +36,7 @@ ROOT_FILES = [
     "auth_middleware.py",
     "param_coercion.py",
     "table_spec.py",
+    "tool_registry.py",
     "manifest.json",
     "pyproject.toml",
     "LICENSE",

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -59,14 +59,22 @@ class TestGetPriorityIncidents:
             assert "result" in result
 
     @pytest.mark.asyncio
-    async def test_deprecated_kwargs(self):
-        with patch('Table_Tools.consolidated_tools.get_records_by_priority') as mock_priority, \
-             patch('Table_Tools.consolidated_tools.logger') as mock_logger:
+    async def test_extra_field_filters_go_through_additional_filters(self):
+        """v5.0 Tier 3.3 dropped the deprecated **kwargs path; extra field
+        filters are passed via additional_filters (the only supported way now,
+        and what lets the tool register without a **kwargs-stripping shim)."""
+        with patch('Table_Tools.consolidated_tools.get_records_by_priority') as mock_priority:
             mock_priority.return_value = {"result": [{"number": "INC001"}]}
-            result = await get_priority_incidents(["1", "2"], state="New")
-            mock_logger.warning.assert_called()
+            await get_priority_incidents(["1", "2"], additional_filters={"state": "New"})
             filters = mock_priority.call_args[0][2]
             assert filters.get("state") == "New"
+
+    @pytest.mark.asyncio
+    async def test_unknown_kwarg_is_rejected(self):
+        """The removed **kwargs path means a stray keyword is now a TypeError,
+        not a silently-merged filter."""
+        with pytest.raises(TypeError):
+            await get_priority_incidents(["1"], state="New")
 
 
 class TestGetPriorityIncidentsEnhanced:

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,97 @@
+"""Tool-guidance registry + docstring-footer injection (v5.0 "Boron" Tier 3.3).
+
+Pins the structured selection-guidance mechanism: every registered tool has a
+TOOL_GUIDANCE entry, the entry is injected as a single canonical docstring footer,
+injection is idempotent, and registration refuses a tool with no guidance (which
+is what makes the WHEN/WHEN-NOT/PREFER protocol mandatory rather than merely a
+docstring convention). The golden-set test can now read these three fields as
+structured data instead of parsing them back out of prose.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import tools
+from tool_registry import (
+    TOOL_GUIDANCE,
+    ToolGuidance,
+    apply_guidance,
+    guidance_footer,
+    register_tools,
+)
+
+_REGISTERED = {fn.__name__ for fn in tools.tools}
+
+
+class TestGuidanceCoverage:
+    """The registry and the registered surface must match exactly."""
+
+    def test_every_registered_tool_has_guidance(self):
+        missing = _REGISTERED - set(TOOL_GUIDANCE)
+        assert not missing, f"registered tools with no TOOL_GUIDANCE entry: {sorted(missing)}"
+
+    def test_no_stale_guidance_entries(self):
+        stale = set(TOOL_GUIDANCE) - _REGISTERED
+        assert not stale, f"TOOL_GUIDANCE entries for unregistered tools: {sorted(stale)}"
+
+    def test_all_three_fields_non_empty(self):
+        for name, g in TOOL_GUIDANCE.items():
+            assert isinstance(g, ToolGuidance), name
+            assert g.when_to_use.strip(), name
+            assert g.when_not.strip(), name
+            assert g.prefer_over.strip(), name
+
+
+class TestFooterInjection:
+    """The registered docstring carries exactly one generated guidance footer."""
+
+    def test_footer_present_once_in_every_registered_doc(self):
+        for fn in tools.tools:
+            doc = inspect.getdoc(fn) or ""
+            assert doc.count("WHEN TO USE:") == 1, f"{fn.__name__}: guidance block not unique"
+            assert doc.count("PREFER OVER:") == 1, fn.__name__
+            assert guidance_footer(fn.__name__) in doc, f"{fn.__name__}: footer text missing"
+
+    def test_footer_is_the_tail_of_the_doc(self):
+        for fn in tools.tools:
+            doc = inspect.getdoc(fn) or ""
+            assert doc.rstrip().endswith(guidance_footer(fn.__name__)), fn.__name__
+
+    def test_injection_is_idempotent(self):
+        async def sample():
+            """A summary line.
+
+            WHEN TO USE: original prose here.
+            WHEN NOT TO USE: not this.
+            PREFER OVER: nothing.
+
+            Args:
+                x: whatever
+            """
+
+        # Borrow a real tool's guidance so guidance_footer has an entry.
+        sample.__name__ = "get_record"
+        once = apply_guidance(sample).__doc__
+        twice = apply_guidance(sample).__doc__
+        assert once == twice
+        assert once.count("WHEN TO USE:") == 1
+        # The original prose guidance was replaced by the canonical footer.
+        assert "original prose here" not in once
+        assert "A summary line." in once and "Args:" in once
+
+
+class TestProtocolIsMandatory:
+    """register_tools fails loudly on a tool with no guidance."""
+
+    def test_register_tools_rejects_ungoverned_tool(self):
+        class _FakeMcp:
+            def tool(self):
+                return lambda fn: fn
+
+        async def brand_new_tool():
+            """No guidance entry exists for this one."""
+
+        with pytest.raises(ValueError, match="no TOOL_GUIDANCE entry"):
+            register_tools(_FakeMcp(), [brand_new_tool])

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -10,6 +10,7 @@ structured data instead of parsing them back out of prose.
 from __future__ import annotations
 
 import inspect
+import re
 
 import pytest
 
@@ -51,13 +52,22 @@ class TestFooterInjection:
         for fn in tools.tools:
             doc = inspect.getdoc(fn) or ""
             assert doc.count("WHEN TO USE:") == 1, f"{fn.__name__}: guidance block not unique"
+            assert doc.count("WHEN NOT TO USE:") == 1, f"{fn.__name__}: middle line duplicated"
             assert doc.count("PREFER OVER:") == 1, fn.__name__
             assert guidance_footer(fn.__name__) in doc, f"{fn.__name__}: footer text missing"
 
-    def test_footer_is_the_tail_of_the_doc(self):
+    def test_footer_precedes_any_args_or_returns_section(self):
+        """FastMCP serves only the pre-Args text as the description, so the
+        guidance MUST sit above the first Args/Returns/Raises section (else it
+        parses into getdoc but never reaches the wire — the PR #75 regression)."""
+        section = re.compile(r'(?m)^(?:Args|Arguments|Parameters|Returns|Return|Yields|Raises)[ \t]*:')
         for fn in tools.tools:
             doc = inspect.getdoc(fn) or ""
-            assert doc.rstrip().endswith(guidance_footer(fn.__name__)), fn.__name__
+            m = section.search(doc)
+            if m:
+                assert doc.index("WHEN TO USE:") < m.start(), (
+                    f"{fn.__name__}: guidance sits after {m.group()!r} — dropped from the served description"
+                )
 
     def test_injection_is_idempotent(self):
         async def sample():
@@ -82,6 +92,32 @@ class TestFooterInjection:
         assert "A summary line." in once and "Args:" in once
 
 
+class TestServedDescription:
+    """The guidance must reach the WIRE, not just inspect.getdoc.
+
+    FastMCP builds the tool description from the docstring text above the first
+    Args/Returns section, so a getdoc-only assertion (every other test here)
+    cannot see the PR #75 regression where the footer landed after Args.
+    """
+
+    @pytest.mark.asyncio
+    async def test_guidance_in_served_description_for_args_and_argless_tools(self):
+        from fastmcp import FastMCP
+        from Table_Tools.generic_tool_wrappers import search_records  # has an Args: section
+        from utility_tools import health_check  # no Args: section
+
+        mcp = FastMCP("contract-probe")
+        register_tools(mcp, [search_records, health_check])
+
+        for name in ("search_records", "health_check"):
+            tool = await mcp.get_tool(name)
+            assert "WHEN TO USE:" in tool.description, (
+                f"{name}: WHEN TO USE missing from the SERVED MCP description "
+                f"(FastMCP dropped it — guidance is below Args/Returns)"
+            )
+            assert "PREFER OVER:" in tool.description, name
+
+
 class TestProtocolIsMandatory:
     """register_tools fails loudly on a tool with no guidance."""
 
@@ -95,3 +131,20 @@ class TestProtocolIsMandatory:
 
         with pytest.raises(ValueError, match="no TOOL_GUIDANCE entry"):
             register_tools(_FakeMcp(), [brand_new_tool])
+
+    def test_register_tools_rejects_blank_guidance_field(self, monkeypatch):
+        """A guidance entry with a blank field fails at the gate, not just in
+        unit tests — the fail-closed check the module docstring promises."""
+        class _FakeMcp:
+            def tool(self):
+                return lambda fn: fn
+
+        async def search_records():  # borrow a real, registered name
+            """Doc."""
+
+        patched = dict(TOOL_GUIDANCE)
+        patched["search_records"] = ToolGuidance(when_to_use="x", when_not="   ", prefer_over="y")
+        monkeypatch.setattr("tool_registry.TOOL_GUIDANCE", patched)
+
+        with pytest.raises(ValueError, match="blank"):
+            register_tools(_FakeMcp(), [search_records])

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -44,9 +44,8 @@ _GUIDANCE_BLOCK = re.compile(
     r'(?=^[ \t]*[A-Z][A-Z ]+:|^[ \t]*$|\Z)'
 )
 
-
 def guidance_footer(name: str) -> str:
-    """The canonical three-line footer generated from a tool's guidance."""
+    """The canonical three-line guidance block generated from a tool's guidance."""
     g = TOOL_GUIDANCE[name]
     return (
         f"WHEN TO USE: {g.when_to_use}\n"
@@ -56,24 +55,65 @@ def guidance_footer(name: str) -> str:
 
 
 def apply_guidance(fn):
-    """Rewrite fn.__doc__ so its guidance comes from TOOL_GUIDANCE (idempotent)."""
-    body = _GUIDANCE_BLOCK.sub("", inspect.getdoc(fn) or "").strip()
+    """Rewrite fn.__doc__ so its guidance comes from TOOL_GUIDANCE (idempotent).
+
+    The block is inserted IMMEDIATELY AFTER THE SUMMARY (the first
+    blank-line-delimited paragraph), because FastMCP/griffe builds the served
+    tool description from the summary plus the paragraphs directly under it, and
+    truncates at the first section-like block (FOOTGUNS:/TABLES:/Args:/…) —
+    verified against fastmcp 3.3.1. A footer placed after those blocks (or after
+    Args) parses fine into `inspect.getdoc`, so every getdoc-based test passes,
+    yet silently vanishes from the wire — the PR #75 regression. Placing it right
+    under the summary is where Tier 1 had it and where it reaches the model.
+    """
+    doc = _GUIDANCE_BLOCK.sub("", inspect.getdoc(fn) or "").strip()
     footer = guidance_footer(fn.__name__)
-    fn.__doc__ = f"{body}\n\n{footer}" if body else footer
+    if not doc:
+        fn.__doc__ = footer
+        return fn
+    summary, _, rest = doc.partition("\n\n")
+    summary = summary.rstrip()
+    rest = rest.strip()
+    fn.__doc__ = f"{summary}\n\n{footer}\n\n{rest}" if rest else f"{summary}\n\n{footer}"
     return fn
 
 
 def register_tools(mcp, fns):
     """Inject guidance into each tool and register it with the FastMCP server.
 
-    Fails loudly if a registered tool has no guidance entry — that is what makes
-    the WHEN/WHEN-NOT/PREFER protocol mandatory rather than merely conventional.
+    Fails loudly if a registered tool has no guidance entry, or has one whose
+    three fields are not all non-blank — that fail-closed gate is what makes the
+    WHEN/WHEN-NOT/PREFER protocol mandatory rather than merely conventional (a
+    blank field would register a tool with an empty guidance line, so the check
+    that lived only in unit tests is mirrored here).
+
+    SIDE EFFECT: `apply_guidance` mutates `fn.__doc__` in place on the live
+    function objects imported from other modules, so importing the MCP entrypoint
+    permanently rewrites those docstrings process-wide (intentional — the served
+    description is generated from the registry).
     """
     missing = [fn.__name__ for fn in fns if fn.__name__ not in TOOL_GUIDANCE]
     if missing:
         raise ValueError(
             f"register_tools: no TOOL_GUIDANCE entry for {missing}. Every tool must "
             f"declare when_to_use / when_not / prefer_over (plan §3.3)."
+        )
+    blank = [
+        fn.__name__
+        for fn in fns
+        if not all(
+            v and v.strip()
+            for v in (
+                TOOL_GUIDANCE[fn.__name__].when_to_use,
+                TOOL_GUIDANCE[fn.__name__].when_not,
+                TOOL_GUIDANCE[fn.__name__].prefer_over,
+            )
+        )
+    ]
+    if blank:
+        raise ValueError(
+            f"register_tools: TOOL_GUIDANCE for {blank} has a blank when_to_use / "
+            f"when_not / prefer_over field. All three are required (plan §3.3)."
         )
     for fn in fns:
         apply_guidance(fn)

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -1,0 +1,210 @@
+"""Tool selection guidance — structured, injected into docstrings (v5.0 Tier 3.3).
+
+The Tier 1 protocol put a WHEN TO USE / WHEN NOT TO USE / PREFER OVER block at the
+top of every tool docstring, as prose. `TOOL_GUIDANCE` makes that block STRUCTURED
+data — one `ToolGuidance` per tool — and `register_tools` injects it back as a
+generated docstring footer at registration. Two payoffs:
+
+  * It forces the protocol. Registration fails if a registered tool has no
+    guidance entry, so a new tool cannot ship without its selection guidance —
+    the thing the prose convention could only ask for politely.
+  * The golden-set test can read the three fields directly (structured) instead
+    of parsing them out of prose.
+
+Injection is idempotent: `apply_guidance` first strips any existing WHEN TO USE …
+PREFER OVER block from the docstring (including a footer it added on a previous
+run), then appends the canonical one. So the served docstring is regenerated from
+this registry — the registry is the single source of truth for tool guidance.
+
+Only three fields, by design (plan §3.3: "only fields something reads"). `domain`,
+`tables`, `public`, `mutates` stay out until a test or router consumes them; at 25
+tools a hand list plus three fields is enough.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ToolGuidance:
+    """The selection guidance for one tool. All three fields are required."""
+    when_to_use: str
+    when_not: str
+    prefer_over: str
+
+
+# The guidance block, wherever it sits in a docstring: from `WHEN TO USE:` through
+# the end of `PREFER OVER:` (and its wrapped continuation lines), stopping at the
+# next uppercase section label (FOOTGUNS/TABLES/SIDE EFFECT/EXAMPLE/…), a blank
+# line, or end of string. Used to strip the old prose block before re-injecting.
+_GUIDANCE_BLOCK = re.compile(
+    r'(?ms)^[ \t]*WHEN TO USE:.*?^[ \t]*PREFER OVER:.*?'
+    r'(?=^[ \t]*[A-Z][A-Z ]+:|^[ \t]*$|\Z)'
+)
+
+
+def guidance_footer(name: str) -> str:
+    """The canonical three-line footer generated from a tool's guidance."""
+    g = TOOL_GUIDANCE[name]
+    return (
+        f"WHEN TO USE: {g.when_to_use}\n"
+        f"WHEN NOT TO USE: {g.when_not}\n"
+        f"PREFER OVER: {g.prefer_over}"
+    )
+
+
+def apply_guidance(fn):
+    """Rewrite fn.__doc__ so its guidance comes from TOOL_GUIDANCE (idempotent)."""
+    body = _GUIDANCE_BLOCK.sub("", inspect.getdoc(fn) or "").strip()
+    footer = guidance_footer(fn.__name__)
+    fn.__doc__ = f"{body}\n\n{footer}" if body else footer
+    return fn
+
+
+def register_tools(mcp, fns):
+    """Inject guidance into each tool and register it with the FastMCP server.
+
+    Fails loudly if a registered tool has no guidance entry — that is what makes
+    the WHEN/WHEN-NOT/PREFER protocol mandatory rather than merely conventional.
+    """
+    missing = [fn.__name__ for fn in fns if fn.__name__ not in TOOL_GUIDANCE]
+    if missing:
+        raise ValueError(
+            f"register_tools: no TOOL_GUIDANCE entry for {missing}. Every tool must "
+            f"declare when_to_use / when_not / prefer_over (plan §3.3)."
+        )
+    for fn in fns:
+        apply_guidance(fn)
+        mcp.tool()(fn)
+    return list(fns)
+
+
+TOOL_GUIDANCE = {
+    "health_check": ToolGuidance(
+        when_to_use='confirm the server is up and ServiceNow is reachable — "is the ServiceNow connection up", "test ServiceNow authentication". Pass probe_table to also list one supported table\'s field names.',
+        when_not="querying records (filter_records / search_records); building or explaining a filter (get_query_syntax_help).",
+        prefer_over="nothing — this is the single diagnostic entry point. It replaces the former nowtest / now_test_oauth / now_auth_info / nowtestauth / nowtest_auth_input tools.",
+    ),
+    "search_records": ToolGuidance(
+        when_to_use='the user describes a topic or symptom and wants matching records — "incidents about a server crashing during backup".',
+        when_not="you already know the record number (get_record); you need field filters like state or priority (filter_records); a priority-plus-date list (get_priority_incidents).",
+        prefer_over="filter_records when the ask is words, not field values.",
+    ),
+    "get_record": ToolGuidance(
+        when_to_use='you know the record number and want its complete detail — "give me the full details of incident INC0012345".',
+        when_not="a list view over many rows (filter_records); text search (search_records).",
+        prefer_over="filter_records when you have the number and want every field of that one record; search_records when you have the number, not keywords.",
+    ),
+    "find_similar": ToolGuidance(
+        when_to_use='you have one record\'s number and want others like it — "find other incidents similar to this one".',
+        when_not="you have search words, not a seed record (search_records); you want that record's own fields (get_record).",
+        prefer_over="search_records when the seed is an existing record, not text.",
+    ),
+    "filter_records": ToolGuidance(
+        when_to_use='the user gives field conditions — state, priority, category, date ranges — "list change requests where state is 3 and category is network".',
+        when_not="free-text topic search (search_records); a single record by number (get_record); a priority-plus-date incident list (get_priority_incidents); KB version rollups (get_kb_articles_by_state).",
+        prefer_over="the table-specific tools when you need an arbitrary filter shape they do not expose.",
+    ),
+    "get_priority_incidents": ToolGuidance(
+        when_to_use='the user names a priority (P1/P2/"priority 1") and wants the matching incidents, optionally within a date range.',
+        when_not='free-text topic search ("incidents about X") — use search_records; arbitrary field filters — use filter_records.',
+        prefer_over="filter_records only for the priority-plus-date shape, which this tool builds with reliable >= / <= operators.",
+    ),
+    "get_kb_articles_by_state": ToolGuidance(
+        when_to_use='the user asks which articles are in a given publication state ("currently in published state", "drafts", "retired KB").',
+        when_not="subject search (search_records on kb_knowledge); one category with no state question (filter_records with kb_category).",
+        prefer_over="filter_records — this collapses ServiceNow's version rows that a raw filter would return duplicated.",
+    ),
+    "create_private_task": ToolGuidance(
+        when_to_use="the user wants a brand-new private task opened.",
+        when_not="to modify a task that already exists (its VTB number is known) — use update_private_task instead.",
+        prefer_over="nothing; this is the only insert path for vtb_task.",
+    ),
+    "update_private_task": ToolGuidance(
+        when_to_use="the task already exists and the user wants to set, close, reassign, or otherwise change it. A VTB number together with a change verb (set / close / update / reassign) is always this tool.",
+        when_not="opening a brand-new task — use create_private_task.",
+        prefer_over="create_private_task whenever the record already exists.",
+    ),
+    "update_knowledge_article": ToolGuidance(
+        when_to_use='change an article\'s content or metadata — "update the body text of KB0001234".',
+        when_not="changing publication state — publish (publish_knowledge_article) or retire (retire_knowledge_article).",
+        prefer_over="nothing; this is the kb_knowledge field-write path.",
+    ),
+    "publish_knowledge_article": ToolGuidance(
+        when_to_use='publish a single article — "publish knowledge article KB0001234".',
+        when_not="several articles at once (use publish_knowledge_articles); only checking for duplicates without publishing (check_kb_duplicates).",
+        prefer_over="publish_knowledge_articles when there is exactly one article.",
+    ),
+    "publish_knowledge_articles": ToolGuidance(
+        when_to_use='two or more articles to publish together — "publish KB0001234, KB0001235 and KB0001236 in one go".',
+        when_not="exactly one article (use publish_knowledge_article); checking duplicates without publishing (check_kb_duplicates).",
+        prefer_over="calling publish_knowledge_article in a loop — this batches and never lets one failure abort the rest.",
+    ),
+    "retire_knowledge_article": ToolGuidance(
+        when_to_use='take a published article out of service — "retire knowledge article KB0004321".',
+        when_not="publishing (publish_knowledge_article); editing content (update_knowledge_article).",
+        prefer_over="nothing; this is the kb_knowledge retire path.",
+    ),
+    "check_kb_duplicates": ToolGuidance(
+        when_to_use='confirm an article has no duplicates before publishing — "check whether KB0001234 has duplicates before I publish it".',
+        when_not="actually publishing (publish_knowledge_article / publish_knowledge_articles run this check themselves first).",
+        prefer_over="nothing; this is the standalone duplicate probe.",
+    ),
+    "get_sla_details": ToolGuidance(
+        when_to_use="you hold the SLA's 32-char sys_id and want that single row.",
+        when_not="you have a task number rather than a sys_id — use query_slas_by_task; a status or stage query — use query_slas_by_status.",
+        prefer_over="query_slas_custom for a known-sys_id point lookup.",
+    ),
+    "query_slas_by_task": ToolGuidance(
+        when_to_use="you have a task number (INC/CHG/RITM/SCTASK/...) and want the SLAs attached to it.",
+        when_not="matching SLAs by the task's wording — use filter_records('task_sla', {'task.short_description': 'LIKE...'}); filtering by status or stage — use query_slas_by_status.",
+        prefer_over="query_slas_custom for this exact task-number lookup.",
+    ),
+    "query_slas_by_status": ToolGuidance(
+        when_to_use='the intent maps to a preset — breached, breaching, active, critical, by_stage, performance ("which SLAs are breached").',
+        when_not="SLAs for one task number (query_slas_by_task); a filter no preset covers (query_slas_custom).",
+        prefer_over="query_slas_custom whenever a preset fits — presets carry curated field lists that protect the token budget.",
+    ),
+    "query_slas_custom": ToolGuidance(
+        when_to_use="the SLA filter you need is not one of query_slas_by_status's presets, and it is not a plain task-number or task-text lookup.",
+        when_not="a preset fits (query_slas_by_status); one task number (query_slas_by_task).",
+        prefer_over="filter_records only when you want task_sla ESSENTIAL_FIELDS defaulting and the optional last-N-days convenience.",
+    ),
+    "find_cis_by_type": ToolGuidance(
+        when_to_use='the user names a CI class — "list every Linux server configuration item".',
+        when_not="searching by attributes like location/IP/status (search_cis_by_attributes); one CI by number (get_ci_details).",
+        prefer_over="search_cis_by_attributes when the filter is purely the class.",
+    ),
+    "search_cis_by_attributes": ToolGuidance(
+        when_to_use='the user filters CIs by attribute — location, IP, status, name — "configuration items at location Brussels with status installed".',
+        when_not="a whole class with no attribute filter (find_cis_by_type); one CI by number (get_ci_details).",
+        prefer_over="find_cis_by_type when the ask includes location/IP/status.",
+    ),
+    "get_ci_details": ToolGuidance(
+        when_to_use='you know the CI number and want its complete record — "get all details for configuration item SRV0001234".',
+        when_not="searching by class (find_cis_by_type) or attributes (search_cis_by_attributes); a loose name/IP lookup (quick_ci_search).",
+        prefer_over="quick_ci_search when you have an exact CI number.",
+    ),
+    "similar_cis_for_ci": ToolGuidance(
+        when_to_use="you have one CI and want others like it (same class, location, status).",
+        when_not="attribute search from scratch (search_cis_by_attributes); one CI's own detail (get_ci_details).",
+        prefer_over="search_cis_by_attributes when the seed is an existing CI.",
+    ),
+    "get_all_ci_types": ToolGuidance(
+        when_to_use='the user wants the list of CI classes this instance defines — "which CI classes exist in this CMDB".',
+        when_not="rows of one class (find_cis_by_type); a specific CI (get_ci_details).",
+        prefer_over="nothing; this is the class-discovery path.",
+    ),
+    "quick_ci_search": ToolGuidance(
+        when_to_use="you have one loose term and don't know which field it is.",
+        when_not="an exact CI number (get_ci_details); structured attribute filters (search_cis_by_attributes); a whole class (find_cis_by_type).",
+        prefer_over="get_ci_details only when the term may not be a CI number.",
+    ),
+    "get_query_syntax_help": ToolGuidance(
+        when_to_use='you need the operator vocabulary in general — "which encoded query operators does ServiceNow support".',
+        when_not="running a query (search_records / filter_records); inspecting the live connection (health_check).",
+        prefer_over="guessing operator syntax when constructing a filter value.",
+    ),
+}

--- a/tools.py
+++ b/tools.py
@@ -46,33 +46,10 @@ from Table_Tools.cmdb_tools import (
 )
 from utility_tools import health_check
 from Table_Tools.intelligent_query_tools import get_query_syntax_help
-from param_coercion import OptJsonDict
+from tool_registry import register_tools
 
-from typing import Any, Dict, List, Optional
-
-
-# fastmcp v3 rejects functions with **kwargs as tools. get_priority_incidents
-# uses **deprecated_kwargs for backwards-compat warnings; expose a clean
-# signature to MCP that forwards to the real implementation. Don't use
-# functools.wraps — it sets __wrapped__, which fastmcp follows back to the
-# original signature.
-async def _mcp_get_priority_incidents(
-    priorities: List[str],
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
-    additional_filters: OptJsonDict = None,
-    include_metadata: bool = False,
-) -> Dict[str, Any]:
-    return await get_priority_incidents(
-        priorities,
-        start_date=start_date,
-        end_date=end_date,
-        additional_filters=additional_filters,
-        include_metadata=include_metadata,
-    )
-
-_mcp_get_priority_incidents.__name__ = "get_priority_incidents"
-_mcp_get_priority_incidents.__doc__ = get_priority_incidents.__doc__
+# v5.0 "Boron" Tier 3.3: get_priority_incidents no longer needs a hand-rolled
+# **kwargs-stripping shim — it dropped **deprecated_kwargs and registers directly.
 
 
 mcp = FastMCP("personalmcpservicenow")
@@ -89,8 +66,8 @@ tools = [
     # Generic table tools (replace 24 table-specific wrappers)
     search_records, get_record, find_similar, filter_records,
 
-    # Priority incidents (unique date logic) — wrapper strips **deprecated_kwargs for fastmcp v3
-    _mcp_get_priority_incidents,
+    # Priority incidents (unique date logic) — registers directly (no **kwargs shim)
+    get_priority_incidents,
 
     # Knowledge read (version-collapsing state rollup)
     get_kb_articles_by_state,
@@ -113,8 +90,9 @@ tools = [
     get_query_syntax_help
 ]
 
-for tool in tools:
-    mcp.tool()(tool)
+# Inject the structured selection-guidance footer (tool_registry.TOOL_GUIDANCE)
+# into each docstring, then register. Fails loudly if any tool lacks guidance.
+register_tools(mcp, tools)
 
 if __name__ == "__main__":
     mcp.run()

--- a/utility_tools.py
+++ b/utility_tools.py
@@ -21,18 +21,9 @@ from http_layer import (
 )
 from constants import TABLE_CONFIGS
 
-
 async def health_check(probe_table: Optional[str] = None) -> Dict[str, Any]:
     """Check this server, its ServiceNow auth config, and the live connection.
 
-    WHEN TO USE: confirm the server is up and ServiceNow is reachable — "is the
-        ServiceNow connection up", "test ServiceNow authentication". Pass
-        probe_table to also list one supported table's field names.
-    WHEN NOT TO USE: querying records (filter_records / search_records);
-        building or explaining a filter (get_query_syntax_help).
-    PREFER OVER: nothing — this is the single diagnostic entry point. It
-        replaces the former nowtest / now_test_oauth / now_auth_info /
-        nowtestauth / nowtest_auth_input tools.
     TABLES: probe_table accepts any supported table; omit it for a plain
         connectivity check.
     SIDE EFFECT: read-only — one lightweight authenticated GET against


### PR DESCRIPTION
## Tier 3.3 — tool-guidance registry + docstring-footer injection

Stacked PR **3 of 3** for v5.0 "Boron" Tier 3. **Base: `feature/v5.0_tablespec`** (merge PRs 1 and 2 first).

The Tier 1 WHEN TO USE / WHEN NOT TO USE / PREFER OVER block lived as prose atop all 25 tool docstrings. New `tool_registry.TOOL_GUIDANCE` makes it **structured** data — one `ToolGuidance` per tool — and `register_tools()` injects it back as a generated docstring footer at registration.

- `register_tools()` fails loudly if a registered tool has no guidance entry → the selection-guidance protocol is now mandatory, not a convention.
- Injection is idempotent (strips any existing block, re-appends canonical footer); the registry is the single source of truth. Prose stripped from source docstrings accordingly.
- The golden-set test can read the three fields as structured data instead of parsing prose. Three fields only (plan §3.3: "only fields something reads").

**Shim absorbed:** `get_priority_incidents` dropped its `**deprecated_kwargs` backwards-compat path (deprecated since v4.0), so it registers directly and the hand-rolled `_mcp_get_priority_incidents` wrapper is gone. Extra field filters go through `additional_filters` (typed `OptJsonDict`); a stray keyword is now a `TypeError`.

NEW `tests/test_tool_registry.py` pins coverage, single-footer injection, idempotency, mandatory-protocol failure.

**Suite: 1125 passed.** Tool-listing footprint 6716 → 6743 (footer labels; ceiling 7200). Golden-set baselines unchanged.
