### PR TITLE
docs(v5.0): refresh diagram bodies for Boron surface

### DIFF
--- a/Diagrams & Documentation/01-architecture-overview.md
+++ b/Diagrams & Documentation/01-architecture-overview.md
@@ -1,6 +1,6 @@
-# MCP Server Architecture Overview (v4.3)
+# MCP Server Architecture Overview (v5.0)
 
-Layered view of the Personal MCP ServiceNow server after the v3 generic-tool consolidation, the v4 package splits (`filter/`, `http_layer/`, `oauth/`), v4.1 shim deletion, v4.1–4.2 KB/perf work, and v4.3 MCPB packaging.
+Layered view of the Personal MCP ServiceNow server after the v3 generic-tool consolidation, the v4 package splits (`filter/`, `http_layer/`, `oauth/`), and the v5.0 "Boron" surface cull: **25 tools**, no in-repo NL engine, §3.1 response contract, `table_spec` SSOT, and guidance-injected registration.
 
 ```mermaid
 graph TB
@@ -11,22 +11,22 @@ graph TB
     subgraph "MCP Server Core"
         B --> C[tools.py — FastMCP]
         C --> MW[AuthMiddleware + AuditMiddleware]
-        MW --> D[Tool registration — 39 tools]
+        MW --> REG[tool_registry.register_tools<br/>guidance injection — 25 tools]
     end
 
     subgraph "Tool Categories"
-        D --> E[Utility / auth — 5]
-        D --> F[Intelligent query — 6]
-        D --> G[Generic wrappers — 5]
-        D --> H[Consolidated — priority, KB read, SLA]
-        D --> I[CMDB — 6]
-        D --> J[VTB CRUD — 2]
-        D --> K[KB write — 5]
+        REG --> E[Diagnostic — 1]
+        REG --> F[Query syntax — 1]
+        REG --> G[Generic wrappers — 4]
+        REG --> H[Consolidated — priority, KB state, SLA]
+        REG --> I[CMDB — 6]
+        REG --> J[VTB CRUD — 2]
+        REG --> K[KB write — 5]
     end
 
     subgraph "Implementation modules"
-        E --> L[utility_tools.py / table_tools.py]
-        F --> AI[intelligent_query_tools.py]
+        E --> L[utility_tools.py]
+        F --> IQ[intelligent_query_tools.py<br/>get_query_syntax_help only]
         G --> GW[generic_tool_wrappers.py]
         H --> CT[consolidated_tools.py]
         I --> CMDB[cmdb_tools.py]
@@ -34,14 +34,19 @@ graph TB
         K --> KB[kb_article_tools.py]
         GW --> GTT[generic_table_tools.py]
         CT --> GTT
-        AI --> GTT
-        AI --> NLP[filter/intelligence.py]
+        GW --> RESP[Table_Tools/response.py<br/>§3.1 contract]
+        CT --> RESP
+        VTB --> RESP
+        KB --> RESP
+        CMDB --> RESP
+        L --> RESP
+        IQ --> RESP
     end
 
     subgraph "filter/ package"
-        NLP --> FV[filter/validator.py]
-        FV --> FB[filter/builder.py]
-        AI --> FEXP[filter/explainer.py]
+        GTT --> FB[filter/builder.py]
+        GTT --> FV[filter/validator.py]
+        GTT --> FVE[filter/value_encoding.py]
         GTT --> FMOD[filter/models.py<br/>TableFilterParams]
     end
 
@@ -51,8 +56,9 @@ graph TB
         VTB --> DISP
         KB --> DISP
         L --> DISP
+        CMDB --> DISP
         DISP -->|GET| URL[url_builder<br/>encode + default params]
-        DISP -->|GET response| RESP[response_parser<br/>display_value flatten]
+        DISP -->|GET response| RPAR[response_parser<br/>display_value flatten]
         DISP -->|POST/PATCH| WRITE[oauth client write path<br/>no GET transforms]
     end
 
@@ -66,7 +72,9 @@ graph TB
     end
 
     subgraph "Support"
-        GTT --> CONST[constants.py]
+        SPEC[table_spec.py<br/>TABLE_SPECS SSOT]
+        SPEC --> CONST[constants.py<br/>derived maps]
+        GTT --> CONST
         GTT --> UTILS[utils.py]
         CT --> DATE[date_utils.py]
         C --> COERCE[param_coercion.py]
@@ -76,38 +84,47 @@ graph TB
     style GTT fill:#e1f5fe,stroke:#2196f3,stroke-width:3px
     style DISP fill:#fce4ec,stroke:#e91e63,stroke-width:2px
     style CLI fill:#fff3e0,stroke:#ff9800,stroke-width:2px
+    style RESP fill:#f3e5f5,stroke:#9c27b0,stroke-width:2px
+    style SPEC fill:#e8eaf6,stroke:#3f51b5,stroke-width:2px
 ```
 
 ## Architecture components
 
 ### Core
 - **Transport**: stdio (Claude Desktop / MCPB) or SSE (`MCP_TRANSPORT=sse`, Docker)
-- **FastMCP** in `tools.py`: registers 39 tools; `AuthMiddleware` (SSE bearer) then `AuditMiddleware` (structured JSON logs to stderr)
-- **`param_coercion`**: stringified JSON dict params coerced at the tool boundary (MCP clients sometimes send JSON as strings)
+- **FastMCP** in `tools.py`: registers **25** tools via `tool_registry.register_tools` (mandatory WHEN / WHEN-NOT / PREFER guidance injected into each docstring above `Args:`)
+- **`AuthMiddleware`** (SSE bearer) then **`AuditMiddleware`** (structured JSON logs to stderr)
+- **`param_coercion`**: stringified JSON dict params coerced at the tool boundary
 
 ### Tool layer
 | Module | Role |
 |--------|------|
-| `generic_tool_wrappers.py` | 5 table-parameterized tools; validates `table` against `TABLE_CONFIGS` |
-| `consolidated_tools.py` | Priority incidents, knowledge read tools, 5 SLA tools |
+| `generic_tool_wrappers.py` | 4 table-parameterized tools; validates `table` against `TABLE_CONFIGS` |
+| `consolidated_tools.py` | Priority incidents, `get_kb_articles_by_state`, 4 SLA tools |
 | `vtb_task_tools.py` | `create_private_task` / `update_private_task` (PATCH) |
 | `kb_article_tools.py` | Update, publish, batch publish, retire, duplicate check |
 | `cmdb_tools.py` | 6 CMDB tools; concurrent CI table probes on detail lookup |
-| `intelligent_query_tools.py` | NL search + filter explain/build/templates/examples + `get_query_syntax_help` |
-| `utility_tools.py` / `table_tools.py` | Connectivity and auth diagnostics |
+| `intelligent_query_tools.py` | `get_query_syntax_help` only (encoded-query operator reference) |
+| `utility_tools.py` | `health_check(probe_table=None)` — single diagnostic |
 
-### `filter/` (v4.0 Sprint 1; shims removed v4.1)
+### SSOT + registration (v5.0)
+- **`table_spec.py`**: one `TableSpec` per table; `constants.py` derives `TABLE_CONFIGS`, `ESSENTIAL_FIELDS`, `DETAIL_FIELDS`, `TABLE_ERROR_MESSAGES`, and identity/text-search maps from it
+- **`tool_registry.py`**: `TOOL_GUIDANCE` + `register_tools()` — selection guidance is structured data, not free-form prose in each file
+- **`Table_Tools/response.py`**: `error_response` / `list_response` / `record_response` — §3.1 contract constructors used by every tool
+
+### `filter/` (v4.0 Sprint 1; NL modules removed v5.0)
 - **builder**: `ServiceNowQueryBuilder` — OR / date-range / exclusion constructors
-- **validator**: validate + `validate_and_correct_filters` (only bridge allowed to call builder from NL path)
-- **intelligence**: `QueryIntelligence` — regex NL → filters; **does not** import builder
-- **explainer**: human-readable explanation + size estimation
-- **models**: `TableFilterParams`, `QueryValidationResult` (`SmartQueryParams` removed in v4.1)
+- **validator**: validate + `validate_and_correct_filters` + result-count / pagination helpers
+- **value_encoding** (v4.4.1): `encode_query_value` — per-value escaping; refuses `^` in operand values
+- **models**: `TableFilterParams`, `QueryValidationResult`
+- **Removed in v5.0**: `filter/intelligence.py`, `filter/explainer.py` (in-repo NL engine; host model does NL → filter)
 
 ### `http_layer/` (v4.0 Sprint 3)
 - **`make_nws_request`**: GET applies `ensure_query_encoded` + `add_default_params` + `extract_display_values`
 - **Writes (POST/PATCH/DELETE)**: bypass all three — locked by negative tests in `tests/test_http_layer.py`
 - **Default GET params**: `sysparm_display_value=true`, `sysparm_exclude_reference_link=true`, `sysparm_no_count=true`
 - **Pagination**: `_make_paginated_request` + deterministic `^ORDERBYDESCsys_created_on` unless an ORDERBY already exists
+- **Read-failure contract** (v4.4): failed GET raises `ServiceNowRequestError` (never `None` for failure)
 
 ### `oauth/` (v4.0 Sprint 3 + v4.2 pool)
 - **singleton** (`oauth/singleton.py`): process-wide client + `make_oauth_request`
@@ -118,8 +135,20 @@ graph TB
 - **exceptions**: OAuth / Authentication / Connection / Authorization
 
 ### Configuration
-- `constants.py`: `TABLE_CONFIGS`, `ESSENTIAL_FIELDS`, `DETAIL_FIELDS`, error strings
+- `table_spec.py` → `constants.py` derived maps (tables, fields, error strings)
 - Env vars or `~/.config/mcp-servicenow/config.json` via `config_loader.py`
+
+## Response contract (§3.1)
+
+| Shape | Envelope |
+|-------|----------|
+| List success | `{result, returned_count, truncated}` |
+| Single record | `{record}` (`record` may be `null` for a miss) |
+| Write success | `{record, message}` |
+| Failure | `{error: {code, message}}` — codes: `VALIDATION` \| `NOT_FOUND` \| `AUTH` \| `FORBIDDEN` \| `TIMEOUT` \| `HTTP` \| `INTERNAL` |
+| Partial page | collected rows + `{partial: true, error}` (only sanctioned data+error coexist) |
+
+Presence of `error` is the discriminator. No bare strings; no `{"message": ...}` success dialect.
 
 ## Supported tables
 
@@ -132,21 +161,21 @@ graph TB
 | `universal_request` | UR |
 | `kb_knowledge` | KB; no priority field |
 | `vtb_task` | VTB; only table with generic-path CRUD tools |
-| `task_sla` | stage instead of state; no number prefix |
+| `task_sla` | stage instead of state; no number prefix (`number_field` structural in `TableSpec`) |
 
-## Tool inventory (39 tools — v4.3)
+## Tool inventory (25 tools — v5.0 "Boron")
 
 | # | Tools | Source |
 |---|--------|--------|
-| 1–5 | `nowtest`, `now_test_oauth`, `now_auth_info`, `nowtestauth`, `nowtest_auth_input` | utility / table_tools |
-| 6–10 | `search_records`, `get_record_summary`, `get_record`, `find_similar`, `filter_records` | generic_tool_wrappers |
-| 11 | `get_priority_incidents` | consolidated_tools |
-| 12–15 | `similar_knowledge_for_text`, `get_knowledge_by_category`, `get_active_knowledge_articles`, `get_kb_articles_by_state` | consolidated_tools |
-| 16–17 | `create_private_task`, `update_private_task` | vtb_task_tools |
-| 18–22 | `update_knowledge_article`, `publish_knowledge_article`, `publish_knowledge_articles`, `retire_knowledge_article`, `check_kb_duplicates` | kb_article_tools |
-| 23–27 | `similar_slas_for_text`, `get_sla_details`, `query_slas_by_task`, `query_slas_by_status`, `query_slas_custom` | consolidated_tools |
-| 28–33 | `find_cis_by_type`, `search_cis_by_attributes`, `get_ci_details`, `similar_cis_for_ci`, `get_all_ci_types`, `quick_ci_search` | cmdb_tools |
-| 34–39 | `intelligent_search`, `explain_servicenow_filters`, `build_smart_servicenow_filter`, `get_servicenow_filter_templates`, `get_query_examples`, `get_query_syntax_help` | intelligent_query_tools |
+| 1 | `health_check` | utility_tools |
+| 2–5 | `search_records`, `get_record`, `find_similar`, `filter_records` | generic_tool_wrappers |
+| 6 | `get_priority_incidents` | consolidated_tools |
+| 7 | `get_kb_articles_by_state` | consolidated_tools |
+| 8–9 | `create_private_task`, `update_private_task` | vtb_task_tools |
+| 10–14 | `update_knowledge_article`, `publish_knowledge_article`, `publish_knowledge_articles`, `retire_knowledge_article`, `check_kb_duplicates` | kb_article_tools |
+| 15–18 | `get_sla_details`, `query_slas_by_task`, `query_slas_by_status`, `query_slas_custom` | consolidated_tools |
+| 19–24 | `find_cis_by_type`, `search_cis_by_attributes`, `get_ci_details`, `similar_cis_for_ci`, `get_all_ci_types`, `quick_ci_search` | cmdb_tools |
+| 25 | `get_query_syntax_help` | intelligent_query_tools |
 
 ## Version lineage (short)
 
@@ -157,10 +186,14 @@ graph TB
 | **v4.1** | Shims deleted; KB write tools + `get_kb_articles_by_state`; `get_query_syntax_help`; `filter_records` truncation metadata |
 | **v4.2** | Pooled httpx; single OR-combined LIKE text search; CMDB concurrency / encoding |
 | **v4.3** | Claude Desktop `.mcpb` packaging (no Nuitka release path) |
+| **v4.4** | Read-failure raise contract; encoded-query value boundary (`^` refuse, `&` left transport safe-set) |
+| **v5.0** | 39→25 tool cull; NL engine deleted; §3.1 response contract; `table_spec` + `tool_registry` |
 
 ## Key invariants
 
 1. **GET** always applies encode + default sysparm + display-value flatten.
 2. **Write methods** never apply those GET transforms.
-3. **filter/intelligence** must not import **filter/builder** (auto-correct only via validator).
-4. **Stdout** is reserved for MCP JSON-RPC; logs and prints go to **stderr**.
+3. **Failed GET raises** `ServiceNowRequestError` — never returns `None` to mean failure.
+4. **Value encoding**: producer safe-set is transport's minus `^`; `&` is not safe in the transport.
+5. **Stdout** is reserved for MCP JSON-RPC; logs and prints go to **stderr**.
+6. **Every tool** returns a §3.1 envelope via `Table_Tools/response.py` constructors.

--- a/Diagrams & Documentation/03-tool-organization.md
+++ b/Diagrams & Documentation/03-tool-organization.md
@@ -1,6 +1,6 @@
-# Tool Organization (v4.3)
+# Tool Organization (v5.0)
 
-How 39 MCP tools are grouped by module, and how the v3 generic-wrapper consolidation still underpins table access.
+How **25** MCP tools are grouped by module after the v5.0 "Boron" cull, and how the v3 generic-wrapper consolidation still underpins table access.
 
 ## Historical consolidation (v3 — still the foundation)
 
@@ -14,10 +14,9 @@ graph TB
         OLD5["… 20 more one-line wrappers"]
     end
 
-    subgraph "After v3: 5 generic tools"
+    subgraph "After v3 → v5: 4 generic tools"
         NEW1["search_records(table, query)"]
         NEW2["get_record(table, number)"]
-        NEW3["get_record_summary(table, number)"]
         NEW4["find_similar(table, number)"]
         NEW5["filter_records(table, filters, fields, max_results)"]
     end
@@ -30,7 +29,6 @@ graph TB
 
     NEW1 --> GTT[generic_table_tools.py]
     NEW2 --> GTT
-    NEW3 --> GTT
     NEW4 --> GTT
     NEW5 --> GTT
 
@@ -39,22 +37,22 @@ graph TB
     style OLD5 fill:#ffebee,stroke:#f44336,stroke-width:1px
 ```
 
-Later releases **added** domain tools (KB write, SLA collapse, syntax help) without bringing back per-table search wrappers.
+v5.0 removed `get_record_summary` (folded into `get_record`). Later releases **added** domain tools (KB write, SLA collapse, syntax help) without bringing back per-table search wrappers; v5.0 then culled near-duplicates and the in-repo NL surface.
 
-## Current tool map (39 tools)
+## Current tool map (25 tools)
 
 ```mermaid
 graph LR
-    subgraph "39 MCP tools"
-        A[Generic table — 5]
+    subgraph "25 MCP tools"
+        A[Generic table — 4]
         B[Priority incidents — 1]
-        C[Knowledge read — 4]
+        C[Knowledge state — 1]
         D[KB write — 5]
         E[Private task CRUD — 2]
-        F[SLA — 5]
+        F[SLA — 4]
         G[CMDB — 6]
-        H[Intelligent query — 6]
-        I[Utility / auth — 5]
+        H[Query syntax — 1]
+        I[Diagnostic — 1]
     end
 
     A --> W[generic_tool_wrappers.py]
@@ -65,11 +63,10 @@ graph LR
     E --> VTB[vtb_task_tools.py]
     G --> CMDB[cmdb_tools.py]
     H --> IQ[intelligent_query_tools.py]
-    I --> U[utility_tools.py / table_tools.py]
+    I --> U[utility_tools.py]
 
     W --> GTT[generic_table_tools.py]
     CNS --> GTT
-    IQ --> GTT
     GTT --> HTTP[http_layer.make_nws_request]
     VTB --> HTTP
     KB --> HTTP
@@ -77,9 +74,18 @@ graph LR
     U --> HTTP
     HTTP --> SN[ServiceNow REST]
 
+    W --> R[Table_Tools/response.py]
+    CNS --> R
+    KB --> R
+    VTB --> R
+    CMDB --> R
+    U --> R
+    IQ --> R
+
     style W fill:#e8f5e8,stroke:#4caf50,stroke-width:3px
     style GTT fill:#e1f5fe,stroke:#2196f3,stroke-width:2px
     style HTTP fill:#fce4ec,stroke:#e91e63,stroke-width:2px
+    style R fill:#f3e5f5,stroke:#9c27b0,stroke-width:2px
 ```
 
 ## Generic wrapper path
@@ -88,7 +94,7 @@ graph LR
 graph TB
     CALL["search_records(table='incident', query='server down')"]
     CALL --> VAL{table in TABLE_CONFIGS?}
-    VAL -->|No| ERR[Error: unsupported table]
+    VAL -->|No| ERR["error_response VALIDATION"]
     VAL -->|Yes| DELEGATE[query_table_by_text / other engine fn]
 
     DELEGATE --> KW[extract_keywords]
@@ -97,38 +103,41 @@ graph TB
     PAG --> REQ[make_nws_request GET]
     REQ --> URL[url_builder + response_parser]
     URL --> SN[ServiceNow]
+    SN --> OUT["list_response result + returned_count + truncated"]
 
     style VAL fill:#fff3e0,stroke:#ff9800,stroke-width:2px
     style ORQ fill:#e8f5e8,stroke:#4caf50,stroke-width:2px
+    style OUT fill:#f3e5f5,stroke:#9c27b0,stroke-width:2px
 ```
 
-### Supported tables (`TABLE_CONFIGS`)
+### Supported tables (`TABLE_CONFIGS`, derived from `table_spec.TABLE_SPECS`)
 
 `incident` · `change_request` · `sc_req_item` · `sc_task` · `universal_request` · `kb_knowledge` · `vtb_task` · `task_sla`
 
 ## Categories in detail
 
-### Generic table tools (5) — `generic_tool_wrappers.py`
+### Generic table tools (4) — `generic_tool_wrappers.py`
 
 | Tool | Engine function | Notes |
 |------|-----------------|--------|
-| `search_records` | `query_table_by_text` | Single OR-LIKE request (v4.2) |
-| `get_record` | `get_record_details` | Detail field set |
-| `get_record_summary` | short description path | Lean response |
+| `search_records` | `query_table_by_text` | Single OR-LIKE request (v4.2); list §3.1 shape |
+| `get_record` | `get_record_details` | Returns `{record}` (or `record: null` on miss) |
 | `find_similar` | `find_similar_records` | Similarity via description text |
-| `filter_records` | `query_table_with_filters` | Optional `max_results` (default 100, max 1000); response includes `returned_count`, `truncated`, `max_results` |
+| `filter_records` | `query_table_with_filters` | Optional `max_results` (default 100, max 1000); `returned_count` / `truncated` |
 
 ### Consolidated tools — `consolidated_tools.py`
 
-- **Priority**: `get_priority_incidents` — date ranges + metadata (MCP wrapper strips `**kwargs` for FastMCP v3)
-- **Knowledge read** (4): `similar_knowledge_for_text`, `get_knowledge_by_category`, `get_active_knowledge_articles`, `get_kb_articles_by_state` (collapses KB versions to one row per `number`)
-- **SLA** (5): see [06-sla-architecture-flow.md](./06-sla-architecture-flow.md)
+- **Priority**: `get_priority_incidents` — date ranges + metadata; extra filters via `additional_filters` (no deprecated `**kwargs`)
+- **Knowledge state** (1): `get_kb_articles_by_state` — collapses KB versions to one row per `number` (published > draft > review > outdated > retired)
+- **SLA** (4): see [06-sla-architecture-flow.md](./06-sla-architecture-flow.md)
+
+Removed in v5.0: the three smart-KB reads (`similar_knowledge_for_text`, `get_knowledge_by_category`, `get_active_knowledge_articles`) — use `search_records` / `filter_records` / `get_kb_articles_by_state` instead.
 
 ### KB write (5) — `kb_article_tools.py`
 
 `update_knowledge_article` · `publish_knowledge_article` · `publish_knowledge_articles` (batch, cap 20) · `retire_knowledge_article` · `check_kb_duplicates`
 
-Shared helpers in `write_helpers.py` (`map_http_error`, `unwrap_write_response`).
+Shared helpers in `write_helpers.py` (`map_http_error`, `unwrap_write_response`). Write success → `{record, message}`; failure → `{error: {code, message}}`. Publish is fail-closed on inconclusive duplicate checks.
 
 ### Private tasks (2) — `vtb_task_tools.py`
 
@@ -138,13 +147,19 @@ Shared helpers in `write_helpers.py` (`map_http_error`, `unwrap_write_response`)
 
 `find_cis_by_type` · `search_cis_by_attributes` · `get_ci_details` · `similar_cis_for_ci` · `get_all_ci_types` · `quick_ci_search`
 
-### Intelligent query (6) — `intelligent_query_tools.py`
+Empty results are success shapes (`{result: []}` / `{record: null}`), not bare not-found strings.
 
-`intelligent_search` · `explain_servicenow_filters` · `build_smart_servicenow_filter` · `get_servicenow_filter_templates` · `get_query_examples` · `get_query_syntax_help` (encoded-query operator reference)
+### Query-syntax reference (1) — `intelligent_query_tools.py`
 
-### Utility / auth (5)
+`get_query_syntax_help` — encoded-query operator reference for the host model.
 
-`nowtest` · `now_test_oauth` · `now_auth_info` · `nowtestauth` · `nowtest_auth_input`
+Removed in v5.0: the five NL/filter tools (`intelligent_search`, `explain_servicenow_filters`, `build_smart_servicenow_filter`, `get_servicenow_filter_templates`, `get_query_examples`). Natural language → filter is the host model's job.
+
+### Diagnostic (1) — `utility_tools.py`
+
+`health_check(probe_table=None)` — server liveness, auth config, live connection; optional table field peek.
+
+Removed in v5.0: `nowtest`, `now_test_oauth`, `now_auth_info`, `nowtestauth`, `nowtest_auth_input`.
 
 ## Counts over time
 
@@ -153,10 +168,13 @@ Shared helpers in `write_helpers.py` (`map_http_error`, `unwrap_write_response`)
 | Pre-v3 | ~55 | Many per-table wrappers |
 | v3 | ~36–37 | Generic wrappers land |
 | v4.0 | 32 | SLA 10 → 5 |
-| v4.1+ | **39** | KB expansion + `get_query_syntax_help` + state collapse tool |
+| v4.1+ | 39 | KB expansion + `get_query_syntax_help` + state collapse tool |
+| **v5.0** | **25** | 39→25 cull + §3.1 response contract + `table_spec` / `tool_registry` |
 
 ## Extensibility
 
-1. Add an entry to `TABLE_CONFIGS` / field maps in `constants.py`
-2. The five generic tools pick up the table automatically
+1. Add a `TableSpec` in `table_spec.py` (SSOT) — derived maps in `constants.py` update automatically
+2. The four generic tools pick up the table automatically
 3. Add a dedicated tool only when behaviour cannot fit the generic engine (dates, KB workflow, CMDB multi-table, SLA presets)
+4. Register via `tool_registry.register_tools` with mandatory WHEN / WHEN-NOT / PREFER guidance
+5. Return shapes only through `Table_Tools/response.py` constructors

--- a/Diagrams & Documentation/04-similarity-search-flow.md
+++ b/Diagrams & Documentation/04-similarity-search-flow.md
@@ -1,30 +1,40 @@
-# Search & Query Flow (v4.3)
+# Search & Query Flow (v5.0)
 
-How text search and AI-assisted search reach ServiceNow: keyword extraction, **one** OR-combined LIKE query (v4.2), pagination, and the GET-only HTTP transforms.
+How text search and structured filters reach ServiceNow: keyword extraction, **one** OR-combined LIKE query (v4.2), pagination, the GET-only HTTP transforms, and the §3.1 response envelopes.
+
+> **v5.0 note:** the in-repo NL path (`intelligent_search`, `filter/intelligence`, `filter/explainer`) is gone. The host model builds filters natively and calls `search_records` / `filter_records` directly.
 
 ## End-to-end flow
 
 ```mermaid
 flowchart TD
-    A["User: find incidents about network outage"] --> B{Tool}
-    B -->|Generic| C["search_records(table, query)"]
-    B -->|NL / AI| D["intelligent_search(params)"]
+    A["User / host model: find incidents about network outage"] --> B{Tool}
+    B -->|Text search| C["search_records(table, query)"]
+    B -->|Structured filters| FR["filter_records(table, filters, …)"]
+    B -->|By number| GR["get_record(table, number)"]
+    B -->|Similarity| FS["find_similar(table, number)"]
 
     C --> VAL{table in TABLE_CONFIGS?}
-    VAL -->|No| VALERR[Unsupported table error]
-    VAL -->|Yes| E[query_table_by_text]
+    FR --> VAL
+    GR --> VAL
+    FS --> VAL
+    VAL -->|No| VALERR["error_response VALIDATION"]
+    VAL -->|Yes| ROUTE{Path}
 
-    D --> F[filter/intelligence QueryIntelligence]
-    F --> V[filter/validator validate_and_correct]
-    V --> R[query_table_with_filters / engine]
+    ROUTE -->|text| E[query_table_by_text]
+    ROUTE -->|filters| R[query_table_with_filters]
+    ROUTE -->|detail| DET[get_record_details]
+    ROUTE -->|similar| SIM[find_similar_records → query_table_by_text]
 
     E --> G[extract_keywords]
     G --> H{Keywords?}
-    H -->|No| L[No records / empty result]
+    H -->|No| L["list_response empty"]
     H -->|Yes| ORQ["Build single query:<br/>short_descriptionLIKEk1^ORshort_descriptionLIKEk2…"]
 
     ORQ --> PAG
     R --> PAG
+    DET --> API
+    SIM --> E
 
     PAG[_make_paginated_request]
     PAG --> SORT[_inject_sort_order<br/>^ORDERBYDESCsys_created_on]
@@ -34,7 +44,7 @@ flowchart TD
     PERF --> OAUTH[oauth request_executor + pool]
     OAUTH --> SN[ServiceNow Table API]
     SN --> FLAT[response_parser.extract_display_values]
-    FLAT --> OUT[Return records / intelligence metadata]
+    FLAT --> OUT["§3.1 envelope<br/>list / record / error"]
 
     subgraph "GET-only invariants"
         ENC
@@ -43,23 +53,25 @@ flowchart TD
     end
 
     style C fill:#e8f5e8,stroke:#4caf50,stroke-width:3px
-    style D fill:#f3e5f5,stroke:#9c27b0,stroke-width:2px
+    style FR fill:#e8f5e8,stroke:#4caf50,stroke-width:2px
     style ORQ fill:#e1f5fe,stroke:#2196f3,stroke-width:2px
     style PERF fill:#fce4ec,stroke:#e91e63,stroke-width:2px
+    style OUT fill:#f3e5f5,stroke:#9c27b0,stroke-width:2px
 ```
 
 ## Generic search (`search_records`)
 
-1. **Validate table** against `TABLE_CONFIGS` (8 tables).
+1. **Validate table** against `TABLE_CONFIGS` (8 tables, derived from `table_spec.TABLE_SPECS`).
 2. **Extract keywords** via compiled regex / stop-word filtering (`utils.extract_keywords`).
 3. **Build one `sysparm_query`**:  
    `short_descriptionLIKE{k1}^ORshort_descriptionLIKE{k2}^OR…`  
-   (v4.2 — **not** one serial request per keyword).
+   (v4.2 — **not** one serial request per keyword; LIKE, never CONTAINS).
 4. **Paginate** with `sysparm_offset` / `sysparm_limit` and deterministic sort.
 5. **GET pipeline** in `make_nws_request`:
-   - encode `sysparm_query` (preserve SN operators in the safe set)
+   - encode `sysparm_query` (preserve SN operators in the transport safe-set)
    - inject `sysparm_display_value`, `sysparm_exclude_reference_link`, `sysparm_no_count`
    - flatten `{display_value, value}` envelopes
+6. **Return** `list_response` → `{result, returned_count, truncated}`. Failures raise then map to `{error: {code, message}}`.
 
 ### Example URL shape
 
@@ -74,36 +86,43 @@ flowchart TD
   &sysparm_offset=0
 ```
 
-## AI-assisted search (`intelligent_search`)
-
-1. Parse natural language with **`filter.intelligence.QueryIntelligence`** (regex-based, not an external LLM).
-2. Map phrases to priority / date / state / keyword fragments.
-3. **Validate / auto-correct** in `filter.validator` (may call `ServiceNowQueryBuilder` — intelligence never imports builder).
-4. Execute via the table filter engine; attach confidence, explanation, and related metadata when available.
-5. Fall back to text search (`query_table_by_text`) when NL conversion is weak.
-
-Related tools (same package):  
-`build_smart_servicenow_filter`, `explain_servicenow_filters`, `get_servicenow_filter_templates`, `get_query_examples`, `get_query_syntax_help`.
-
 ## Similarity (`find_similar`)
 
 1. Load the seed record’s short description (or detail fields).
 2. Reuse **`query_table_by_text`** on that description so the same OR-LIKE path runs.
-3. Return peer records (excluding trivial self-matches as implemented in the engine).
+3. Return peer records as a list envelope (excluding trivial self-matches as implemented in the engine).
 
 ## Structured filter (`filter_records`)
 
 - Accepts structured filter maps (and coerced JSON dicts via `param_coercion`).
 - Optional **`max_results`** (default 100, max 1000).
-- Response metadata: **`returned_count`**, **`truncated`**, **`max_results`** for partial-set detection (v4.1).
+- Response: **`{result, returned_count, truncated}`** (§3.1 list shape; `max_results` is a call param, not a response key requirement beyond truncation detection).
+- Filter values pass through `filter/value_encoding.encode_query_value` (refuses `^` in operands); assembled queries go through the transport encoder.
+
+## Single record (`get_record`)
+
+- Returns **`{record: {...}}`** on hit, **`{record: null}`** on miss — never a one-row `result` list.
+- Detail field set from `DETAIL_FIELDS` (derived from `TableSpec`).
+
+## Host-model NL (replaces removed intelligent_search)
+
+The host model translates natural language into:
+
+- `search_records(table, "keywords…")` for free-text, or
+- `filter_records(table, {field: value, …})` for structured conditions, or
+- `get_query_syntax_help` when it needs the encoded-query operator reference.
+
+There is no server-side regex NL engine and no confidence/explanation metadata path.
 
 ## HTTP enhancements (still critical)
 
 | Concern | Implementation |
 |---------|----------------|
 | Stable pages | `_inject_sort_order` → `^ORDERBYDESCsys_created_on` unless ORDERBY present |
-| Encoding | `ensure_query_encoded` — unquote then `quote(..., safe='=<>&^():@!')` |
+| Value encoding | `encode_query_value` — safe `=<>():@!`; **refuses `^`** in operand values |
+| Transport encoding | `encode_query_string` — safe `=<>^():@!` (**no `&`** — v4.4.1) |
 | Token size / latency | `exclude_reference_link` + `no_count` + essential field lists |
 | Display values | flatten after GET only |
+| Read failure | raises `ServiceNowRequestError` — never `None` for failure |
 
 Writes (VTB, KB) use the same OAuth stack but **skip** encode/default-params/flatten.

--- a/Diagrams & Documentation/06-sla-architecture-flow.md
+++ b/Diagrams & Documentation/06-sla-architecture-flow.md
@@ -1,6 +1,6 @@
-# SLA Architecture (v4.3)
+# SLA Architecture (v5.0)
 
-SLA monitoring against the ServiceNow **`task_sla`** table. v4 collapsed **10 tools into 5**: three task/status/custom entry points plus details and text similarity. Defaults favour small, recent result sets so large instances do not flood the LLM context.
+SLA monitoring against the ServiceNow **`task_sla`** table. v4 collapsed **10 tools into 5**; v5.0 removed the broken text-similarity entry point, leaving **4 SLA tools**. Defaults favour small, recent result sets so large instances do not flood the LLM context.
 
 ## Tool surface (current)
 
@@ -10,7 +10,9 @@ SLA monitoring against the ServiceNow **`task_sla`** table. v4 collapsed **10 to
 | `query_slas_by_task(task_number)` | All SLAs for a parent task number |
 | `query_slas_custom(filters, fields, days)` | Escape hatch; `fields=None` → `ESSENTIAL_FIELDS["task_sla"]` |
 | `get_sla_details(sla_sys_id)` | Single row by **`sys_id=`** (v3 bug fixed) |
-| `similar_slas_for_text(input_text)` | Text-oriented SLA discovery |
+
+> **Removed in v5.0:** `similar_slas_for_text` — it queried a `short_description` field that `task_sla` lacks, so ServiceNow silently returned an arbitrary page. Replacement:  
+> `filter_records("task_sla", {"task.short_description": "LIKE…"})`.
 
 ### `query_slas_by_status` presets
 
@@ -27,12 +29,12 @@ active | breached | breaching | critical | by_stage | performance
 | `by_stage` | Stage filter | Requires `stage=` |
 | `performance` | Summary-oriented | Curated field list; `days` window |
 
-Unknown `status` → `ValueError`. **`by_stage`** requires the `stage` argument.
+Unknown `status` → validation error envelope. **`by_stage`** requires the `stage` argument.
 
 ## v3 → v4 mapping (for older clients)
 
-| Removed v3 tool | v4 replacement |
-|-----------------|----------------|
+| Removed v3 tool | v4+ replacement |
+|-----------------|-----------------|
 | `get_slas_for_task(num)` | `query_slas_by_task(num)` |
 | `get_breaching_slas(mins)` | `query_slas_by_status("breaching", threshold_minutes=mins)` |
 | `get_breached_slas(filters, days)` | `query_slas_by_status("breached", days=…, extra_filters=…)` |
@@ -42,52 +44,54 @@ Unknown `status` → `ValueError`. **`by_stage`** requires the `stage` argument.
 | `get_recent_breached_slas(days)` | `query_slas_by_status("breached", days=…)` |
 | `get_critical_sla_status()` | `query_slas_by_status("critical")` |
 
-Unchanged names: `similar_slas_for_text`, `get_sla_details` (behaviour of details fixed — see below).
+Unchanged names: `get_sla_details` (behaviour of details fixed — see below).  
+v5.0 additionally removed `similar_slas_for_text` (see note above).
 
 ### `get_sla_details` bug fix
 
-v3 routed through a path that used `number={sys_id}` on `task_sla` (no `number` field). ServiceNow ignored the filter and returned a full page (~10k rows / huge token cost). v4 queries **`sys_id={sys_id}`** and returns one record. Details: [MIGRATION_v3_to_v4.md](../MIGRATION_v3_to_v4.md).
+v3 routed through a path that used `number={sys_id}` on `task_sla` (no `number` field). ServiceNow ignored the filter and returned a full page (~10k rows / huge token cost). v4+ queries **`sys_id={sys_id}`** and returns one record under `{record}`. Details: [MIGRATION_v3_to_v4.md](../MIGRATION_v3_to_v4.md).
 
 ## Architecture diagram
 
 ```mermaid
 graph TB
-    subgraph "SLA MCP tools — 5"
+    subgraph "SLA MCP tools — 4"
         S1["query_slas_by_status<br/>preset enum"]
         S2["query_slas_by_task"]
         S3["query_slas_custom"]
         S4["get_sla_details"]
-        S5["similar_slas_for_text"]
     end
 
     subgraph "Implementation"
         CNS[consolidated_tools.py]
         GTT[generic_table_tools.py]
         CONST[constants.py<br/>ESSENTIAL_FIELDS task_sla]
+        RESP[Table_Tools/response.py]
         HTTP[http_layer GET path]
     end
 
-    subgraph "Optional NL"
-        IQ[intelligent_search<br/>on table task_sla]
+    subgraph "Text fallback (generic)"
+        FR["filter_records task_sla<br/>task.short_description LIKE…"]
     end
 
     S1 --> CNS
     S2 --> CNS
     S3 --> CNS
     S4 --> CNS
-    S5 --> CNS
     CNS --> GTT
+    CNS --> RESP
     GTT --> CONST
     GTT --> HTTP
-    IQ --> GTT
+    FR --> GTT
     HTTP --> SN[task_sla Table API]
 
     style S1 fill:#fff3e0,stroke:#ff9800,stroke-width:3px
     style S4 fill:#e8f5e8,stroke:#4caf50,stroke-width:2px
     style HTTP fill:#fce4ec,stroke:#e91e63,stroke-width:2px
+    style RESP fill:#f3e5f5,stroke:#9c27b0,stroke-width:2px
 ```
 
-## Operational flows (v4 tool names)
+## Operational flows (v5 tool names)
 
 ```mermaid
 graph LR
@@ -115,7 +119,7 @@ graph TB
         BAD[Unbounded task_sla queries<br/>thousands of rows → context blow-up]
     end
 
-    subgraph "Controls in v4"
+    subgraph "Controls in v4+"
         T1[Time windows — days on presets]
         T2[critical / performance curated fields]
         T3[ESSENTIAL_FIELDS default on custom]
@@ -154,7 +158,7 @@ graph TB
 ### Incident-linked
 1. `query_slas_by_task("INC…")`  
 2. `get_sla_details("<sys_id>")`  
-3. `similar_slas_for_text("database performance")`  
+3. Text on parent task (v5): `filter_records("task_sla", {"task.short_description": "LIKE database"})`  
 
 ### Fully custom
 `query_slas_custom(filters={…}, fields=[…], days=N)` when no preset fits.
@@ -162,8 +166,9 @@ graph TB
 ## Table quirks (`task_sla`)
 
 - Uses **`stage`** (not the same as task `state` vocabulary on incidents).
-- No reliable **`number`** field for the SLA row itself — identify by **`sys_id`** or via task relationship.
+- No reliable **`number`** field for the SLA row itself — identify by **`sys_id`** or via task relationship (`TableSpec.number_field` makes this structural).
 - Parent task priority often filtered as `task.priority=…` in presets such as `critical`.
+- Parent task text is on **`task.short_description`**, not on the SLA row.
 
 ## Design goals
 
@@ -171,3 +176,4 @@ graph TB
 - Hard stop on accidental full-table dumps (`get_sla_details`, field defaults)  
 - Escape hatch without opening “select *” by default  
 - Same OAuth + GET optimization path as the rest of the server  
+- §3.1 response envelopes (list / record / error) like every other tool  

--- a/Diagrams & Documentation/README.md
+++ b/Diagrams & Documentation/README.md
@@ -2,25 +2,17 @@
 
 Mermaid diagrams for the Personal MCP ServiceNow server. Packaging is Claude Desktop Extension (`.mcpb`); distribution is no longer Nuitka binaries.
 
-> **⚠️ Pending v5.0 refresh.** The diagram bodies below still describe the pre-v5.0
-> surface (39 tools, the NL/`filter` intelligence engine, the v4 module layout).
-> **v5.0 "Boron"** culled the surface to **25 tools**, removed the NL engine, and
-> added the §3.1 response contract (`Table_Tools/response.py`), `table_spec.py`,
-> and `tool_registry.py`. Until these are redrawn, treat [CHANGELOG.md](../CHANGELOG.md),
-> [MIGRATION_v4_to_v5.md](../MIGRATION_v4_to_v5.md), and the root
-> [CLAUDE.md]/README as the source of truth for the current surface.
-> (`05-ai-intelligence-flow.md` was deleted in v5.0 — the NL engine it documented
-> is gone; natural language → filter is the host model's job.)
-
 ## Diagram Index
 
 | File | Description | Diagram Type | Status |
 |------|-------------|--------------|--------|
-| [01-architecture-overview.md](./01-architecture-overview.md) | Layered architecture: tools → filter → http_layer → oauth → ServiceNow | Component | v4.3 · stale |
+| [01-architecture-overview.md](./01-architecture-overview.md) | Layered architecture: tools → filter → http_layer → oauth → ServiceNow | Component | v5.0 |
 | [02-oauth-authentication-flow.md](./02-oauth-authentication-flow.md) | Client-credentials flow, token cache, 401 retry, pooled httpx | Sequence | v4.3 (oauth layer unchanged in v5.0) |
-| [03-tool-organization.md](./03-tool-organization.md) | tools by source module; generic wrappers + domain tools | Graph | v4.3 · stale (was 39 tools; v5.0 = 25) |
-| [04-similarity-search-flow.md](./04-similarity-search-flow.md) | `search_records` read path (OR-LIKE, pagination, GET params) | Flowchart | v4.3 · stale |
-| [06-sla-architecture-flow.md](./06-sla-architecture-flow.md) | 5 SLA tools, status presets, token-safe defaults | Architecture | v4.3 · stale |
+| [03-tool-organization.md](./03-tool-organization.md) | 25 tools by source module; generic wrappers + domain tools | Graph | v5.0 |
+| [04-similarity-search-flow.md](./04-similarity-search-flow.md) | `search_records` / `filter_records` read path (OR-LIKE, pagination, GET params, §3.1) | Flowchart | v5.0 |
+| [06-sla-architecture-flow.md](./06-sla-architecture-flow.md) | 4 SLA tools, status presets, token-safe defaults | Architecture | v5.0 |
+
+> `05-ai-intelligence-flow.md` was deleted in v5.0 — the NL engine it documented is gone; natural language → filter is the host model's job.
 
 ## How to View Diagrams
 
@@ -36,15 +28,17 @@ Mermaid diagrams for the Personal MCP ServiceNow server. Packaging is Claude Des
 1. Copy a mermaid code block
 2. Paste into [Mermaid Live Editor](https://mermaid.live/)
 
-## System Overview (v4.3)
+## System Overview (v5.0)
 
-- **39 MCP tools** over stdio (Claude Desktop) or SSE (Docker / network agents)
-- **8 tables** in `TABLE_CONFIGS`: `incident`, `change_request`, `sc_req_item`, `sc_task`, `universal_request`, `kb_knowledge`, `vtb_task`, `task_sla`
-- **5 generic tools** for any configured table (`search_records`, `get_record`, …)
-- **Filter pipeline** in `filter/` (no v3 shims — deleted in v4.1)
+- **25 MCP tools** over stdio (Claude Desktop) or SSE (Docker / network agents)
+- **8 tables** via `table_spec.TABLE_SPECS` → derived `TABLE_CONFIGS`: `incident`, `change_request`, `sc_req_item`, `sc_task`, `universal_request`, `kb_knowledge`, `vtb_task`, `task_sla`
+- **4 generic tools** for any configured table (`search_records`, `get_record`, `find_similar`, `filter_records`)
+- **§3.1 response contract** — list / record / write / error envelopes from `Table_Tools/response.py`
+- **Filter pipeline** in `filter/` (builder, validator, value_encoding, models — no NL intelligence)
 - **HTTP layer** in `http_layer/` — GET token-optimization invariants; writes bypass them
 - **OAuth** in `oauth/` — façade + TokenStore + RequestExecutor + process-wide httpx pool (v4.2)
 - **Writes**: `vtb_task` CRUD + KB article lifecycle tools
+- **Registration**: `tool_registry.register_tools` injects WHEN / WHEN-NOT / PREFER guidance
 - **Distribution**: `.mcpb` bundle (`scripts/build_mcpb.py`) or Docker SSE
 
 ## Architecture Summary
@@ -52,18 +46,20 @@ Mermaid diagrams for the Personal MCP ServiceNow server. Packaging is Claude Des
 ```
 MCP Client (Claude / agent)
   ↓ stdio | SSE
-tools.py (FastMCP + AuthMiddleware + AuditMiddleware — 39 tools)
-  ↓
-generic_tool_wrappers.py   (5 generic tools — TABLE_CONFIGS validate)
-consolidated_tools.py      (priority incidents, knowledge read, 5 SLA tools)
+tools.py (FastMCP + AuthMiddleware + AuditMiddleware)
+  ↓ tool_registry.register_tools — 25 tools + guidance injection
+utility_tools.py           (health_check — 1)
+generic_tool_wrappers.py   (4 generic tools — TABLE_CONFIGS validate)
+consolidated_tools.py      (priority, KB state rollup, 4 SLA tools)
 vtb_task_tools.py          (private task create/update)
 kb_article_tools.py        (KB update / publish / batch / retire / dup-check)
 cmdb_tools.py              (6 CMDB tools)
-intelligent_query_tools.py (6 NLP / filter-help tools)
-  ↓
+intelligent_query_tools.py (get_query_syntax_help only)
+  ↓ Table_Tools/response.py  (§3.1 contract constructors)
 generic_table_tools.py     (query engine, pagination)
   ↓
-filter/                    (builder, validator, intelligence, explainer, models)
+table_spec.py → constants.py   (SSOT → derived field/config maps)
+filter/                    (builder, validator, value_encoding, models)
   ↓
 http_layer/                (make_nws_request: GET url_builder + response_parser)
   ↓
@@ -85,4 +81,4 @@ httpx → ServiceNow Table API
 
 ---
 
-*Last updated: 2026-08-11 · Project version: 5.0.0 · diagram bodies pending v5.0 refresh (see banner above)*
+*Last updated: 2026-08-11 · Project version: 5.0.0*


### PR DESCRIPTION
## Summary

Deferred follow-up from v5.0.0 release (PR #76): refresh the four stale diagram bodies under `Diagrams & Documentation/` to match the Boron surface, then clear the index banner.

- **01** architecture: 25 tools, `tool_registry` / `table_spec` / `response.py`, filter without NL engine
- **03** tool organization: module map 39→25; generic 4; `health_check`; `get_query_syntax_help` only
- **04** search flow: drop `intelligent_search` branch; §3.1 envelopes + v4.4.1 encoding contract
- **06** SLA: 4 tools; remove `similar_slas_for_text`; replacement via `filter_records`
- **README**: drop pending banner; status column → v5.0

Left alone: `02-oauth-authentication-flow.md` (oauth unchanged). Did **not** re-add `05`.

## Verification

- Registered tools: **25** (from `tools.tools`)
- `pytest tests/ -q` → **1136 passed**
- Staleness grep hits are only deliberate "removed in v5.0" notes

## Test plan

- [x] Tool count 25
- [x] Full unit suite green
- [ ] Spot-check Mermaid render in GitHub file viewer after merge