### PR TITLE
chore: Sonar composite asserts and noqa suppression syntax

### DIFF
--- a/http_layer/request_dispatcher.py
+++ b/http_layer/request_dispatcher.py
@@ -115,7 +115,8 @@ async def _get_typed(url: str, display_value: bool) -> dict[str, Any] | None:
         # outside would let a parser failure propagate uncaught to MCP clients
         # for every caller, migrated or not.
         return extract_display_values(result) if result and display_value else result
-    except Exception as e:  # noqa: BLE001 - every failure is classified, none swallowed
+    # Every failure is classified; none are swallowed.
+    except Exception as e:  # noqa: BLE001
         error = classify_read_failure(e)
         # stderr only — stdout is reserved for the MCP JSON-RPC frame stream.
         print(

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -433,4 +433,5 @@ class TestSLATools:
                 filters, _ = _build_sla_status_filter(status, stage="x")
             else:
                 filters, _ = _build_sla_status_filter(status)
-            assert isinstance(filters, dict) and filters
+            assert isinstance(filters, dict)
+            assert filters

--- a/tests/test_query_value_encoding.py
+++ b/tests/test_query_value_encoding.py
@@ -824,7 +824,8 @@ class TestPreBuiltFragmentChannels:
         ))
         assert urls, "the legitimate exclusion list was refused"
         conditions = servicenow_conditions(urls[0])
-        assert "caller_id!=a" in conditions and "caller_id!=b" in conditions
+        assert "caller_id!=a" in conditions
+        assert "caller_id!=b" in conditions
 
     def test_complete_query_is_guarded_when_the_flag_enables_it(self):
         """Gated off by default, so the guard behind the gate needs its own test."""
@@ -970,7 +971,9 @@ async def test_all_three_assembly_paths_build_the_same_query(filters):
         "incident", ["1"], additional_filters={"assigned_to": "x"}
     ))
 
-    assert typed_urls and generic_urls and priority_urls
+    assert typed_urls
+    assert generic_urls
+    assert priority_urls
     assert servicenow_params(typed_urls[0])["sysparm_query"] == \
         servicenow_params(generic_urls[0])["sysparm_query"]
     # The priority path takes its filters differently, so agreement is asserted on

--- a/tests/test_table_spec.py
+++ b/tests/test_table_spec.py
@@ -66,9 +66,12 @@ class TestSpecWellFormed:
 
     def test_required_string_fields_present(self):
         for name, spec in TABLE_SPECS.items():
-            assert spec.display_name and isinstance(spec.display_name, str), name
-            assert spec.state_field and isinstance(spec.state_field, str), name
-            assert spec.text_search_field and isinstance(spec.text_search_field, str), name
+            assert isinstance(spec.display_name, str), name
+            assert spec.display_name, name
+            assert isinstance(spec.state_field, str), name
+            assert spec.state_field, name
+            assert isinstance(spec.text_search_field, str), name
+            assert spec.text_search_field, name
             assert spec.error_message.endswith("."), name
 
     def test_field_lists_are_non_empty_and_start_with_essentials_subset(self):

--- a/tests/test_token_footprint.py
+++ b/tests/test_token_footprint.py
@@ -291,7 +291,8 @@ class TestPerResponseEnvelopeFootprint:
         with patch("Table_Tools.generic_table_tools._make_paginated_request",
                    return_value=rows):
             resp = await filter_records("incident", {"priority": "1"})
-        assert resp["result"] and "message" not in resp
+        assert resp["result"]
+        assert "message" not in resp
         assert _list_envelope_overhead(resp) <= BUDGET_LIST_ENVELOPE_OVERHEAD
 
     @pytest.mark.asyncio
@@ -301,7 +302,8 @@ class TestPerResponseEnvelopeFootprint:
         with patch("Table_Tools.generic_table_tools._make_paginated_request",
                    return_value=rows):
             resp = await search_records("incident", "server crash backup")
-        assert resp["result"] and "message" not in resp
+        assert resp["result"]
+        assert "message" not in resp
         assert _list_envelope_overhead(resp) <= BUDGET_LIST_ENVELOPE_OVERHEAD
 
     @pytest.mark.asyncio
@@ -310,7 +312,8 @@ class TestPerResponseEnvelopeFootprint:
         with patch("Table_Tools.generic_table_tools.make_nws_request",
                    return_value={"result": [dict(_GENERIC_ROW)]}):
             resp = await get_record("incident", "INC0010001")
-        assert "record" in resp and "result" not in resp
+        assert "record" in resp
+        assert "result" not in resp
         overhead = _count_tokens(resp) - _count_tokens({"record": resp["record"]})
         assert overhead <= BUDGET_RECORD_ENVELOPE_OVERHEAD
 
@@ -321,7 +324,8 @@ class TestPerResponseEnvelopeFootprint:
         with patch("Table_Tools.cmdb_tools.make_nws_request",
                    return_value={"result": rows}):
             resp = await find_cis_by_type("cmdb_ci_server")
-        assert resp["result"] and "message" not in resp
+        assert resp["result"]
+        assert "message" not in resp
         # CMDB list carries a `ci_type` descriptor key; still well under budget.
         assert _list_envelope_overhead(resp) <= BUDGET_LIST_ENVELOPE_OVERHEAD
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -89,7 +89,8 @@ class TestFooterInjection:
         assert once.count("WHEN TO USE:") == 1
         # The original prose guidance was replaced by the canonical footer.
         assert "original prose here" not in once
-        assert "A summary line." in once and "Args:" in once
+        assert "A summary line." in once
+        assert "Args:" in once
 
 
 class TestServedDescription:
@@ -129,8 +130,10 @@ class TestProtocolIsMandatory:
         async def brand_new_tool():
             """No guidance entry exists for this one."""
 
+        mcp = _FakeMcp()
+        candidates = [brand_new_tool]
         with pytest.raises(ValueError, match="no TOOL_GUIDANCE entry"):
-            register_tools(_FakeMcp(), [brand_new_tool])
+            register_tools(mcp, candidates)
 
     def test_register_tools_rejects_blank_guidance_field(self, monkeypatch):
         """A guidance entry with a blank field fails at the gate, not just in
@@ -146,5 +149,7 @@ class TestProtocolIsMandatory:
         patched["search_records"] = ToolGuidance(when_to_use="x", when_not="   ", prefer_over="y")
         monkeypatch.setattr("tool_registry.TOOL_GUIDANCE", patched)
 
+        mcp = _FakeMcp()
+        candidates = [search_records]
         with pytest.raises(ValueError, match="blank"):
-            register_tools(_FakeMcp(), [search_records])
+            register_tools(mcp, candidates)

--- a/tests/test_tool_response_contract.py
+++ b/tests/test_tool_response_contract.py
@@ -187,7 +187,8 @@ def _assert_error_shape(err):
     assert isinstance(err, dict), f"error must be a dict, got {type(err)}"
     assert set(err) >= {"code", "message"}, f"error must carry code+message, got {err}"
     assert err["code"] in ERROR_CODES, f"code {err['code']!r} outside the vocabulary"
-    assert isinstance(err["message"], str) and err["message"]
+    assert isinstance(err["message"], str)
+    assert err["message"]
 
 
 def assert_contract(resp, *, tool_name):
@@ -199,7 +200,10 @@ def assert_contract(resp, *, tool_name):
         _assert_error_shape(resp["error"])
         is_partial = resp.get("partial") is True
         if not is_partial and tool_name not in _EXCEPTION_TOOLS:
-            assert "result" not in resp and "record" not in resp, (
+            assert "result" not in resp, (
+                f"{tool_name}: error must not sit beside result/record (got keys {sorted(resp)})"
+            )
+            assert "record" not in resp, (
                 f"{tool_name}: error must not sit beside result/record (got keys {sorted(resp)})"
             )
 
@@ -235,7 +239,8 @@ async def test_success_shape_conforms(name, factory, kind, transport):
     assert_contract(resp, tool_name=name)
 
     if kind == "list":
-        assert "result" in resp and isinstance(resp["result"], list)
+        assert "result" in resp
+        assert isinstance(resp["result"], list)
     elif kind == "record_read":
         # Read hit: {"record": {...}} with NO top-level message (reads never
         # carry the write-success message).
@@ -244,14 +249,19 @@ async def test_success_shape_conforms(name, factory, kind, transport):
     elif kind == "record_write":
         # Write success: {"record": {...}, "message": str}. The §3.1 write shape
         # REQUIRES the message, so dropping success_message= now fails here.
-        assert "record" in resp and resp["record"] is not None, f"{name}: write should return a record"
-        assert isinstance(resp.get("message"), str) and resp["message"], (
+        assert "record" in resp, f"{name}: write should return a record"
+        assert resp["record"] is not None, f"{name}: write should return a record"
+        assert isinstance(resp.get("message"), str), (
+            f"{name}: write success must carry a non-empty `message` (§3.1 write shape)"
+        )
+        assert resp["message"], (
             f"{name}: write success must carry a non-empty `message` (§3.1 write shape)"
         )
     elif kind == "diagnostic":
         assert "connection" in resp  # health_check status bag
     elif kind == "reference":
-        assert isinstance(resp, dict) and "error" not in resp
+        assert isinstance(resp, dict)
+        assert "error" not in resp
 
 
 @pytest.mark.asyncio
@@ -273,7 +283,8 @@ async def test_failure_shape_conforms(name, factory, kind, transport):
         _assert_error_shape(resp["error"])
     elif name in _BATCH_TOOLS:
         # A batch stays a valid list; the per-article failure lands inside its row.
-        assert isinstance(resp["result"], list) and resp["result"]
+        assert isinstance(resp["result"], list)
+        assert resp["result"]
     else:
         assert "error" in resp, f"{name} should surface a failure as {{'error': ...}}, got {sorted(resp)}"
         _assert_error_shape(resp["error"])
@@ -337,4 +348,5 @@ class TestDocumentedExceptions:
         resp = _partial_envelope(list_response([dict(_ROW)], truncated=False), partial)
         assert_contract(resp, tool_name="filter_records")
         assert resp["partial"] is True
-        assert resp["result"] and "error" in resp
+        assert resp["result"]
+        assert "error" in resp


### PR DESCRIPTION
## Summary

Sonar code-smell cleanup (no behavior change):

- `http_layer/request_dispatcher.py`: fix invalid `# noqa: BLE001 - …` suppression syntax (rationale on its own line; clean `# noqa: BLE001`).
- Split composite `assert a and b` into separate asserts in:
  - `tests/test_consolidated_tools.py`
  - `tests/test_query_value_encoding.py`
  - `tests/test_table_spec.py`
  - `tests/test_token_footprint.py`
  - `tests/test_tool_registry.py`
  - `tests/test_tool_response_contract.py`
- `tests/test_tool_registry.py`: build `mcp` / `candidates` outside `pytest.raises` so only one call can throw.

## Test plan

- [x] Affected modules: 356 passed
- [ ] Re-scan Sonar / SonarCloud after merge