### PR TITLE
fix(kb): state rollup hid drafts and guessed states — 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to the Personal MCP ServiceNow project will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] — 2026-08-12
+
+Two silent-data-loss defects in `get_kb_articles_by_state`, both found by live
+testing against a real KB (363 raw rows) rather than by the test suite. Neither
+raised an error — the tool returned confidently wrong data.
+
+### Fixed
+
+- **Drafts on already-published articles were invisible to a `draft` filter.**
+  The `workflow_state` filter tested equality against `current_state`, the
+  priority winner of `published > draft > review > outdated > retired`. Because
+  re-drafting an update leaves a `published` row beside the new `draft` one,
+  `published` won and the article dropped out of the filtered result. Measured
+  live: the tool reported **1** pending draft where a raw `filter_records` saw
+  **48** — 47 of 48 real work items silently missing, in the *common* KB-churn
+  case (edits to existing articles, not new ones).
+
+  Each entry now carries **`states_present`** — every distinct `workflow_state`
+  across that number's versions — and `workflow_state` filters on membership in
+  it. `current_state` keeps its meaning (the canonical/live state) for
+  post-publish verification. Because `published` is the top-priority state,
+  `current_state == "published"` already implies membership, so the published
+  view is unchanged; only the lower-priority states widen, which is the fix.
+
+- **A capped raw scan reported the wrong `current_state`, not merely fewer rows.**
+  `max_results` capped the *raw row fetch*, and de-duplication then ran on
+  whatever arrived. The scan sorts `sys_created_on` DESC, so a recent `draft`
+  row could land inside a 100-row cap while its older `published` sibling fell
+  off the end — and the article came back as `current_state: draft`. Rows for one
+  number are scattered across the sort, so truncation poisons *every* entry's
+  state, not just the omitted ones.
+
+  The raw scan is now decoupled from the output cap: it always runs to
+  `KB_STATE_SCAN_LIMIT` (1000 rows), while `max_results` caps the deduped
+  entries returned. If the scan itself hits its ceiling the response carries
+  `scan_incomplete: true` and a `warning` naming the risk, instead of serving a
+  guessed state as authoritative.
+
+- `max_results` outside 1..1000 now returns a `VALIDATION` error instead of
+  raising an unhandled pydantic `ValidationError`.
+
+### Behavior changes
+
+- `truncated` on this tool now means **the deduped output was capped at
+  `max_results`**. It previously reflected the raw fetch. A capped raw scan is
+  reported separately as `scan_incomplete` — the two were one flag, which
+  conflated "there are more articles than I returned" with "the states I
+  reported may be wrong". Only the second makes the returned rows untrustworthy.
+- `workflow_state="draft"` (and `review`, `outdated`, `retired`) now return
+  strictly more articles. `workflow_state="published"` is unchanged.
+
+### Added
+
+- `tests/test_kb_state_rollup.py` — 17 regression tests covering both defects.
+- Regression tests pinning that retired/outdated duplicates do **not** block a
+  publish while a live duplicate beside them still does. This behavior was
+  already correct but untested, and was flagged as unverified in the live-test
+  handoff.
+
 ## [5.0.0] — Boron — 2026-08-11
 
 The MCP-surface redesign. **Breaking**: the tool surface is culled 39 → 25, and

--- a/Diagrams & Documentation/03-tool-organization.md
+++ b/Diagrams & Documentation/03-tool-organization.md
@@ -128,7 +128,7 @@ graph TB
 ### Consolidated tools — `consolidated_tools.py`
 
 - **Priority**: `get_priority_incidents` — date ranges + metadata; extra filters via `additional_filters` (no deprecated `**kwargs`)
-- **Knowledge state** (1): `get_kb_articles_by_state` — collapses KB versions to one row per `number` (published > draft > review > outdated > retired)
+- **Knowledge state** (1): `get_kb_articles_by_state` — collapses KB versions to one row per `number`; `current_state` is the priority winner (published > draft > review > outdated > retired), `states_present` lists all of them and is what the `workflow_state` filter tests
 - **SLA** (4): see [05-sla-architecture-flow.md](./05-sla-architecture-flow.md)
 
 Removed in v5.0: the three smart-KB reads (`similar_knowledge_for_text`, `get_knowledge_by_category`, `get_active_knowledge_articles`) — use `search_records` / `filter_records` / `get_kb_articles_by_state` instead.

--- a/Diagrams & Documentation/README.md
+++ b/Diagrams & Documentation/README.md
@@ -81,4 +81,4 @@ httpx → ServiceNow Table API
 
 ---
 
-*Last updated: 2026-08-11 · Project version: 5.0.0*
+*Last updated: 2026-08-12 · Project version: 5.0.1*

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ MCP server for ServiceNow integration. Uses FastMCP over stdio transport, OAuth 
 
 ## Release highlights
 
-Current release: **5.0.0 "Boron"** (25 tools). Breaking — the tool surface was culled 39 → 25 and every tool now returns one minimal response contract. If upgrading, read [MIGRATION_v4_to_v5.md](MIGRATION_v4_to_v5.md). Full history in [CHANGELOG.md](CHANGELOG.md).
+Current release: **5.0.1** (25 tools). The 5.0.0 "Boron" surface was breaking — culled 39 → 25 with one minimal response contract. If upgrading from v4, read [MIGRATION_v4_to_v5.md](MIGRATION_v4_to_v5.md). Full history in [CHANGELOG.md](CHANGELOG.md).
 
 | Release | What changed |
 |---|---|
+| **5.0.1** | Two silent-data-loss fixes in `get_kb_articles_by_state`, both found live. A `draft` filter now finds drafts on **already-published** articles (the priority collapse hid them — live, 1 reported against 48 real); entries carry `states_present` and the state filter tests membership. The raw scan no longer inherits `max_results`, which had made a truncated fetch report the *wrong* `current_state`; a capped scan now says `scan_incomplete` instead of guessing. |
 | **5.0.0 "Boron"** | Breaking. Tool surface culled **39 → 25** (5 diagnostics folded into one `health_check`; the NL/filter and smart-KB/SLA read tools removed — the host model does NL→filter natively). One **minimal response contract** across every tool: list `{result, returned_count, truncated}`, single-record `{record}`, write `{record, message}`, failure `{error:{code, message}}` — no more bare-string returns or `result`-is-sometimes-a-dict. `TableSpec` makes per-table config one source of truth; tool selection guidance is a structured registry injected into each docstring. ~2000 lines of dead NL-engine code removed. See MIGRATION_v4_to_v5.md. |
 | **4.5.0** | Tool-selection docstring protocol on all 39 tools (WHEN TO USE / WHEN NOT TO USE / PREFER OVER / TABLES / SIDE EFFECT / EXAMPLE). Non-breaking — no tool added, removed, or re-signatured. The fatal footguns (LIKE-not-CONTAINS, reference fields hold sys_ids) now sit inline on `search_records` and `filter_records`. Static tool-selection preferred-hit rose 21/30 → 29/30, ambiguity 66 → 50 plausible paths. |
 | **4.4.1** | Encoded-query values are carried faithfully. A `&` or a literal `%XY` in a search value no longer silently changes the query into a broader one; a `^` is refused rather than answered, because ServiceNow's syntax cannot carry it inside a value. A KB title containing `&` or `%` no longer blocks a publish. |
@@ -195,7 +196,7 @@ Work across all supported tables: `incident`, `change_request`, `sc_req_item`, `
 
 ### Knowledge base — read (1)
 
-- `get_kb_articles_by_state(workflow_state, category, kb_base, max_results)` — collapses ServiceNow KB versioning to one row per `number`, with `current_state` and `version_count`. For topic search use `search_records("kb_knowledge", ...)`; for a category use `filter_records("kb_knowledge", {"kb_category": ...})`.
+- `get_kb_articles_by_state(workflow_state, category, kb_base, max_results)` — collapses ServiceNow KB versioning to one row per `number`, with `current_state` (the canonical/live state), `states_present` (every state that number has a version in) and `version_count`. `workflow_state` matches on `states_present` membership, so a draft on an already-published article is found. `max_results` caps the returned entries; the raw scan runs to its own 1000-row ceiling and sets `scan_incomplete` + `warning` if it hits it. For topic search use `search_records("kb_knowledge", ...)`; for a category use `filter_records("kb_knowledge", {"kb_category": ...})`.
 
 ### Knowledge base — write (5)
 

--- a/Table_Tools/consolidated_tools.py
+++ b/Table_Tools/consolidated_tools.py
@@ -22,8 +22,13 @@ from .date_utils import (
     build_date_filter,
     build_last_n_days_filter,
 )
-from typing import Any, Dict, Optional, List
-from constants import TABLE_ERROR_MESSAGES, TASK_NUMBER_FIELD
+from typing import Any, Dict, Optional, List, Set
+from constants import (
+    TABLE_ERROR_MESSAGES,
+    TASK_NUMBER_FIELD,
+    KB_STATE_SCAN_LIMIT,
+    KB_STATE_SCAN_WARNING,
+)
 from param_coercion import OptJsonList, OptJsonDict
 
 # v5.0 "Boron" Tier 3.3: get_priority_incidents dropped its **deprecated_kwargs
@@ -209,7 +214,13 @@ _KB_DEDUP_FIELDS = [
 def _pick_canonical_kb_row(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
     """De-duplicate kb_knowledge rows by `number`, keeping the highest-priority workflow_state row.
 
-    Returns a dict keyed by number with {canonical_row, version_count, canonical_rank}.
+    Returns a dict keyed by number with {row, rank, version_count, states}.
+
+    `states` — every distinct workflow_state seen for that number — is what makes
+    a draft on an already-published article discoverable. Collapsing to the
+    priority winner alone hid 47 of one KB's 48 pending drafts (see
+    tests/test_kb_state_rollup.py): re-drafting an update leaves a `published`
+    row beside the `draft` one, and `published` outranks it.
     """
     by_number: Dict[str, Dict[str, Any]] = {}
     for row in rows:
@@ -220,13 +231,22 @@ def _pick_canonical_kb_row(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
         rank = _KB_STATE_RANK.get(state, len(_KB_STATE_PRIORITY))
         entry = by_number.get(num)
         if entry is None:
-            by_number[num] = {"row": row, "rank": rank, "version_count": 1}
+            by_number[num] = {
+                "row": row, "rank": rank, "version_count": 1, "states": {state},
+            }
         else:
             entry["version_count"] += 1
+            entry["states"].add(state)
             if rank < entry["rank"]:
                 entry["row"] = row
                 entry["rank"] = rank
     return by_number
+
+def _order_states(states: Set[str]) -> List[str]:
+    """Distinct states in priority order (unknown states last, alphabetical)."""
+    return sorted(
+        states, key=lambda s: (_KB_STATE_RANK.get(s, len(_KB_STATE_PRIORITY)), s)
+    )
 
 def _format_deduped_kb_row(number: str, info: Dict[str, Any]) -> Dict[str, Any]:
     """Render a de-duplicated KB row in the public response shape."""
@@ -236,6 +256,7 @@ def _format_deduped_kb_row(number: str, info: Dict[str, Any]) -> Dict[str, Any]:
         "sys_id": row.get("sys_id"),
         "short_description": row.get("short_description"),
         "current_state": (row.get("workflow_state") or "").strip().lower(),
+        "states_present": _order_states(info["states"]),
         "version_count": info["version_count"],
         "kb_category": row.get("kb_category"),
         "sys_updated_on": row.get("sys_updated_on"),
@@ -255,33 +276,58 @@ async def get_kb_articles_by_state(
 
     ServiceNow KB versioning surfaces one article number across several
     workflow states (publish creates a new sys_id and marks the prior row
-    `outdated`). This collapses them to one entry per number: `current_state`
-    is the highest-priority state found, `version_count` the raw-row count.
-    Priority (highest first): published > draft > review > outdated > retired.
+    `outdated`). This collapses them to one entry per number:
+
+      * `current_state`   — the highest-priority state found (the canonical /
+        live view). Priority: published > draft > review > outdated > retired.
+      * `states_present`  — EVERY distinct state found for that number.
+      * `version_count`   — how many raw rows the number had.
+
+    `workflow_state` filters on `states_present` MEMBERSHIP, not on
+    `current_state`. Re-drafting an update leaves a `published` row beside the
+    new `draft` one, so an equality test on the priority winner hid the draft
+    entirely — live, that reported 1 pending draft where there were 48.
+    Membership only ever widens the non-published states: `published` is rank 0,
+    so `current_state == "published"` already implies membership.
 
     Args:
-        workflow_state: Optional canonical-state filter applied AFTER dedup
-            (e.g. "published" → numbers whose live version is published).
+        workflow_state: Optional state filter — matches any article carrying
+            that state in ANY of its versions (e.g. "draft" → articles with
+            pending draft work, including already-published ones).
         category: Optional kb_category filter (server-side).
         kb_base: Optional kb_knowledge_base filter (server-side).
-        max_results: Max raw rows fetched (default 100, max 1000); `truncated`
-            reflects the raw fetch, deduped output may be smaller.
+        max_results: Cap on the deduped entries RETURNED (1..1000, default 100).
+            The raw scan is separate and always runs to KB_STATE_SCAN_LIMIT —
+            capping the scan by this value used to corrupt `current_state`.
 
     Returns:
         {"result": [{"number","sys_id","short_description","current_state",
-                     "version_count","kb_category","sys_updated_on"}, ...],
+                     "states_present","version_count","kb_category",
+                     "sys_updated_on"}, ...],
          "returned_count": N, "truncated": bool}
+        `truncated` means the deduped output was capped at `max_results`.
+        A capped raw scan instead adds `scan_incomplete: true` + `warning`,
+        because then the reported states themselves may be wrong.
     """
+    if not 1 <= max_results <= KB_STATE_SCAN_LIMIT:
+        return error_response(
+            "VALIDATION",
+            f"max_results must be between 1 and {KB_STATE_SCAN_LIMIT}, got {max_results}.",
+        )
+
     filters: Dict[str, str] = {}
     if category:
         filters["kb_category"] = category
     if kb_base:
         filters["kb_knowledge_base"] = kb_base
 
+    # The scan ceiling, NOT max_results. Dedup over a partial row set reports the
+    # wrong `current_state` (rows for one number are scattered across the
+    # sys_created_on DESC sort), so the scan must not inherit an output cap.
     params = TableFilterParams(
         filters=filters or None,
         fields=_KB_DEDUP_FIELDS,
-        max_results=max_results,
+        max_results=KB_STATE_SCAN_LIMIT,
     )
     raw = await query_table_with_filters("kb_knowledge", params)
     # De-duplicating a failure would answer "No matching KB articles." for a
@@ -293,24 +339,33 @@ async def get_kb_articles_by_state(
     by_number = _pick_canonical_kb_row(rows)
 
     target_state = workflow_state.strip().lower() if workflow_state else None
-    deduped = []
+    matched = []
     for num, info in by_number.items():
         formatted = _format_deduped_kb_row(num, info)
-        if target_state and formatted["current_state"] != target_state:
+        # Membership, not equality against the priority winner — see the docstring.
+        if target_state and target_state not in formatted["states_present"]:
             continue
-        deduped.append(formatted)
+        matched.append(formatted)
+
+    deduped = matched[:max_results]
+    extra: Dict[str, Any] = {}
+    if raw.get("truncated"):
+        # Loud, not just a bool: a caller spot-checking a few fields must not read
+        # a poisoned state as authoritative.
+        extra["scan_incomplete"] = True
+        extra["warning"] = KB_STATE_SCAN_WARNING.format(limit=KB_STATE_SCAN_LIMIT)
+
+    response = list_response(
+        deduped, truncated=len(matched) > len(deduped), **extra
+    )
 
     # Dedup + the workflow_state filter can empty a partial set. Answering
     # "No matching KB articles." from pages that never arrived would be the same
     # confident-wrong answer this tier removes, so that case reports the failure.
     if not deduped:
-        return carry_partial_after_filter(
-            list_response([], truncated=bool(raw.get("truncated", False))), raw
-        )
+        return carry_partial_after_filter(response, raw)
 
-    return carry_partial(
-        list_response(deduped, truncated=bool(raw.get("truncated", False))), raw
-    )
+    return carry_partial(response, raw)
 
 # ---------------------------------------------------------------------------
 # SLA tools — v4.0 consolidation (10 -> 5)

--- a/constants.py
+++ b/constants.py
@@ -327,6 +327,26 @@ KB_DEDUP_REASON_TRUNCATED = (
     "the search hit its {limit}-row cap, so a duplicate may have been left off the page"
 )
 
+# Raw-row ceiling for the `get_kb_articles_by_state` version rollup. Deliberately
+# DECOUPLED from the caller's `max_results`, which caps the deduped OUTPUT.
+#
+# Found live 2026-08-12: when `max_results` capped the raw scan, dedup ran on a
+# partial row set and reported the WRONG `current_state` — the scan sorts
+# sys_created_on DESC, so a recent `draft` row landed inside a 100-row cap while
+# its older `published` sibling fell off the end. Truncating the scan poisons
+# every number's state, not just the omitted ones, because rows for one number
+# are scattered across the sort order. 1000 is the ceiling
+# `TableFilterParams.max_results` validates to; past it the rollup says so
+# (`scan_incomplete`) instead of guessing.
+KB_STATE_SCAN_LIMIT = 1000
+
+# A capped raw scan cannot be silently served: the states it reports may be wrong.
+KB_STATE_SCAN_WARNING = (
+    "raw scan hit its {limit}-row cap, so `current_state` and `states_present` may be "
+    "incorrect for any article whose other version rows fell outside the scan. Narrow "
+    "the query with `category` or `kb_base` for a trustworthy rollup."
+)
+
 # ---------------------------------------------------------------------------
 # Encoded-query value boundary (v4.4.1)
 # ---------------------------------------------------------------------------

--- a/docs/E2E_TEST_PROMPTS.md
+++ b/docs/E2E_TEST_PROMPTS.md
@@ -52,8 +52,11 @@ Check KB0001234 and KB0005678 for duplicates
 **Watch for:** knowledge search now goes through `search_records`/`filter_records`
 (the smart-KB reads were culled in v5.0 — no `input_text` silently discarded when a
 category filter is set). `get_kb_articles_by_state` returns one row per number with
-`current_state` + `version_count` (KB versioning collapsed). `check_kb_duplicates` is
-read-only and safe.
+`current_state` + `states_present` + `version_count` (KB versioning collapsed). A draft
+filter must return articles that are *already published but have a pending draft* — that
+is the common re-draft case, and it was silently dropped before 5.0.1. Cross-check the
+count against `filter_records("kb_knowledge", {"workflow_state": "draft"})`: the deduped
+number must not be lower. `check_kb_duplicates` is read-only and safe.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "personal-mcp-servicenow",
   "display_name": "ServiceNow for Claude",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Query and manage ServiceNow incidents, changes, knowledge articles, SLAs and CMDB directly from Claude.",
   "long_description": "25 tools for ServiceNow: incident/change/request search, filtered queries, knowledge base management, SLA reporting, CMDB exploration and private task CRUD. Uses OAuth client credentials against your company's ServiceNow instance.",
   "author": {

--- a/personal_mcp_servicenow_main.py
+++ b/personal_mcp_servicenow_main.py
@@ -22,7 +22,7 @@ structlog.configure(
     logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
 )
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 
 def parse_args():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "personal-mcp-servicenow"
-version = "5.0.0"
+version = "5.0.1"
 description = "MCP server for ServiceNow (incidents, changes, KB, SLA, CMDB)"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -252,14 +252,24 @@ class TestGetKbArticlesByState:
             assert params.filters == {"kb_category": "IT", "kb_knowledge_base": "IT_KB"}
 
     @pytest.mark.asyncio
-    async def test_propagates_truncated_flag(self):
+    async def test_capped_raw_scan_reports_scan_incomplete_not_truncated(self):
+        """`truncated` is about the OUTPUT cap; a capped raw scan is a separate flag.
+
+        These were one flag until 2026-08-12, which conflated "there are more
+        articles than I returned" with "the states I reported may be wrong".
+        Only the second one makes the returned rows untrustworthy.
+        See tests/test_kb_state_rollup.py for the live case.
+        """
         with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
             mock_query.return_value = {
                 "result": [{"number": "KB001", "sys_id": "s1", "workflow_state": "published"}],
                 "truncated": True,
             }
             result = await get_kb_articles_by_state()
-            assert result["truncated"] is True
+            assert result["scan_incomplete"] is True
+            assert "warning" in result
+            # One deduped row, output cap 100 — the output itself is complete.
+            assert result["truncated"] is False
 
     @pytest.mark.asyncio
     async def test_empty_result_is_list_contract_shape(self):

--- a/tests/test_kb_state_rollup.py
+++ b/tests/test_kb_state_rollup.py
@@ -1,0 +1,270 @@
+"""Regression tests for the `get_kb_articles_by_state` dedup/truncation defects.
+
+Found by live testing against KB `a9703827c38a2e1026bb03d9d0013148` (2026-08-12),
+where the tool reported **1** draft against `filter_records`' **48**.
+
+Two distinct defects, both silent — no error, no exception, just wrong data:
+
+1. **Priority collapse hid drafts.** The `workflow_state` filter tested equality
+   against `current_state` (the priority WINNER). An article re-drafted for an
+   update has both a `published` and a `draft` row, so `published` won and the
+   article vanished from a `draft` filter. 47 of that KB's 48 pending drafts
+   followed this pattern — the common case, not an edge case.
+
+2. **Raw-scan truncation poisoned `current_state`.** `max_results` capped the RAW
+   row fetch, and dedup then ran on whatever arrived. Because the scan sorts
+   `sys_created_on` DESC, a recent `draft` row could land inside the cap while
+   its older `published` sibling fell off the end — so `current_state` came back
+   *wrong*, not merely missing. Worse than an incomplete list: a confidently
+   incorrect answer for rows that DID make it into the output.
+"""
+import pytest
+from unittest.mock import patch
+
+from Table_Tools.consolidated_tools import (
+    get_kb_articles_by_state,
+    _pick_canonical_kb_row,
+)
+from constants import KB_STATE_SCAN_LIMIT
+
+
+def _rows(*specs):
+    """Build raw kb_knowledge rows from (number, state, sys_id) triples."""
+    return [
+        {
+            "number": num,
+            "sys_id": sys_id,
+            "short_description": f"desc {num}",
+            "workflow_state": state,
+            "kb_category": "Docs",
+            "sys_updated_on": "2026-08-12 07:30:03",
+        }
+        for num, state, sys_id in specs
+    ]
+
+
+class TestDraftMaskedByPublished:
+    """Defect 1: a draft on an already-published article must stay discoverable."""
+
+    @pytest.mark.asyncio
+    async def test_draft_filter_finds_redrafted_published_article(self):
+        """The live KB0011378 case: Draft + Published rows, filtered on draft."""
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(
+                    ("KB0011378", "draft", "s_draft"),
+                    ("KB0011378", "published", "s_pub"),
+                ),
+                "truncated": False,
+            }
+            result = await get_kb_articles_by_state(workflow_state="draft")
+
+        numbers = [r["number"] for r in result["result"]]
+        assert numbers == ["KB0011378"], (
+            "a draft on an already-published article was dropped by the "
+            "priority collapse — the defect that hid 47 of 48 live drafts"
+        )
+
+    @pytest.mark.asyncio
+    async def test_canonical_state_still_reports_the_priority_winner(self):
+        """`current_state` keeps its verification meaning: published wins."""
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(
+                    ("KB0011378", "draft", "s_draft"),
+                    ("KB0011378", "published", "s_pub"),
+                ),
+                "truncated": False,
+            }
+            result = await get_kb_articles_by_state(workflow_state="draft")
+
+        row = result["result"][0]
+        assert row["current_state"] == "published"
+        assert row["states_present"] == ["published", "draft"]
+        assert row["version_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_states_present_ordered_by_priority(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(
+                    ("KB001", "retired", "s1"),
+                    ("KB001", "draft", "s2"),
+                    ("KB001", "published", "s3"),
+                    ("KB001", "outdated", "s4"),
+                ),
+                "truncated": False,
+            }
+            result = await get_kb_articles_by_state()
+
+        assert result["result"][0]["states_present"] == [
+            "published", "draft", "outdated", "retired",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_published_filter_is_unchanged_by_membership(self):
+        """`published` is rank 0, so membership and equality coincide there.
+
+        This is why the fix widens draft/review discovery without loosening the
+        published view: `current_state == "published"` already implies
+        `"published" in states_present`.
+        """
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(
+                    ("KB001", "published", "s1"),
+                    ("KB002", "draft", "s2"),
+                    ("KB003", "retired", "s3"),
+                ),
+                "truncated": False,
+            }
+            result = await get_kb_articles_by_state(workflow_state="published")
+
+        assert [r["number"] for r in result["result"]] == ["KB001"]
+
+    @pytest.mark.asyncio
+    async def test_state_absent_everywhere_returns_empty(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(("KB001", "published", "s1")),
+                "truncated": False,
+            }
+            result = await get_kb_articles_by_state(workflow_state="review")
+
+        assert result["result"] == []
+        assert result["returned_count"] == 0
+        assert "error" not in result
+
+    def test_pick_canonical_tracks_every_state_seen(self):
+        info = _pick_canonical_kb_row(
+            _rows(("KB001", "draft", "s1"), ("KB001", "published", "s2"))
+        )["KB001"]
+        assert info["states"] == {"draft", "published"}
+        assert info["row"]["sys_id"] == "s2"
+
+
+class TestRawScanDecoupledFromOutputCap:
+    """Defect 2: truncating the raw scan must never produce a wrong state."""
+
+    @pytest.mark.asyncio
+    async def test_scan_uses_its_own_ceiling_not_max_results(self):
+        """`max_results` shapes OUTPUT; the raw scan runs to its own ceiling.
+
+        The live failure: max_results=100 fetched 100 of 363 raw rows, so
+        KB0011378's published row fell off the end and it reported
+        `current_state: draft`.
+        """
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {"result": [], "truncated": False}
+            await get_kb_articles_by_state(max_results=10)
+
+        params = mock_query.call_args[0][1]
+        assert params.max_results == KB_STATE_SCAN_LIMIT, (
+            "the raw scan must not inherit the caller's output cap"
+        )
+
+    @pytest.mark.asyncio
+    async def test_max_results_caps_deduped_output(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(*[(f"KB{i:04d}", "published", f"s{i}") for i in range(10)]),
+                "truncated": False,
+            }
+            result = await get_kb_articles_by_state(max_results=4)
+
+        assert result["returned_count"] == 4
+        assert result["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_complete_output_is_not_truncated(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(*[(f"KB{i:04d}", "published", f"s{i}") for i in range(3)]),
+                "truncated": False,
+            }
+            result = await get_kb_articles_by_state(max_results=100)
+
+        assert result["truncated"] is False
+        assert "scan_incomplete" not in result
+
+    @pytest.mark.asyncio
+    async def test_capped_scan_flags_states_as_untrustworthy(self):
+        """A capped raw scan poisons EVERY number's state, so say so loudly."""
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(("KB0011378", "draft", "s_draft")),
+                "truncated": True,
+            }
+            result = await get_kb_articles_by_state()
+
+        assert result["scan_incomplete"] is True
+        assert str(KB_STATE_SCAN_LIMIT) in result["warning"]
+        assert "current_state" in result["warning"]
+        # Rows are still served — discarding them would be the bug class this
+        # repo already fixed for partial pages.
+        assert result["result"][0]["number"] == "KB0011378"
+
+    @pytest.mark.asyncio
+    async def test_capped_scan_warns_even_when_filter_empties_the_set(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(("KB001", "published", "s1")),
+                "truncated": True,
+            }
+            result = await get_kb_articles_by_state(workflow_state="review")
+
+        assert result["result"] == []
+        assert result["scan_incomplete"] is True, (
+            "an empty answer off a capped scan must not read as a clean 'none found'"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", [0, -1, KB_STATE_SCAN_LIMIT + 1])
+    async def test_out_of_range_max_results_is_a_validation_error(self, bad):
+        """Previously raised an unhandled pydantic ValidationError."""
+        result = await get_kb_articles_by_state(max_results=bad)
+        assert result["error"]["code"] == "VALIDATION"
+
+
+class TestReadFailuresStillPropagate:
+    """The v4.4 Tier 0.3 contract must survive the rewrite."""
+
+    @pytest.mark.asyncio
+    async def test_failure_passes_through_untouched(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "error": {"code": "TIMEOUT", "message": "timed out"}
+            }
+            result = await get_kb_articles_by_state()
+
+        assert result["error"]["code"] == "TIMEOUT"
+        assert "result" not in result
+
+    @pytest.mark.asyncio
+    async def test_partial_read_keeps_its_rows_and_error(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(("KB001", "published", "s1")),
+                "truncated": False,
+                "partial": True,
+                "error": {"code": "TIMEOUT", "message": "page 2 died"},
+            }
+            result = await get_kb_articles_by_state()
+
+        assert result["partial"] is True
+        assert result["error"]["code"] == "TIMEOUT"
+        assert result["result"][0]["number"] == "KB001"
+
+    @pytest.mark.asyncio
+    async def test_partial_emptied_by_filter_reports_the_failure(self):
+        with patch('Table_Tools.consolidated_tools.query_table_with_filters') as mock_query:
+            mock_query.return_value = {
+                "result": _rows(("KB001", "published", "s1")),
+                "truncated": False,
+                "partial": True,
+                "error": {"code": "TIMEOUT", "message": "page 2 died"},
+            }
+            result = await get_kb_articles_by_state(workflow_state="review")
+
+        assert result["error"]["code"] == "TIMEOUT"
+        assert not result.get("result")

--- a/tests/test_typed_read_kb_article_tools.py
+++ b/tests/test_typed_read_kb_article_tools.py
@@ -32,6 +32,7 @@ from urllib.parse import unquote
 from constants import (
     ERROR_KB_ARTICLE_NOT_FOUND_OP,
     KB_DEDUP_QUERY_LIMIT,
+    KB_DUPLICATE_IGNORED_STATES,
 )
 from http_layer.errors import ErrorCode, ServiceNowRequestError
 from Table_Tools.kb_article_tools import (
@@ -289,6 +290,37 @@ class TestDuplicateCheckOutcomes:
             await _check_kb_duplicates("How to reset a password", "KB0001234")
         url = request.call_args.args[0]
         assert f"sysparm_limit={KB_DEDUP_QUERY_LIMIT}" in url
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ignored_state", sorted(KB_DUPLICATE_IGNORED_STATES))
+    async def test_retired_and_outdated_duplicates_do_not_block(self, ignored_state):
+        """An exact-title match in a dead state must not block a publish.
+
+        Retired = explicitly killed; outdated = the prior version ServiceNow
+        leaves behind after a newer publish. Blocking on either reintroduces the
+        false-positive publish blocks this exclusion was added to fix. Flagged as
+        unverified in the 2026-08-12 live-test handoff — the behaviour was already
+        correct, it just had no test.
+        """
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            request.return_value = {"result": [
+                {"number": "KB0009999", "short_description": "How to reset a password",
+                 "workflow_state": ignored_state},
+            ]}
+            assert await _check_kb_duplicates("How to reset a password", "KB0001234") == []
+
+    @pytest.mark.asyncio
+    async def test_a_live_duplicate_still_blocks_alongside_a_dead_one(self):
+        """Excluding dead states must not swallow a genuine blocker beside them."""
+        with patch("Table_Tools.kb_article_tools.make_nws_request") as request:
+            request.return_value = {"result": [
+                {"number": "KB0009998", "short_description": "How to reset a password",
+                 "workflow_state": "retired"},
+                {"number": "KB0009999", "short_description": "How to reset a password",
+                 "workflow_state": "draft"},
+            ]}
+            matches = await _check_kb_duplicates("How to reset a password", "KB0001234")
+        assert [m["number"] for m in matches] == ["KB0009999"]
 
 
 class TestUnreadableVerifyDoesNotRefire:

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -153,9 +153,9 @@ TOOL_GUIDANCE = {
         prefer_over="filter_records only for the priority-plus-date shape, which this tool builds with reliable >= / <= operators.",
     ),
     "get_kb_articles_by_state": ToolGuidance(
-        when_to_use='the user asks which articles are in a given publication state ("currently in published state", "drafts", "retired KB").',
+        when_to_use='the user asks which articles are in a given publication state ("currently in published state", "drafts", "retired KB"). The state filter matches ANY version of an article, so a draft on an already-published article is found; `current_state` reports the canonical/live state and `states_present` lists every state found.',
         when_not="subject search (search_records on kb_knowledge); one category with no state question (filter_records with kb_category).",
-        prefer_over="filter_records — this collapses ServiceNow's version rows that a raw filter would return duplicated.",
+        prefer_over="filter_records — this collapses ServiceNow's version rows that a raw filter would return duplicated. Check `scan_incomplete` on the response: when set, the raw scan was capped and the reported states may be wrong, so narrow with category/kb_base.",
     ),
     "create_private_task": ToolGuidance(
         when_to_use="the user wants a brand-new private task opened.",


### PR DESCRIPTION
Two silent-data-loss defects in `get_kb_articles_by_state`, both found by live testing against a real 363-row KB. Neither raised an error — the tool returned confidently wrong data, which is why the suite never caught them.

## Defect 1 — priority collapse hid drafts on published articles

The `workflow_state` filter tested **equality against `current_state`**, the winner of `published > draft > review > outdated > retired`. Re-drafting an update leaves a `published` row beside the new `draft` one, so `published` won and the article vanished from a `draft` filter.

Measured live: the tool reported **1** pending draft where a raw `filter_records` saw **48**. That is 47 of 48 real work items missing, in the *common* KB-churn case (edits to existing articles, not new ones) — any draft-review workflow trusting this tool reviewed ~2% of its backlog.

Entries now carry **`states_present`** (every distinct state across that number's versions) and the filter tests membership in it. `current_state` keeps its meaning for post-publish verification. Because `published` is rank 0, `current_state == "published"` already implies membership — so the published view is unchanged and only the lower-priority states widen.

## Defect 2 — a capped raw scan reported the *wrong* state

`max_results` capped the raw row fetch and dedup ran on whatever arrived. The scan sorts `sys_created_on` DESC, so a recent `draft` row landed inside a 100-row cap while its older `published` sibling fell off the end — and the article came back as `current_state: draft`. Rows for one number are scattered across the sort, so truncation poisons **every** entry's state, not just the omitted ones.

The scan now runs to its own `KB_STATE_SCAN_LIMIT` (1000) while `max_results` caps the deduped output. A capped scan sets `scan_incomplete: true` + a `warning` naming the risk instead of serving a guess.

## Behavior changes

- `truncated` now means **the output was capped at `max_results`** (was: the raw fetch). A capped scan is the separate `scan_incomplete` flag — these were one flag, conflating "more articles exist than I returned" with "the states I reported may be wrong". Only the second voids the returned rows.
- `workflow_state="draft"` / `review` / `outdated` / `retired` return strictly more articles. `published` unchanged.
- `max_results` outside 1..1000 returns `VALIDATION` instead of raising an unhandled pydantic `ValidationError`.

## Not a defect

`check_kb_duplicates`' retired/outdated exclusion was flagged unverified in the handoff. The behavior was already correct — it just had no test. Added, plus one pinning that a live duplicate beside a dead one still blocks.

## Test plan

- [x] `tests/test_kb_state_rollup.py` — 17 new regression tests over both defects
- [x] Simulated the reported KB (363 raw rows, 48 masked drafts): recovers 48/48, was 1
- [x] Full suite 1136 → **1156 passed**
- [x] Token footprint tests green (`states_present` adds one short field per row)
- [x] `.mcpb` rebuilds clean at 5.0.1
- [ ] Live re-run of section B of `docs/E2E_TEST_PROMPTS.md` against the real KB